### PR TITLE
Initial NSP Loader Implementation (Supports Decrypted NSPs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We have recieved a fair share of advice from the team behind [yuzu](https://yuzu
 
 [<img align="left" height="10%" width="10%" src="https://avatars3.githubusercontent.com/u/31827450?v=4"/>](https://ryujinx.org/)
 [**Switchbrew**](https://github.com/switchbrew/)<br>
-We've extensively used Switchbrew whether that be their [wiki](https://switchbrew.org/) with it's collosal amount of information on the Switch that has saved us countless hours of time or [libNX](https://github.com/switchbrew/libnx) which was crucial to initial development of the emulator to ensure that our implementations were correct.
+We've extensively used Switchbrew whether that be their [wiki](https://switchbrew.org/) with it's collosal amount of information on the Switch that has saved us countless hours of time or [libnx](https://github.com/switchbrew/libnx) which was crucial to initial development of the emulator to ensure that our implementations were correct.
 
 ### Disclaimer
 * Nintendo Switch is a trademark of Nintendo Co., Ltd.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -100,6 +100,8 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/visrv/IManagerDisplayService.cpp
         ${source_DIR}/skyline/services/visrv/IManagerRootService.cpp
         ${source_DIR}/skyline/services/visrv/ISystemDisplayService.cpp
+        ${source_DIR}/skyline/vfs/partition_filesystem.cpp
+        ${source_DIR}/skyline/vfs/rom_filesystem.cpp
         ${source_DIR}/skyline/vfs/os_backing.cpp
         ${source_DIR}/skyline/vfs/nacp.cpp
         )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/loader/loader.cpp
         ${source_DIR}/skyline/loader/nro.cpp
         ${source_DIR}/skyline/loader/nso.cpp
+        ${source_DIR}/skyline/loader/nca.cpp
         ${source_DIR}/skyline/kernel/memory.cpp
         ${source_DIR}/skyline/kernel/ipc.cpp
         ${source_DIR}/skyline/kernel/svc.cpp
@@ -104,6 +105,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/vfs/rom_filesystem.cpp
         ${source_DIR}/skyline/vfs/os_backing.cpp
         ${source_DIR}/skyline/vfs/nacp.cpp
+        ${source_DIR}/skyline/vfs/nca.cpp
         )
 
 target_link_libraries(skyline vulkan android fmt tinyxml2 oboe lz4_static)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/loader/nro.cpp
         ${source_DIR}/skyline/loader/nso.cpp
         ${source_DIR}/skyline/loader/nca.cpp
+        ${source_DIR}/skyline/loader/nsp.cpp
         ${source_DIR}/skyline/kernel/memory.cpp
         ${source_DIR}/skyline/kernel/ipc.cpp
         ${source_DIR}/skyline/kernel/svc.cpp

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -4,6 +4,7 @@
 #include "skyline/vfs/os_backing.h"
 #include "skyline/loader/nro.h"
 #include "skyline/loader/nso.h"
+#include "skyline/loader/nca.h"
 #include "skyline/jvm.h"
 
 extern "C" JNIEXPORT jlong JNICALL Java_emu_skyline_loader_RomFile_initialize(JNIEnv *env, jobject thiz, jint jformat, jint fd) {
@@ -17,6 +18,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_emu_skyline_loader_RomFile_initialize(JN
                 return reinterpret_cast<jlong>(new skyline::loader::NroLoader(backing));
             case skyline::loader::RomFormat::NSO:
                 return reinterpret_cast<jlong>(new skyline::loader::NsoLoader(backing));
+            case skyline::loader::RomFormat::NCA:
+                return reinterpret_cast<jlong>(new skyline::loader::NcaLoader(backing));
             default:
                 return 0;
         }

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -5,6 +5,7 @@
 #include "skyline/loader/nro.h"
 #include "skyline/loader/nso.h"
 #include "skyline/loader/nca.h"
+#include "skyline/loader/nsp.h"
 #include "skyline/jvm.h"
 
 extern "C" JNIEXPORT jlong JNICALL Java_emu_skyline_loader_RomFile_initialize(JNIEnv *env, jobject thiz, jint jformat, jint fd) {
@@ -20,6 +21,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_emu_skyline_loader_RomFile_initialize(JN
                 return reinterpret_cast<jlong>(new skyline::loader::NsoLoader(backing));
             case skyline::loader::RomFormat::NCA:
                 return reinterpret_cast<jlong>(new skyline::loader::NcaLoader(backing));
+            case skyline::loader::RomFormat::NSP:
+                return reinterpret_cast<jlong>(new skyline::loader::NspLoader(backing));
             default:
                 return 0;
         }

--- a/app/src/main/cpp/skyline/kernel/memory.h
+++ b/app/src/main/cpp/skyline/kernel/memory.h
@@ -213,6 +213,7 @@ namespace skyline {
     namespace loader {
         class NroLoader;
         class NsoLoader;
+        class NcaLoader;
     }
 
     namespace kernel {
@@ -324,6 +325,7 @@ namespace skyline {
             friend class type::KProcess;
             friend class loader::NroLoader;
             friend class loader::NsoLoader;
+            friend class loader::NcaLoader;
 
             friend void svc::SetMemoryAttribute(DeviceState &state);
 

--- a/app/src/main/cpp/skyline/loader/loader.h
+++ b/app/src/main/cpp/skyline/loader/loader.h
@@ -32,8 +32,6 @@ namespace skyline::loader {
             size_t size; //!< The total size of the loaded executable
         };
 
-        std::shared_ptr<vfs::Backing> backing; //!< The backing of the loader
-
         /**
          * @brief This loads an executable into memory
          * @param process The process to load the executable into
@@ -46,11 +44,6 @@ namespace skyline::loader {
       public:
         std::shared_ptr<vfs::NACP> nacp; //!< The NACP of the current application
         std::shared_ptr<vfs::Backing> romFs; //!< The RomFS of the current application
-
-        /**
-         * @param backing The backing for the NRO
-         */
-        Loader(const std::shared_ptr<vfs::Backing> &backing) : backing(backing) {}
 
         virtual ~Loader() = default;
 

--- a/app/src/main/cpp/skyline/loader/loader.h
+++ b/app/src/main/cpp/skyline/loader/loader.h
@@ -15,6 +15,7 @@ namespace skyline::loader {
     enum class RomFormat {
         NRO, //!< The NRO format: https://switchbrew.org/wiki/NRO
         NSO, //!< The NSO format: https://switchbrew.org/wiki/NSO
+        NCA, //!< The NCA format: https://switchbrew.org/wiki/NCA
         XCI, //!< The XCI format: https://switchbrew.org/wiki/XCI
         NSP, //!< The NSP format from "nspwn" exploit: https://switchbrew.org/wiki/Switch_System_Flaws
     };

--- a/app/src/main/cpp/skyline/loader/nca.cpp
+++ b/app/src/main/cpp/skyline/loader/nca.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <nce.h>
+#include <os.h>
+#include <kernel/memory.h>
+#include "nso.h"
+#include "nca.h"
+
+namespace skyline::loader {
+    NcaLoader::NcaLoader(const std::shared_ptr<vfs::Backing> &backing) : nca(backing) {
+        if (nca.exeFs == nullptr)
+            throw exception("Only NCAs with an ExeFS can be loaded directly");
+    }
+
+    void NcaLoader::LoadExeFs(const std::shared_ptr<vfs::FileSystem> &exeFs, const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state) {
+        if (exeFs == nullptr)
+            throw exception("Cannot load a null ExeFS");
+
+        auto nsoFile = exeFs->OpenFile("rtld");
+        if (nsoFile == nullptr)
+            throw exception("Cannot load an ExeFS that doesn't contain rtld");
+
+        auto loadInfo = NsoLoader::LoadNso(nsoFile, process, state);
+        u64 offset = loadInfo.size;
+        u64 base = loadInfo.base;
+
+        state.logger->Info("Loaded nso 'rtld' at 0x{:X}", base);
+
+        for (const auto &nso : {"main", "subsdk0", "subsdk1", "subsdk2", "subsdk3", "subsdk4", "subsdk5", "subsdk6", "subsdk7", "sdk"}) {
+            nsoFile = exeFs->OpenFile(nso);
+
+            if (nsoFile == nullptr)
+                continue;
+
+            loadInfo = NsoLoader::LoadNso(nsoFile, process, state, offset);
+            state.logger->Info("Loaded nso '{}' at 0x{:X}", nso, base + offset);
+            offset += loadInfo.size;
+        }
+
+        state.os->memory.InitializeRegions(base, offset, memory::AddressSpaceType::AddressSpace39Bit);
+    }
+
+    void NcaLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state) {
+        LoadExeFs(nca.exeFs, process, state);
+    }
+}

--- a/app/src/main/cpp/skyline/loader/nca.h
+++ b/app/src/main/cpp/skyline/loader/nca.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+#include <vfs/nca.h>
+#include "loader.h"
+
+namespace skyline::loader {
+    /**
+     * @brief The NcaLoader class allows loading an NCA's ExeFS through the Loader interface (https://switchbrew.org/wiki/NSO)
+     */
+    class NcaLoader : public Loader {
+      private:
+        vfs::NCA nca; //!< The backing NCA of the loader
+
+      public:
+        NcaLoader(const std::shared_ptr<vfs::Backing> &backing);
+
+        /**
+         * @brief This loads an ExeFS into memory
+         * @param exefs A filesystem object containing the ExeFS filesystem to load into memory
+         * @param process The process to load the ExeFS into
+         */
+        static void LoadExeFs(const std::shared_ptr<vfs::FileSystem> &exefs, const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state);
+
+        void LoadProcessData(const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state);
+    };
+}

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -9,7 +9,7 @@
 #include "nro.h"
 
 namespace skyline::loader {
-    NroLoader::NroLoader(const std::shared_ptr<vfs::Backing> &backing) : Loader(backing) {
+    NroLoader::NroLoader(const std::shared_ptr<vfs::Backing> &backing) : backing(backing) {
         backing->Read(&header);
 
         if (header.magic != util::MakeMagic<u32>("NRO0"))

--- a/app/src/main/cpp/skyline/loader/nro.h
+++ b/app/src/main/cpp/skyline/loader/nro.h
@@ -66,6 +66,8 @@ namespace skyline::loader {
             NroAssetSection romFs; //!< The header describing the location of the RomFS
         } assetHeader{};
 
+        std::shared_ptr<vfs::Backing> backing; //!< The backing of the NRO loader
+
         /**
          * @brief This reads the data of the specified segment
          * @param segment The header of the segment to read

--- a/app/src/main/cpp/skyline/loader/nso.cpp
+++ b/app/src/main/cpp/skyline/loader/nso.cpp
@@ -8,7 +8,7 @@
 #include "nso.h"
 
 namespace skyline::loader {
-    NsoLoader::NsoLoader(const std::shared_ptr<vfs::Backing> &backing) : Loader(backing) {
+    NsoLoader::NsoLoader(const std::shared_ptr<vfs::Backing> &backing) : backing(backing) {
         u32 magic{};
         backing->Read(&magic);
 

--- a/app/src/main/cpp/skyline/loader/nso.h
+++ b/app/src/main/cpp/skyline/loader/nso.h
@@ -67,6 +67,8 @@ namespace skyline::loader {
         };
         static_assert(sizeof(NsoHeader) == 0x100);
 
+        std::shared_ptr<vfs::Backing> backing; //!< The backing of the NSO loader
+
         /**
          * @brief This reads the specified segment from the backing and decompresses it if needed
          * @param segment The header of the segment to read

--- a/app/src/main/cpp/skyline/loader/nsp.cpp
+++ b/app/src/main/cpp/skyline/loader/nsp.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "nca.h"
+#include "nsp.h"
+
+namespace skyline::loader {
+    NspLoader::NspLoader(const std::shared_ptr<vfs::Backing> &backing) : nsp(std::make_shared<vfs::PartitionFileSystem>(backing)) {
+        auto root = nsp->OpenDirectory("", {false, true});
+
+        for (const auto &entry : root->Read()) {
+            if (entry.name.substr(entry.name.find_last_of(".") + 1) != "nca")
+                continue;
+
+            try {
+                auto nca = vfs::NCA(nsp->OpenFile(entry.name));
+
+                if (nca.contentType == vfs::NcaContentType::Program && nca.romFs != nullptr && nca.exeFs != nullptr)
+                    programNca = std::move(nca);
+                else if (nca.contentType == vfs::NcaContentType::Control && nca.romFs != nullptr)
+                    controlNca = std::move(nca);
+            } catch (const std::exception &e) {
+                continue;
+            }
+        }
+
+        if (!programNca.has_value() || !controlNca.has_value())
+            throw exception("Incomplete NSP file");
+
+        romFs = programNca->romFs;
+        controlRomFs = std::make_shared<vfs::RomFileSystem>(controlNca->romFs);
+        nacp = std::make_shared<vfs::NACP>(controlRomFs->OpenFile("control.nacp"));
+    }
+
+    void NspLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state) {
+        NcaLoader::LoadExeFs(programNca->exeFs, process, state);
+    }
+
+    std::vector<u8> NspLoader::GetIcon() {
+        if (romFs == nullptr)
+            return std::vector<u8>();
+
+        auto root = controlRomFs->OpenDirectory("", {false, true});
+        std::shared_ptr<vfs::Backing> icon;
+
+        // Use the first icon file available
+        for (const auto &entry : root->Read()) {
+            if (entry.name.rfind("icon") == 0) {
+                icon = controlRomFs->OpenFile(entry.name);
+                break;
+            }
+        }
+
+        if (icon == nullptr)
+            return std::vector<u8>();
+
+        std::vector<u8> buffer(icon->size);
+
+        icon->Read(buffer.data(), 0, icon->size);
+        return buffer;
+    }
+}

--- a/app/src/main/cpp/skyline/loader/nsp.h
+++ b/app/src/main/cpp/skyline/loader/nsp.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+#include <vfs/nca.h>
+#include <vfs/rom_filesystem.h>
+#include <vfs/partition_filesystem.h>
+#include "loader.h"
+
+namespace skyline::loader {
+    /**
+     * @brief The NspLoader class consolidates all the data in an NSP providing a simple way to load an application and access its metadata (https://switchbrew.org/wiki/NCA_Format#PFS0)
+     */
+    class NspLoader : public Loader {
+      private:
+        std::shared_ptr<vfs::PartitionFileSystem> nsp; //!< A shared pointer to the NSP's PFS0
+        std::shared_ptr<vfs::RomFileSystem> controlRomFs; //!< A pointer to the control NCA's RomFS
+        std::optional<vfs::NCA> programNca; //!< The main program NCA within the NSP
+        std::optional<vfs::NCA> controlNca; //!< The main control NCA within the NSP
+
+      public:
+        NspLoader(const std::shared_ptr<vfs::Backing> &backing);
+
+        std::vector<u8> GetIcon();
+
+        void LoadProcessData(const std::shared_ptr<kernel::type::KProcess> process, const DeviceState &state);
+    };
+}

--- a/app/src/main/cpp/skyline/nce/guest.cpp
+++ b/app/src/main/cpp/skyline/nce/guest.cpp
@@ -289,9 +289,9 @@ namespace skyline::guest {
 
         ctx->state = ThreadState::Running;
 
-        asm("MOV LR, XZR\n\t"
-            "MOV X0, %0\n\t"
-            "MOV X1, %1\n\t"
+        asm("MOV LR, %0\n\t"
+            "MOV X0, %1\n\t"
+            "MOV X1, %2\n\t"
             "MOV X2, XZR\n\t"
             "MOV X3, XZR\n\t"
             "MOV X4, XZR\n\t"
@@ -299,7 +299,7 @@ namespace skyline::guest {
             "MOV X6, XZR\n\t"
             "MOV X7, XZR\n\t"
             "MOV X8, XZR\n\t"
-            "MOV X9, %2\n\t"
+            "MOV X9, XZR\n\t"
             "MOV X10, XZR\n\t"
             "MOV X11, XZR\n\t"
             "MOV X12, XZR\n\t"
@@ -354,7 +354,7 @@ namespace skyline::guest {
             "DUP V29.16B, WZR\n\t"
             "DUP V30.16B, WZR\n\t"
             "DUP V31.16B, WZR\n\t"
-            "BR X9"::"r"(ctx->registers.x0), "r"(ctx->registers.x1), "r"(address) : "x0", "x1", "x9");
+            "RET"::"r"(address), "r"(ctx->registers.x0), "r"(ctx->registers.x1) : "x0", "x1", "lr");
 
         __builtin_unreachable();
     }

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -4,6 +4,7 @@
 #include "vfs/os_backing.h"
 #include "loader/nro.h"
 #include "loader/nso.h"
+#include "loader/nca.h"
 #include "nce/guest.h"
 #include "os.h"
 
@@ -17,6 +18,8 @@ namespace skyline::kernel {
             state.loader = std::make_shared<loader::NroLoader>(romFile);
         } else if (romType == loader::RomFormat::NSO) {
             state.loader = std::make_shared<loader::NsoLoader>(romFile);
+        } else if (romType == loader::RomFormat::NCA) {
+            state.loader = std::make_shared<loader::NcaLoader>(romFile);
         } else {
             throw exception("Unsupported ROM extension.");
         }

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -5,6 +5,7 @@
 #include "loader/nro.h"
 #include "loader/nso.h"
 #include "loader/nca.h"
+#include "loader/nsp.h"
 #include "nce/guest.h"
 #include "os.h"
 
@@ -20,6 +21,8 @@ namespace skyline::kernel {
             state.loader = std::make_shared<loader::NsoLoader>(romFile);
         } else if (romType == loader::RomFormat::NCA) {
             state.loader = std::make_shared<loader::NcaLoader>(romFile);
+        } else if (romType == loader::RomFormat::NSP) {
+            state.loader = std::make_shared<loader::NspLoader>(romFile);
         } else {
             throw exception("Unsupported ROM extension.");
         }

--- a/app/src/main/cpp/skyline/vfs/backing.h
+++ b/app/src/main/cpp/skyline/vfs/backing.h
@@ -11,12 +11,27 @@ namespace skyline::vfs {
      */
     class Backing {
       public:
+        /**
+         * @brief This describes the modes that a backing is capable of
+         */
+        union Mode {
+            struct {
+                bool read : 1; //!< The backing is readable
+                bool write : 1; //!< The backing is writable
+                bool append : 1; //!< The backing can be appended
+            };
+            u32 raw; //!< The raw value of the mode
+        };
+        static_assert(sizeof(Mode) == 0x4);
+
+        Mode mode; //!< The mode of the backing
         size_t size; //!< The size of the backing in bytes
 
         /**
+         * @param mode The mode to use for the backing
          * @param size The initial size of the backing
          */
-        Backing(size_t size = 0) : size(size) {}
+        Backing(Mode mode = {true, false, false}, size_t size = 0) : mode(mode), size(size) {}
 
         /* Delete the move constructor to prevent multiple instances of the same backing */
         Backing(const Backing &) = delete;

--- a/app/src/main/cpp/skyline/vfs/directory.h
+++ b/app/src/main/cpp/skyline/vfs/directory.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+
+namespace skyline::vfs {
+    /**
+     * @brief The Directory class represents an abstract directory in a filesystem
+     */
+    class Directory {
+      public:
+        /**
+         * @brief This enumerates the types of entry a directory can contain
+         */
+        enum class EntryType : u32 {
+            Directory = 0x0, //!< The entry is a directory
+            File = 0x1, //!< The entry is a file
+        };
+
+        /**
+         * @brief This hold information about a single directory entry
+         */
+        struct Entry {
+            std::string name; //!< The name of the entry
+            EntryType type; //!< The type of the entry
+        };
+
+        /**
+         * @brief This describes what will be returned when reading a directories contents
+         */
+        union ListMode {
+            struct {
+                bool directory : 1; //!< The directory listing will contain subdirectories
+                bool file : 1; //!< The directory listing will contain files
+            };
+            u32 raw; //!< The raw value of the listing mode
+        };
+        static_assert(sizeof(ListMode) == 0x4);
+
+        ListMode listMode; //!< This describes what this directory will return when it is Read
+
+        Directory(ListMode listMode) : listMode(listMode) {}
+
+        /* Delete the move constructor to prevent multiple instances of the same directory */
+        Directory(const Directory &) = delete;
+
+        Directory &operator=(const Directory &) = delete;
+
+        virtual ~Directory() = default;
+
+        /**
+         * @brief Reads the contents of a directory non-recursively
+         * @return A vector containing each entry
+         */
+        virtual std::vector<Entry> Read() = 0;
+    };
+}

--- a/app/src/main/cpp/skyline/vfs/filesystem.h
+++ b/app/src/main/cpp/skyline/vfs/filesystem.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+#include "backing.h"
+#include "directory.h"
+
+namespace skyline::vfs {
+    /**
+     * @brief The FileSystem class represents an abstract filesystem with child files and folders
+     */
+    class FileSystem {
+      public:
+        FileSystem() = default;
+
+        /* Delete the move constructor to prevent multiple instances of the same filesystem */
+        FileSystem(const FileSystem &) = delete;
+
+        FileSystem &operator=(const FileSystem &) = delete;
+
+        virtual ~FileSystem() = default;
+
+        /**
+         * @brief Opens a file from the specified path in the filesystem
+         * @param path The path to the file
+         * @param mode The mode to open the file with
+         * @return A shared pointer to a Backing object of the file
+         */
+        virtual std::shared_ptr<Backing> OpenFile(std::string path, Backing::Mode mode = {true, false, false}) = 0;
+
+        /**
+         * @brief Checks if a given file exists in a filesystem
+         * @param path The path to the file
+         * @return A boolean containing whether the file exists
+         */
+        virtual bool FileExists(std::string path) = 0;
+
+        /**
+         * @brief Opens a directory from the specified path in the filesystem
+         * @param path The path to the directory
+         * @param listMode The list mode for the directory
+         * @return A shared pointer to a Directory object of the directory
+         */
+        virtual std::shared_ptr<Directory> OpenDirectory(std::string path, Directory::ListMode listMode) = 0;
+    };
+}

--- a/app/src/main/cpp/skyline/vfs/nacp.cpp
+++ b/app/src/main/cpp/skyline/vfs/nacp.cpp
@@ -8,8 +8,14 @@ namespace skyline::vfs {
         backing->Read(&nacpContents);
 
         // TODO: Select based on language settings, complete struct, yada yada
-        ApplicationTitle &languageEntry = nacpContents.titleEntries[0];
-        applicationName = std::string(languageEntry.applicationName.data(), languageEntry.applicationName.size());
-        applicationPublisher = std::string(languageEntry.applicationPublisher.data(), languageEntry.applicationPublisher.size());
+
+        // Iterate till we get to the first populated entry
+        for (auto &entry : nacpContents.titleEntries) {
+            if (entry.applicationName.front() == '\0')
+                continue;
+
+            applicationName = std::string(entry.applicationName.data(), entry.applicationName.size());
+            applicationPublisher = std::string(entry.applicationPublisher.data(), entry.applicationPublisher.size());
+        }
     }
 }

--- a/app/src/main/cpp/skyline/vfs/nacp.h
+++ b/app/src/main/cpp/skyline/vfs/nacp.h
@@ -26,7 +26,7 @@ namespace skyline::vfs {
          * @brief This struct encapsulates all the data within an NACP file
          */
         struct NacpData {
-            ApplicationTitle titleEntries[0x10]; //!< Title entries for each language
+            std::array<ApplicationTitle, 0x10> titleEntries; //!< Title entries for each language
             u8 _pad_[0x4000 - (0x10 * 0x300)];
         } nacpContents{};
         static_assert(sizeof(NacpData) == 0x4000);

--- a/app/src/main/cpp/skyline/vfs/nca.cpp
+++ b/app/src/main/cpp/skyline/vfs/nca.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "region_backing.h"
+#include "partition_filesystem.h"
+#include "nca.h"
+#include "rom_filesystem.h"
+#include "directory.h"
+
+namespace skyline::vfs {
+    NCA::NCA(const std::shared_ptr<vfs::Backing> &backing) : backing(backing) {
+        backing->Read(&header);
+
+        if (header.magic != util::MakeMagic<u32>("NCA3"))
+            throw exception("Attempting to load an encrypted or invalid NCA");
+
+        contentType = header.contentType;
+
+        for (size_t i = 0; i < header.sectionHeaders.size(); i++) {
+            auto &sectionHeader = header.sectionHeaders.at(i);
+            auto &sectionEntry = header.fsEntries.at(i);
+
+            if (sectionHeader.fsType == NcaSectionFsType::PFS0 && sectionHeader.hashType == NcaSectionHashType::HierarchicalSha256)
+                ReadPfs0(sectionHeader, sectionEntry);
+            else if (sectionHeader.fsType == NcaSectionFsType::RomFs && sectionHeader.hashType == NcaSectionHashType::HierarchicalIntegrity)
+                ReadRomFs(sectionHeader, sectionEntry);
+        }
+    }
+
+    void NCA::ReadPfs0(const NcaSectionHeader &header, const NcaFsEntry &entry) {
+        size_t offset = static_cast<size_t>(entry.startOffset) * constant::MediaUnitSize + header.sha256HashInfo.pfs0Offset;
+        size_t size = constant::MediaUnitSize * static_cast<size_t>(entry.endOffset - entry.startOffset);
+
+        auto pfs = std::make_shared<PartitionFileSystem>(std::make_shared<RegionBacking>(backing, offset, size));
+
+        if (contentType == NcaContentType::Program) {
+            // An ExeFS must always contain an NPDM and a main NSO, whereas the logo section will always contain a logo and a startup movie
+            if (pfs->FileExists("main") && pfs->FileExists("main.npdm"))
+                exeFs = std::move(pfs);
+            else if (pfs->FileExists("NintendoLogo.png") && pfs->FileExists("StartupMovie.gif"))
+                logo = std::move(pfs);
+        } else if (contentType == NcaContentType::Meta) {
+            cnmt = std::move(pfs);
+        }
+    }
+
+    void NCA::ReadRomFs(const NcaSectionHeader &header, const NcaFsEntry &entry) {
+        size_t offset = static_cast<size_t>(entry.startOffset) * constant::MediaUnitSize + header.integrityHashInfo.levels.back().offset;
+        size_t size = header.integrityHashInfo.levels.back().size;
+
+        romFs = std::make_shared<RegionBacking>(backing, offset, size);
+    }
+}

--- a/app/src/main/cpp/skyline/vfs/nca.h
+++ b/app/src/main/cpp/skyline/vfs/nca.h
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <array>
+#include "filesystem.h"
+
+namespace skyline {
+    namespace constant {
+        constexpr size_t MediaUnitSize = 0x200; //!< The unit size of entries in an NCA
+    }
+
+    namespace vfs {
+        /**
+         * @brief This enumerates the various content types of an NCA
+         */
+        enum class NcaContentType : u8 {
+            Program = 0x0, //!< This is a program NCA
+            Meta = 0x1, //!< This is a metadata NCA
+            Control = 0x2, //!< This is a control NCA
+            Manual = 0x3, //!< This is a manual NCA
+            Data = 0x4, //!< This is a data NCA
+            PublicData = 0x5, //!< This is a public data NCA
+        };
+
+        /**
+         * @brief The NCA class provides an easy way to access the contents of an NCA file (https://switchbrew.org/wiki/NCA_Format)
+         */
+        class NCA {
+          private:
+            /**
+             * @brief This enumerates the distribution types of an NCA
+             */
+            enum class NcaDistributionType : u8 {
+                System = 0x0, //!< This NCA was distributed on the EShop or is part of the system
+                GameCard = 0x1, //!< This NCA was distributed on a GameCard
+            };
+
+            /**
+             * @brief This enumerates the key generation version in NCAs before HOS 3.0.1
+             */
+            enum class NcaLegacyKeyGenerationType : u8 {
+                Fw100 = 0x0, //!< 1.0.0
+                Fw300 = 0x2, //!< 3.0.0
+            };
+
+            /**
+             * @brief This enumerates the key generation version in NCAs after HOS 3.0.0
+             */
+            enum class NcaKeyGenerationType : u8 {
+                Fw301 = 0x3, //!< 3.0.1
+                Fw400 = 0x4, //!< 4.0.0
+                Fw500 = 0x5, //!< 5.0.0
+                Fw600 = 0x6, //!< 6.0.0
+                Fw620 = 0x7, //!< 6.2.0
+                Fw700 = 0x8, //!< 7.0.0
+                Fw810 = 0x9, //!< 8.1.0
+                Fw900 = 0xa, //!< 9.0.0
+                Fw910 = 0xb, //!< 9.1.0
+                Invalid = 0xff, //!< An invalid key generation type
+            };
+
+            /**
+             * @brief This enumerates the key area encryption key types
+             */
+            enum class NcaKeyAreaEncryptionKeyType : u8 {
+                Application = 0x0, //!< This NCA uses the application key encryption area
+                Ocean = 0x1, //!< This NCA uses the ocean key encryption area
+                System = 0x2, //!< This NCA uses the system key encryption area
+            };
+
+            /**
+             * @brief This hold the entry of a single filesystem in an NCA
+             */
+            struct NcaFsEntry {
+                u32 startOffset; //!< The start offset of the filesystem in units of 0x200 bytes
+                u32 endOffset; //!< The start offset of the filesystem in units of 0x200 bytes
+                u64 _pad_;
+            };
+
+            /**
+             * @brief This enumerates the possible filesystem types a section of an NCA can contain
+             */
+            enum class NcaSectionFsType : u8 {
+                RomFs = 0x0, //!< This section contains a RomFs filesystem
+                PFS0 = 0x1, //!< This section contains a PFS0 filesystem
+            };
+
+            /**
+             * @brief This enumerates the possible hash header types of an NCA section
+             */
+            enum class NcaSectionHashType : u8 {
+                HierarchicalSha256 = 0x2, //!< The hash header for this section is that of a PFS0
+                HierarchicalIntegrity = 0x3, //!< The hash header for this section is that of a RomFS
+            };
+
+            /**
+             * @brief This enumerates the possible encryption types of an NCA section
+             */
+            enum class NcaSectionEncryptionType : u8 {
+                None = 0x1, //!< This NCA doesn't use any encryption
+                XTS = 0x2, //!< This NCA uses AES-XTS encryption
+                CTR = 0x3, //!< This NCA uses AES-CTR encryption
+                BKTR = 0x4, //!< This NCA uses BKTR together AES-CTR encryption
+            };
+
+            /**
+             * @brief This holds the data for a single level of the hierarchical integrity scheme
+             */
+            struct HierarchicalIntegrityLevel {
+                u64 offset; //!< The offset of the level data
+                u64 size; //!< The size of the level data
+                u32 blockSize; //!< The block size of the level data
+                u32 _pad_;
+            };
+            static_assert(sizeof(HierarchicalIntegrityLevel) == 0x18);
+
+            /**
+             * @brief This holds the hash info header of the hierarchical integrity scheme
+             */
+            struct HierarchicalIntegrityHashInfo {
+                u32 magic; //!< The hierarchical integrity magic, 'IVFC'
+                u32 magicNumber; //!< The magic number 0x2000
+                u32 masterHashSize; //!< The size of the master hash
+                u32 numLevels; //!< The number of levels
+                std::array<HierarchicalIntegrityLevel, 6> levels; //!< An array of the hierarchical integrity levels
+                u8 _pad0_[0x20];
+                std::array<u8, 0x20> masterHash; //!< The master hash of the hierarchical integrity system
+                u8 _pad1_[0x18];
+            };
+            static_assert(sizeof(HierarchicalIntegrityHashInfo) == 0xf8);
+
+            /**
+             * @brief This holds the hash info header of the SHA256 hashing scheme for PFS0
+             */
+            struct HierarchicalSha256HashInfo {
+                std::array<u8, 0x20> hashTableHash; //!< A SHA256 hash over the hash table
+                u32 blockSize; //!< The block size of the filesystem
+                u32 _pad_;
+                u64 hashTableOffset; //!< The offset from the end of the section header of the hash table
+                u64 hashTableSize; //!< The size of the hash table
+                u64 pfs0Offset; //!< The offset from the end of the section header of the PFS0
+                u64 pfs0Size; //!< The size of the PFS0
+                u8 _pad1_[0xb0];
+            };
+            static_assert(sizeof(HierarchicalSha256HashInfo) == 0xf8);
+
+            /**
+             * @brief This holds the header of each specific section in an NCA
+             */
+            struct NcaSectionHeader {
+                u16 version; //!< The version, always 2
+                NcaSectionFsType fsType; //!< The type of the filesystem in the section
+                NcaSectionHashType hashType; //!< The type of hash header that is used for this section
+                NcaSectionEncryptionType encryptionType; //!< The type of encryption that is used for this section
+                u8 _pad0_[0x3];
+                union {
+                    HierarchicalIntegrityHashInfo integrityHashInfo; //!< The HashInfo used for RomFS
+                    HierarchicalSha256HashInfo sha256HashInfo; //!< The HashInfo used for PFS0
+                };
+                u8 _pad1_[0x40]; // PatchInfo
+                u32 generation; //!< The generation of the NCA section
+                u32 secureValue; //!< The secure value of the section
+                u8 _pad2_[0x30]; //!< SparseInfo
+                u8 _pad3_[0x88];
+            };
+            static_assert(sizeof(NcaSectionHeader) == 0x200);
+
+            /**
+             * @brief This struct holds the header of a Nintendo Content Archive
+             */
+            struct NcaHeader {
+                std::array<u8, 0x100> fixed_key_sig; //!< An RSA-PSS signature over the header with fixed key
+                std::array<u8, 0x100> npdm_key_sig; //!< An RSA-PSS signature over header with key in NPDM
+                u32 magic; //!< The magic of the NCA: 'NCA3'
+                NcaDistributionType distributionType; //!< Whether this NCA is from a gamecard or the E-Shop
+                NcaContentType contentType; //!< The content type of the NCA
+                NcaLegacyKeyGenerationType legacyKeyGenerationType; //!< The keyblob to use for decryption
+                NcaKeyAreaEncryptionKeyType keyAreaEncryptionKeyType; //!< The index of the key area encryption key that is needed
+                u64 size; //!< The total size of the NCA
+                u64 programId; //!< The program ID of the NCA
+                u32 contentIndex; //!< The index of the content
+                u32 sdkVersion; //!< The version of the SDK the NCA was built with
+                NcaKeyGenerationType keyGenerationType; //!< The keyblob to use for decryption
+                u8 fixedKeyGeneration; //!< The fixed key index
+                u8 _pad0_[0xe];
+                std::array<u8, 0x10> rightsId; //!< The NCA's rights ID
+                std::array<NcaFsEntry, 4> fsEntries; //!< The filesystem entries for this NCA
+                std::array<std::array<u8, 0x20>, 4> sectionHashes; //!< This contains SHA-256 hashes for each filesystem header
+                std::array<std::array<u8, 0x10>, 4> encryptedKeyArea; //!< The encrypted key area for each filesystem
+                u8 _pad1_[0xc0];
+                std::array<NcaSectionHeader, 4> sectionHeaders;
+            } header{};
+            static_assert(sizeof(NcaHeader) == 0xc00);
+
+            std::shared_ptr<Backing> backing; //!< The backing for the NCA
+
+            void ReadPfs0(const NcaSectionHeader &header, const NcaFsEntry &entry);
+
+            void ReadRomFs(const NcaSectionHeader &header, const NcaFsEntry &entry);
+
+          public:
+            std::shared_ptr<FileSystem> exeFs; //!< The PFS0 filesystem for this NCA's ExeFS section
+            std::shared_ptr<FileSystem> logo; //!< The PFS0 filesystem for this NCA's logo section
+            std::shared_ptr<FileSystem> cnmt; //!< The PFS0 filesystem for this NCA's CNMT section
+            std::shared_ptr<Backing> romFs; //!< The backing for this NCA's RomFS section
+            NcaContentType contentType; //!< The content type of the NCA
+
+            NCA(const std::shared_ptr<vfs::Backing> &backing);
+        };
+    }
+}

--- a/app/src/main/cpp/skyline/vfs/os_backing.cpp
+++ b/app/src/main/cpp/skyline/vfs/os_backing.cpp
@@ -7,7 +7,7 @@
 #include "os_backing.h"
 
 namespace skyline::vfs {
-    OsBacking::OsBacking(int fd) : fd(fd) {
+    OsBacking::OsBacking(int fd) : Backing(), fd(fd) {
         struct stat fileInfo;
 
         if (fstat(fd, &fileInfo))
@@ -17,6 +17,9 @@ namespace skyline::vfs {
     }
 
     size_t OsBacking::Read(u8 *output, size_t offset, size_t size) {
+        if (!mode.read)
+            throw exception("Attempting to read a backing that is not readable");
+
         auto ret = pread64(fd, output, size, offset);
 
         if (ret < 0)

--- a/app/src/main/cpp/skyline/vfs/partition_filesystem.cpp
+++ b/app/src/main/cpp/skyline/vfs/partition_filesystem.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "region_backing.h"
+#include "partition_filesystem.h"
+
+namespace skyline::vfs {
+    PartitionFileSystem::PartitionFileSystem(std::shared_ptr<Backing> backing) : FileSystem(), backing(backing) {
+        backing->Read(&header);
+
+        if (header.magic == util::MakeMagic<u32>("PFS0"))
+            hashed = false;
+        else if (header.magic == util::MakeMagic<u32>("HFS0"))
+            hashed = true;
+        else
+            throw exception("Invalid filesystem magic: {}", header.magic);
+
+        size_t entrySize = hashed ? sizeof(HashedFileEntry) : sizeof(PartitionFileEntry);
+        size_t stringTableOffset = sizeof(FsHeader) + (header.numFiles * entrySize);
+        fileDataOffset = stringTableOffset + header.stringTableSize;
+
+        std::vector<char> stringTable(header.stringTableSize);
+        backing->Read(stringTable.data(), stringTableOffset, header.stringTableSize);
+
+        for (u32 i = 0; i < header.numFiles; i++) {
+            PartitionFileEntry entry{};
+            backing->Read(&entry, sizeof(FsHeader) + i * entrySize);
+
+            std::string name(&stringTable[entry.stringTableOffset]);
+            fileMap.emplace(name, std::move(entry));
+        }
+    }
+
+    std::shared_ptr<Backing> PartitionFileSystem::OpenFile(std::string path, Backing::Mode mode) {
+        try {
+            auto &entry = fileMap.at(path);
+            return std::make_shared<RegionBacking>(backing, fileDataOffset + entry.offset, entry.size, mode);
+        } catch (std::out_of_range &e) {
+            return nullptr;
+        }
+    }
+
+    bool PartitionFileSystem::FileExists(std::string path) {
+        return fileMap.count(path);
+    }
+
+    std::shared_ptr<Directory> PartitionFileSystem::OpenDirectory(std::string path, Directory::ListMode listMode) {
+        // PFS doesn't have directories
+        if (path != "")
+            return nullptr;
+
+        std::vector<Directory::Entry> fileList;
+        for (const auto &file : fileMap)
+            fileList.emplace_back(Directory::Entry{file.first, Directory::EntryType::File});
+
+        return std::make_shared<PartitionFileSystemDirectory>(fileList, listMode);
+    }
+
+    PartitionFileSystemDirectory::PartitionFileSystemDirectory(const std::vector<Entry> &fileList, ListMode listMode) : Directory(listMode), fileList(fileList) {}
+
+    std::vector<Directory::Entry> PartitionFileSystemDirectory::Read() {
+        if (listMode.file)
+            return fileList;
+        else
+            return std::vector<Entry>();
+    }
+}

--- a/app/src/main/cpp/skyline/vfs/partition_filesystem.h
+++ b/app/src/main/cpp/skyline/vfs/partition_filesystem.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <array>
+#include "filesystem.h"
+
+namespace skyline::vfs {
+    /**
+     * @brief The PartitionFileSystem class abstracts a partition filesystem using the vfs::FileSystem api
+     */
+    class PartitionFileSystem : public FileSystem {
+      private:
+        /**
+         * @brief This holds the header of the filesystem
+         */
+        struct FsHeader {
+            u32 magic; //!< The filesystem magic: 'PFS0' or 'HFS0'
+            u32 numFiles; //!< The number of files in the filesystem
+            u32 stringTableSize; //!< The size of the filesystem's string table
+            u32 _pad_;
+        } header{};
+        static_assert(sizeof(FsHeader) == 0x10);
+
+        /**
+         * @brief This holds a file entry in a partition filesystem
+         */
+        struct PartitionFileEntry {
+            u64 offset; //!< The offset of the file in the backing
+            u64 size; //!< The size of the file
+            u32 stringTableOffset; //!< The offset of the file in the string table
+            u32 _pad_;
+        };
+        static_assert(sizeof(PartitionFileEntry) == 0x18);
+
+        /**
+         * @brief This holds a file entry in a hashed filesystem
+         */
+        struct HashedFileEntry {
+            PartitionFileEntry entry; //!< The base file entry
+            u32 _pad_;
+            std::array<u8, 0x20> hash; //!< The hash of the file
+        };
+        static_assert(sizeof(HashedFileEntry) == 0x40);
+
+        bool hashed; //!< Whether the filesystem contains hash data
+        size_t fileDataOffset; //!< The offset from the backing to the base of the file data
+        std::shared_ptr<Backing> backing; //!< The backing file of the filesystem
+        std::unordered_map<std::string, PartitionFileEntry> fileMap; //!< A map that maps file names to their corresponding entry
+
+      public:
+        PartitionFileSystem(std::shared_ptr<Backing> backing);
+
+        std::shared_ptr<Backing> OpenFile(std::string path, Backing::Mode mode = {true, false, false});
+
+        bool FileExists(std::string path);
+
+        std::shared_ptr<Directory> OpenDirectory(std::string path, Directory::ListMode listMode);
+    };
+
+    /**
+     * @brief The PartitionFileSystemDirectory provides access to the root directory of a partition filesystem
+     */
+    class PartitionFileSystemDirectory : public Directory {
+      private:
+        std::vector<Entry> fileList; //!< A list of every file in the PFS root directory
+
+      public:
+        PartitionFileSystemDirectory(const std::vector<Entry> &fileList, ListMode listMode);
+
+        std::vector<Entry> Read();
+    };
+}

--- a/app/src/main/cpp/skyline/vfs/region_backing.h
+++ b/app/src/main/cpp/skyline/vfs/region_backing.h
@@ -20,9 +20,12 @@ namespace skyline::vfs {
          * @param offset The offset of the region start within the parent backing
          * @param size The size of the region in the parent backing
          */
-        RegionBacking(const std::shared_ptr<vfs::Backing> &backing, size_t offset, size_t size) : Backing(size), backing(backing), offset(offset) {};
+        RegionBacking(const std::shared_ptr<vfs::Backing> &backing, size_t offset, size_t size, Mode mode = {true, false, false}) : Backing(mode, size), backing(backing), offset(offset) {};
 
         inline size_t Read(u8 *output, size_t offset, size_t size) {
+            if (!mode.read)
+                throw exception("Attempting to read a backing that is not readable");
+
             size = std::min(offset + size, this->size) - offset;
 
             return backing->Read(output, this->offset + offset, size);

--- a/app/src/main/cpp/skyline/vfs/rom_filesystem.cpp
+++ b/app/src/main/cpp/skyline/vfs/rom_filesystem.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "region_backing.h"
+#include "rom_filesystem.h"
+
+namespace skyline::vfs {
+    RomFileSystem::RomFileSystem(std::shared_ptr <Backing> backing) : FileSystem(), backing(backing) {
+        backing->Read(&header);
+
+        TraverseDirectory(0, "");
+    }
+
+    void RomFileSystem::TraverseFiles(u32 offset, std::string path) {
+        RomFsFileEntry entry{};
+
+        do {
+            backing->Read(&entry, header.fileMetaTableOffset + offset);
+
+            if (entry.nameSize) {
+                std::vector<char> name(entry.nameSize);
+                backing->Read(name.data(), header.fileMetaTableOffset + offset + sizeof(RomFsFileEntry), entry.nameSize);
+
+                std::string fullPath = path + (path.empty() ? "" : "/") + std::string(name.data(), entry.nameSize);
+                fileMap.emplace(fullPath, entry);
+            }
+
+            offset = entry.siblingOffset;
+        } while (offset != constant::RomFsEmptyEntry);
+    }
+
+    void RomFileSystem::TraverseDirectory(u32 offset, std::string path) {
+        RomFsDirectoryEntry entry{};
+        backing->Read(&entry, header.dirMetaTableOffset + offset);
+
+        std::string childPath = path;
+        if (entry.nameSize) {
+            std::vector<char> name(entry.nameSize);
+            backing->Read(name.data(), header.dirMetaTableOffset + offset + sizeof(RomFsDirectoryEntry), entry.nameSize);
+            childPath = path + (path.empty() ? "" : "/") + std::string(name.data(), entry.nameSize);
+        }
+
+        directoryMap.emplace(childPath, entry);
+
+        if (entry.fileOffset != constant::RomFsEmptyEntry)
+            TraverseFiles(entry.fileOffset, childPath);
+
+        if (entry.childOffset != constant::RomFsEmptyEntry)
+            TraverseDirectory(entry.childOffset, childPath);
+
+        if (entry.siblingOffset != constant::RomFsEmptyEntry)
+            TraverseDirectory(entry.siblingOffset, path);
+    }
+
+    std::shared_ptr <Backing> RomFileSystem::OpenFile(std::string path, Backing::Mode mode) {
+        try {
+            const auto &entry = fileMap.at(path);
+            return std::make_shared<RegionBacking>(backing, header.dataOffset + entry.offset, entry.size, mode);
+        } catch (std::out_of_range &e) {
+            return nullptr;
+        }
+    }
+
+    bool RomFileSystem::FileExists(std::string path) {
+        return fileMap.count(path);
+    }
+
+    std::shared_ptr <Directory> RomFileSystem::OpenDirectory(std::string path, Directory::ListMode listMode) {
+        try {
+            auto &entry = directoryMap.at(path);
+            return std::make_shared<RomFileSystemDirectory>(backing, header, entry, listMode);
+        } catch (std::out_of_range &e) {
+            return nullptr;
+        }
+    }
+
+    RomFileSystemDirectory::RomFileSystemDirectory(const std::shared_ptr <Backing> &backing, const RomFileSystem::RomFsHeader &header, const RomFileSystem::RomFsDirectoryEntry &ownEntry, ListMode listMode) : Directory(listMode), backing(backing), header(header), ownEntry(ownEntry) {}
+
+    std::vector <RomFileSystemDirectory::Entry> RomFileSystemDirectory::Read() {
+        std::vector <Entry> contents;
+
+        if (listMode.file) {
+            RomFileSystem::RomFsFileEntry romFsFileEntry;
+            u32 offset = ownEntry.fileOffset;
+
+            do {
+                backing->Read(&romFsFileEntry, header.fileMetaTableOffset + offset);
+
+                if (romFsFileEntry.nameSize) {
+                    std::vector<char> name(romFsFileEntry.nameSize);
+                    backing->Read(name.data(), header.fileMetaTableOffset + offset + sizeof(RomFileSystem::RomFsFileEntry), romFsFileEntry.nameSize);
+
+                    contents.emplace_back(Entry{std::string(name.data(), romFsFileEntry.nameSize), EntryType::File});
+                }
+
+                offset = romFsFileEntry.siblingOffset;
+            } while (offset != constant::RomFsEmptyEntry);
+        }
+
+        if (listMode.directory) {
+            RomFileSystem::RomFsDirectoryEntry romFsDirectoryEntry;
+            u32 offset = ownEntry.childOffset;
+
+            do {
+                backing->Read(&romFsDirectoryEntry, header.dirMetaTableOffset + offset);
+
+                if (romFsDirectoryEntry.nameSize) {
+                    std::vector<char> name(romFsDirectoryEntry.nameSize);
+                    backing->Read(name.data(), header.dirMetaTableOffset + offset + sizeof(RomFileSystem::RomFsDirectoryEntry), romFsDirectoryEntry.nameSize);
+
+                    contents.emplace_back(Entry{std::string(name.data(), romFsDirectoryEntry.nameSize), EntryType::Directory});
+                }
+
+                offset = romFsDirectoryEntry.siblingOffset;
+            } while (offset != constant::RomFsEmptyEntry);
+        }
+
+        return contents;
+    }
+}

--- a/app/src/main/cpp/skyline/vfs/rom_filesystem.h
+++ b/app/src/main/cpp/skyline/vfs/rom_filesystem.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include "filesystem.h"
+
+namespace skyline {
+    namespace constant {
+        constexpr u32 RomFsEmptyEntry = 0xffffffff; //!< The value a RomFS entry has it's offset set to if it is empty
+    }
+
+    namespace vfs {
+        /**
+         * @brief The RomFileSystem class abstracts access to a RomFS image using the vfs::FileSystem api
+         */
+        class RomFileSystem : public FileSystem {
+          private:
+            std::shared_ptr<Backing> backing; //!< The backing file of the filesystem
+
+            /**
+             * @brief Traverses the sibling files of the given file and adds them to the file map
+             * @param offset The offset of the file entry to traverses the siblings of
+             * @param path The path to the parent directory of the supplied file entry
+             */
+            void TraverseFiles(u32 offset, std::string path);
+
+            /**
+             * @brief Traverses the directories within the given directory, adds them to the directory map and calls TraverseFiles on them
+             * @param offset The offset of the directory entry to traverses the directories in
+             * @param path The path to the supplied directory entry
+             */
+            void TraverseDirectory(u32 offset, std::string path);
+
+          public:
+            /**
+             * @brief This holds the header of a RomFS image
+             */
+            struct RomFsHeader {
+                u64 headerSize; //!< The size of the header
+                u64 dirHashTableOffset; //!< The offset of the directory hash table
+                u64 dirHashTableSize; //!< The size of the directory hash table
+                u64 dirMetaTableOffset; //!< The offset of the directory metadata table
+                u64 dirMetaTableSize; //!< The size of the directory metadata table
+                u64 fileHashTableOffset; //!< The offset of the file hash table
+                u64 fileHashTableSize; //!< The size of the file hash table
+                u64 fileMetaTableOffset; //!< The offset of the file metadata table
+                u64 fileMetaTableSize; //!< The size of the file metadata table
+                u64 dataOffset; //!< The offset of the file data
+            } header{};
+            static_assert(sizeof(RomFsHeader) == 0x50);
+
+            /**
+             * @brief This holds a directory entry in a RomFS image
+             */
+            struct RomFsDirectoryEntry {
+                u32 parentOffset; //!< The offset from the directory metadata base of the parent directory
+                u32 siblingOffset; //!< The offset from the directory metadata base of a sibling directory
+                u32 childOffset; //!< The offset from the directory metadata base of a child directory
+                u32 fileOffset; //!< The offset from the file metadata base of a child file
+                u32 hash; //!< The hash of the directory
+                u32 nameSize; //!< The size of the directory's name in bytes
+            };
+
+            /**
+             * @brief This holds a file entry in a RomFS image
+             */
+            struct RomFsFileEntry {
+                u32 parentOffset; //!< The offset from the directory metadata base of the parent directory
+                u32 siblingOffset; //!< The offset from the file metadata base of a sibling file
+                u64 offset; //!< The offset from the file data base of the file contents
+                u64 size; //!< The size of the file in bytes
+                u32 hash; //!< The hash of the file
+                u32 nameSize; //!< The size of the file's name in bytes
+            };
+
+            std::unordered_map<std::string, RomFsFileEntry> fileMap; //!< A map that maps file names to their corresponding entry
+            std::unordered_map<std::string, RomFsDirectoryEntry> directoryMap; //!< A map that maps directory names to their corresponding entry
+
+            RomFileSystem(std::shared_ptr<Backing> backing);
+
+            std::shared_ptr<Backing> OpenFile(std::string path, Backing::Mode mode = {true, false, false});
+
+            bool FileExists(std::string path);
+
+            std::shared_ptr<Directory> OpenDirectory(std::string path, Directory::ListMode listMode);
+        };
+
+        /**
+         * @brief The RomFileSystemDirectory provides access to directories within a RomFS
+         */
+        class RomFileSystemDirectory : public Directory {
+          private:
+            RomFileSystem::RomFsDirectoryEntry ownEntry; //!< This directory's entry in the RomFS header
+            RomFileSystem::RomFsHeader header; //!< A header of this files parent RomFS image
+            std::shared_ptr<Backing> backing; //!< The backing of the RomFS image
+
+          public:
+            RomFileSystemDirectory(const std::shared_ptr<Backing> &backing, const RomFileSystem::RomFsHeader &header, const RomFileSystem::RomFsDirectoryEntry &ownEntry, ListMode listMode);
+
+            std::vector<Entry> Read();
+        };
+    }
+}

--- a/app/src/main/java/emu/skyline/AppDialog.kt
+++ b/app/src/main/java/emu/skyline/AppDialog.kt
@@ -81,7 +81,7 @@ class AppDialog(val item : AppItem? = null) : BottomSheetDialogFragment() {
                 val info = ShortcutInfo.Builder(context, item.title)
                 info.setShortLabel(item.meta.name)
                 info.setActivity(ComponentName(context!!, EmulationActivity::class.java))
-                info.setIcon(Icon.createWithBitmap(item.icon ?: missingIcon))
+                info.setIcon(Icon.createWithAdaptiveBitmap(item.icon ?: missingIcon))
 
                 val intent = Intent(context, EmulationActivity::class.java)
                 intent.data = item.uri

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -113,6 +113,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
 
                 var foundRoms = addEntries("nro", RomFormat.NRO, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
                 foundRoms = foundRoms or addEntries("nso", RomFormat.NSO, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
+                foundRoms = foundRoms or addEntries("nca", RomFormat.NCA, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
 
                 runOnUiThread {
                     if (!foundRoms)

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -114,6 +114,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, View.OnLongClick
                 var foundRoms = addEntries("nro", RomFormat.NRO, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
                 foundRoms = foundRoms or addEntries("nso", RomFormat.NSO, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
                 foundRoms = foundRoms or addEntries("nca", RomFormat.NCA, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
+                foundRoms = foundRoms or addEntries("nsp", RomFormat.NSP, DocumentFile.fromTreeUri(this, Uri.parse(sharedPreferences.getString("search_location", "")))!!)
 
                 runOnUiThread {
                     if (!foundRoms)

--- a/app/src/main/java/emu/skyline/loader/RomFile.kt
+++ b/app/src/main/java/emu/skyline/loader/RomFile.kt
@@ -25,8 +25,9 @@ import java.util.*
 enum class RomFormat(val format: Int){
     NRO(0),
     NSO(1),
-    XCI(2),
-    NSP(3),
+    NCA(2),
+    XCI(3),
+    NSP(4),
 }
 
 /**


### PR DESCRIPTION
- This PR adds a few new VFS API features for modes, directories and filesystems. They are designed to be easily mappable to Horizon's APIs when needed. 
- Using these new VFS APIs two new filesystem backends have been implemented, the ROM filesystem and the [partition filesystem (PFS0)](https://switchbrew.org/wiki/NCA_Format#PFS0). They are the two main filesystems for holding data on the Switch. In the future, the ROM filesystem can be extended to support LayeredFS mods.
- The [NCA](https://switchbrew.org/wiki/NCA_Format) class has been implemented, this currently only handles parsing the header and extracting the sections but in the future it will be extended to support decryption and [BKTR data (updates)](https://switchbrew.org/wiki/NCA_Format#PatchInfo).
 - An NCA loader has also been implemented, this uses the aforementioned NCA class to load the game [NSOs](https://switchbrew.org/wiki/NSO) within the Program NCAs [ExeFS ](https://switchbrew.org/wiki/ExeFS) into memory, they are linked by [rtld](https://switchbrew.org/wiki/Rtld). In the future it will be extended to support loading an [NPDM](https://switchbrew.org/wiki/NPDM).
- NSPs now have their loader implemented, this is currently very basic. In the future, it will need to be extended with [CNMT](https://switchbrew.org/wiki/CNMT) support together to support game DLC and updates.
- Finally... there are also a few miscellaneous fixes that "Improve system stability". 

Closes #5