### PR TITLE
Add empty aoc:u and pctl implementations

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/visrv/IManagerRootService.cpp
         ${source_DIR}/skyline/services/visrv/ISystemDisplayService.cpp
         ${source_DIR}/skyline/services/pl/IPlatformServiceManager.cpp
+        ${source_DIR}/skyline/services/aocsrv/IAddOnContentManager.cpp
         ${source_DIR}/skyline/vfs/partition_filesystem.cpp
         ${source_DIR}/skyline/vfs/rom_filesystem.cpp
         ${source_DIR}/skyline/vfs/os_backing.cpp

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/visrv/ISystemDisplayService.cpp
         ${source_DIR}/skyline/services/pl/IPlatformServiceManager.cpp
         ${source_DIR}/skyline/services/aocsrv/IAddOnContentManager.cpp
+        ${source_DIR}/skyline/services/pctl/IParentalControlServiceFactory.cpp
         ${source_DIR}/skyline/vfs/partition_filesystem.cpp
         ${source_DIR}/skyline/vfs/rom_filesystem.cpp
         ${source_DIR}/skyline/vfs/os_backing.cpp

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "IAddOnContentManager.h"
+
+namespace skyline::service::aocsrv {
+    IAddOnContentManager::IAddOnContentManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::aocsrv_IAddOnContentManager, "aocsrv:IAddOnContentManager", {
+    }) {}
+}

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/base_service.h>
+#include <services/serviceman.h>
+
+namespace skyline::service::aocsrv {
+    /**
+     * @brief IAddOnContentManager or aoc:u is used by applications to access add-on content information (https://switchbrew.org/wiki/NS_Services#aoc:u)
+     */
+    class IAddOnContentManager : public BaseService {
+      public:
+        IAddOnContentManager(const DeviceState &state, ServiceManager &manager);
+    };
+}

--- a/app/src/main/cpp/skyline/services/base_service.h
+++ b/app/src/main/cpp/skyline/services/base_service.h
@@ -61,6 +61,7 @@ namespace skyline::service {
         visrv_IManagerDisplayService,
         hosbinder_IHOSBinderDriver,
         pl_IPlatformServiceManager
+        aocsrv_IAddOnContentManager,
     };
 
     /**
@@ -86,6 +87,7 @@ namespace skyline::service {
         {"nvdrv:t", Service::nvdrv_INvDrvServices},
         {"vi:m", Service::visrv_IManagerRootService},
         {"pl:u", Service::pl_IPlatformServiceManager}
+        {"aoc:u", Service::aocsrv_IAddOnContentManager}
     };
 
     class ServiceManager;

--- a/app/src/main/cpp/skyline/services/base_service.h
+++ b/app/src/main/cpp/skyline/services/base_service.h
@@ -62,6 +62,7 @@ namespace skyline::service {
         hosbinder_IHOSBinderDriver,
         pl_IPlatformServiceManager
         aocsrv_IAddOnContentManager,
+        pctl_IParentalControlServiceFactory,
     };
 
     /**
@@ -86,8 +87,12 @@ namespace skyline::service {
         {"nvdrv:s", Service::nvdrv_INvDrvServices},
         {"nvdrv:t", Service::nvdrv_INvDrvServices},
         {"vi:m", Service::visrv_IManagerRootService},
-        {"pl:u", Service::pl_IPlatformServiceManager}
-        {"aoc:u", Service::aocsrv_IAddOnContentManager}
+        {"pl:u", Service::pl_IPlatformServiceManager},
+        {"aoc:u", Service::aocsrv_IAddOnContentManager},
+        {"pctl", Service::pctl_IParentalControlServiceFactory},
+        {"pctl:a", Service::pctl_IParentalControlServiceFactory},
+        {"pctl:s", Service::pctl_IParentalControlServiceFactory},
+        {"pctl:r", Service::pctl_IParentalControlServiceFactory}
     };
 
     class ServiceManager;

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "IParentalControlServiceFactory.h"
+
+namespace skyline::service::pctl {
+    IParentalControlServiceFactory::IParentalControlServiceFactory(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::pctl_IParentalControlServiceFactory, "pctl:IParentalControlServiceFactory", {
+    }) {}
+}

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.h
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/base_service.h>
+#include <services/serviceman.h>
+
+namespace skyline::service::pctl {
+    /**
+     * @brief IParentalControlServiceFactory is used to open a parental controls instance (https://switchbrew.org/wiki/Parental_Control_services#pctl:s.2C_pctl:r.2C_pctl:a.2C_pctl)
+     */
+    class IParentalControlServiceFactory : public BaseService {
+      public:
+        IParentalControlServiceFactory(const DeviceState &state, ServiceManager &manager);
+    };
+}

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -17,6 +17,7 @@
 #include "services/nvdrv/INvDrvServices.h"
 #include "visrv/IManagerRootService.h"
 #include "pl/IPlatformServiceManager.h"
+#include "aocsrv/IAddOnContentManager.h"
 #include "serviceman.h"
 
 namespace skyline::service {
@@ -73,6 +74,9 @@ namespace skyline::service {
                 break;
             case Service::pl_IPlatformServiceManager:
                 serviceObj = std::make_shared<pl::IPlatformServiceManager>(state, *this);
+                break;
+            case Service::aocsrv_IAddOnContentManager:
+                serviceObj = std::make_shared<aocsrv::IAddOnContentManager>(state, *this);
                 break;
             default:
                 throw exception("CreateService called on missing object, type: {}", serviceType);

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -18,6 +18,7 @@
 #include "visrv/IManagerRootService.h"
 #include "pl/IPlatformServiceManager.h"
 #include "aocsrv/IAddOnContentManager.h"
+#include "pctl/IParentalControlServiceFactory.h"
 #include "serviceman.h"
 
 namespace skyline::service {
@@ -77,6 +78,9 @@ namespace skyline::service {
                 break;
             case Service::aocsrv_IAddOnContentManager:
                 serviceObj = std::make_shared<aocsrv::IAddOnContentManager>(state, *this);
+                break;
+            case Service::pctl_IParentalControlServiceFactory:
+                serviceObj = std::make_shared<pctl::IParentalControlServiceFactory>(state, *this);
                 break;
             default:
                 throw exception("CreateService called on missing object, type: {}", serviceType);


### PR DESCRIPTION
These are both required by Puyo Puyo Tetris.
aoc:u will be extended in the future to allow using real DLC with the emulator. 