### PR TITLE
Mark as requiring legacy external storage in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             tools:ignore="GoogleAppIndexingWarning"
-            android:fullBackupContent="@xml/backup_descriptor">
+            android:fullBackupContent="@xml/backup_descriptor"
+            android:requestLegacyExternalStorage="true">
         <activity
                 android:name="emu.skyline.LogActivity"
                 android:label="@string/log"


### PR DESCRIPTION
Android 10 and above block access to the legacy java file apis on external storage without this option. In the future the app should move to using the modern SAF apis.