### PR TITLE
Introduce support for RomFS

### DIFF
--- a/app/src/main/cpp/skyline/common.h
+++ b/app/src/main/cpp/skyline/common.h
@@ -361,6 +361,9 @@ namespace skyline {
     namespace audio {
         class Audio;
     }
+    namespace loader {
+        class Loader;
+    }
 
     /**
      * @brief This struct is used to hold the state of a device
@@ -375,6 +378,7 @@ namespace skyline {
         std::shared_ptr<NCE> nce; //!< This holds a reference to the NCE class
         std::shared_ptr<gpu::GPU> gpu; //!< This holds a reference to the GPU class
         std::shared_ptr<audio::Audio> audio; //!< This holds a reference to the Audio class
+        std::shared_ptr<loader::Loader> loader; //!< This holds a reference to the Loader class
         std::shared_ptr<JvmManager> jvm; //!< This holds a reference to the JvmManager class
         std::shared_ptr<Settings> settings; //!< This holds a reference to the Settings class
         std::shared_ptr<Logger> logger; //!< This holds a reference to the Logger class

--- a/app/src/main/cpp/skyline/loader/loader.h
+++ b/app/src/main/cpp/skyline/loader/loader.h
@@ -26,6 +26,7 @@ namespace skyline::loader {
 
       public:
         std::shared_ptr<vfs::NACP> nacp; //!< The NACP of the current application
+        std::shared_ptr<vfs::Backing> romFs; //!< The RomFS of the current application
 
         /**
          * @param backing The backing for the NRO

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -24,6 +24,9 @@ namespace skyline::loader {
 
             NroAssetSection &nacpHeader = assetHeader.nacp;
             nacp = std::make_shared<vfs::NACP>(std::make_shared<vfs::RegionBacking>(backing, header.size + nacpHeader.offset, nacpHeader.size));
+
+            NroAssetSection &romFsHeader = assetHeader.romFs;
+            romFs = std::make_shared<vfs::RegionBacking>(backing, header.size + romFsHeader.offset, romFsHeader.size);
         }
     }
 

--- a/app/src/main/cpp/skyline/loader/nro.h
+++ b/app/src/main/cpp/skyline/loader/nro.h
@@ -60,8 +60,8 @@ namespace skyline::loader {
             u32 magic; //!< The asset section magic "ASET"
             u32 version; //!< The format version
             NroAssetSection icon; //!< The header describing the location of the icon
-            NroAssetSection nacp; //!< The header describing the location of the nacp
-            NroAssetSection romfs; //!< The header describing the location of the romfs
+            NroAssetSection nacp; //!< The header describing the location of the NACP
+            NroAssetSection romFs; //!< The header describing the location of the RomFS
         } assetHeader{};
 
         /**

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -10,16 +10,15 @@ namespace skyline::kernel {
     OS::OS(std::shared_ptr<JvmManager> &jvmManager, std::shared_ptr<Logger> &logger, std::shared_ptr<Settings> &settings) : state(this, process, jvmManager, settings, logger), memory(state), serviceManager(state) {}
 
     void OS::Execute(int romFd, loader::RomFormat romType) {
-        std::shared_ptr<loader::Loader> loader;
         auto romFile = std::make_shared<vfs::OsBacking>(romFd);
 
         if (romType == loader::RomFormat::NRO) {
-            loader = std::make_shared<loader::NroLoader>(romFile);
+            state.loader = std::make_shared<loader::NroLoader>(romFile);
         } else
             throw exception("Unsupported ROM extension.");
 
         auto process = CreateProcess(constant::BaseAddress, 0, constant::DefStackSize);
-        loader->LoadProcessData(process, state);
+        state.loader->LoadProcessData(process, state);
         process->InitializeMemory();
         process->threads.at(process->pid)->Start(); // The kernel itself is responsible for starting the main thread
 

--- a/app/src/main/cpp/skyline/services/base_service.h
+++ b/app/src/main/cpp/skyline/services/base_service.h
@@ -52,6 +52,7 @@ namespace skyline::service {
         timesrv_ITimeZoneService,
         fssrv_IFileSystemProxy,
         fssrv_IFileSystem,
+        fssrv_IStorage,
         nvdrv_INvDrvServices,
         visrv_IManagerRootService,
         visrv_IApplicationDisplayService,

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include <loader/loader.h>
 #include "IFileSystemProxy.h"
+#include "IStorage.h"
 
 namespace skyline::service::fssrv {
     IFileSystemProxy::IFileSystemProxy(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::fssrv_IFileSystemProxy, "fssrv:IFileSystemProxy", {
         {0x1, SFUNC(IFileSystemProxy::SetCurrentProcess)},
-        {0x12, SFUNC(IFileSystemProxy::OpenSdCardFileSystem)}
+        {0x12, SFUNC(IFileSystemProxy::OpenSdCardFileSystem)},
+        {0xc8, SFUNC(IFileSystemProxy::OpenDataStorageByCurrentProcess)}
     }) {}
 
     void IFileSystemProxy::SetCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
@@ -15,5 +18,12 @@ namespace skyline::service::fssrv {
 
     void IFileSystemProxy::OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<IFileSystem>(FsType::SdCard, state, manager), session, response);
+    }
+
+    void IFileSystemProxy::OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        if (state.loader->romFs)
+            manager.RegisterService(std::make_shared<IStorage>(state.loader->romFs, state, manager), session, response);
+        else
+            throw exception("Tried to call OpenDataStorageByCurrentProcess without a valid RomFS");
     }
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
@@ -26,5 +26,10 @@ namespace skyline::service::fssrv {
          * @brief This returns a handle to an instance of #IFileSystem (https://switchbrew.org/wiki/Filesystem_services#IFileSystem) with type SDCard
          */
         void OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief This returns a handle to an instance of #IStorage (https://switchbrew.org/wiki/Filesystem_services#IStorage) for the application's data storage
+         */
+        void OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <kernel/types/KProcess.h>
+#include "IStorage.h"
+
+namespace skyline::service::fssrv {
+    IStorage::IStorage(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, Service::fssrv_IStorage, "fssrv:IStorage", {
+        {0x0, SFUNC(IStorage::Read)},
+        {0x4, SFUNC(IStorage::GetSize)}
+    }) {}
+
+    void IStorage::Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto offset = request.Pop<u64>();
+        auto size = request.Pop<u64>();
+
+        backing->Read(state.process->GetPointer<u8>(request.outputBuf.at(0).address), offset, size);
+    }
+
+    void IStorage::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u64>(backing->size);
+    }
+}

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/base_service.h>
+#include <services/serviceman.h>
+#include <vfs/backing.h>
+
+namespace skyline::service::fssrv {
+    /**
+     * @brief IStorage is an interface to a raw backing device (https://switchbrew.org/wiki/Filesystem_services#IStorage)
+     */
+    class IStorage : public BaseService {
+      private:
+        std::shared_ptr<vfs::Backing> backing; //!< The backing of the IStorage
+
+      public:
+        IStorage(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief This reads a buffer from a region of an IStorage (https://switchbrew.org/wiki/Filesystem_services#Read)
+         */
+        void Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief This obtains the size of an IStorage (https://switchbrew.org/wiki/Filesystem_services#GetSize)
+         */
+        void GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+    };
+}


### PR DESCRIPTION
RomFS is used by homebrew and games to access content files, it is accessed through an IStorage object. This implementation currently only supports the `Read` and `GetSize` IStorage functions which is enough for most homebrew.