### PR TITLE
Fixes for control IPC

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/timesrv/ITimeZoneService.cpp
         ${source_DIR}/skyline/services/fssrv/IFileSystemProxy.cpp
         ${source_DIR}/skyline/services/fssrv/IFileSystem.cpp
+        ${source_DIR}/skyline/services/fssrv/IStorage.cpp
         ${source_DIR}/skyline/services/nvdrv/INvDrvServices.cpp
         ${source_DIR}/skyline/services/nvdrv/devices/nvmap.cpp
         ${source_DIR}/skyline/services/nvdrv/devices/nvhost_ctrl_gpu.cpp

--- a/app/src/main/cpp/skyline/kernel/ipc.cpp
+++ b/app/src/main/cpp/skyline/kernel/ipc.cpp
@@ -76,7 +76,7 @@ namespace skyline::kernel::ipc {
         auto padding = util::AlignUp(offset, constant::IpcPaddingSum) - offset; // Calculate the amount of padding at the front
         pointer += padding;
 
-        if (isDomain && (header->type == CommandType::Request)) {
+        if (isDomain && (header->type == CommandType::Request || header->type == CommandType::RequestWithContext)) {
             domain = reinterpret_cast<DomainHeaderRequest *>(pointer);
             pointer += sizeof(DomainHeaderRequest);
 
@@ -102,7 +102,7 @@ namespace skyline::kernel::ipc {
 
         payloadOffset = cmdArg;
 
-        if (payload->magic != util::MakeMagic<u32>("SFCI") && header->type != CommandType::Control) // SFCI is the magic in received IPC messages
+        if (payload->magic != util::MakeMagic<u32>("SFCI") && (header->type != CommandType::Control && header->type != CommandType::ControlWithContext)) // SFCI is the magic in received IPC messages
             state.logger->Debug("Unexpected Magic in PayloadHeader: 0x{:X}", u32(payload->magic));
 
         pointer += constant::IpcPaddingSum - padding;
@@ -124,7 +124,7 @@ namespace skyline::kernel::ipc {
             }
         }
 
-        if (header->type == CommandType::Request) {
+        if (header->type == CommandType::Request || header->type == CommandType::RequestWithContext) {
             state.logger->Debug("Header: Input No: {}, Output No: {}, Raw Size: {}", inputBuf.size(), outputBuf.size(), u64(cmdArgSz));
             if (header->handleDesc)
                 state.logger->Debug("Handle Descriptor: Send PID: {}, Copy Count: {}, Move Count: {}", bool(handleDesc->sendPid), u32(handleDesc->copyCount), u32(handleDesc->moveCount));

--- a/app/src/main/cpp/skyline/kernel/ipc.cpp
+++ b/app/src/main/cpp/skyline/kernel/ipc.cpp
@@ -134,9 +134,9 @@ namespace skyline::kernel::ipc {
         }
     }
 
-    IpcResponse::IpcResponse(bool isDomain, const DeviceState &state) : isDomain(isDomain), state(state) {}
+    IpcResponse::IpcResponse(const DeviceState &state) : state(state) {}
 
-    void IpcResponse::WriteResponse() {
+    void IpcResponse::WriteResponse(bool isDomain) {
         auto tls = state.process->GetPointer<u8>(state.thread->tls);
         u8 *pointer = tls;
 

--- a/app/src/main/cpp/skyline/kernel/ipc.h
+++ b/app/src/main/cpp/skyline/kernel/ipc.h
@@ -310,8 +310,6 @@ namespace skyline {
             std::vector<u8> payload; //!< This holds all of the contents to be pushed to the payload
 
           public:
-            bool nWrite{}; //!< This is to signal the IPC handler to not write this, as it will be manually written
-            bool isDomain{}; //!< If this is a domain request
             u32 errorCode{}; //!< The error code to respond with, it is 0 (Success) by default
             std::vector<KHandle> copyHandles; //!< A vector of handles to copy
             std::vector<KHandle> moveHandles; //!< A vector of handles to move
@@ -321,7 +319,7 @@ namespace skyline {
              * @param isDomain If the following request is a domain request
              * @param state The state of the device
              */
-            IpcResponse(bool isDomain, const DeviceState &state);
+            IpcResponse(const DeviceState &state);
 
             /**
              * @brief Writes an object to the payload
@@ -350,8 +348,9 @@ namespace skyline {
 
             /**
              * @brief Writes this IpcResponse object's contents into TLS
+             * @param isDomain Indicates if this is a domain response
              */
-            void WriteResponse();
+            void WriteResponse(bool isDomain);
         };
     }
 }


### PR DESCRIPTION
1. Moves isDomain from the response itself to a parameter of `WriteResponce` to allow domain data to be ignored on control requests.
2. Adds additional checks for the -WithContext command variants - they can be treated the same as the non -WithContext versions.