### PR TITLE
Implement the set service together with GetAvailableLanguageCodes

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
         ${source_DIR}/skyline/services/audio/IAudioRenderer/voice.cpp
         ${source_DIR}/skyline/services/audio/IAudioRenderer/memory_pool.cpp
+        ${source_DIR}/skyline/services/settings/ISettingsServer.cpp
         ${source_DIR}/skyline/services/settings/ISystemSettingsServer.cpp
         ${source_DIR}/skyline/services/apm/IManager.cpp
         ${source_DIR}/skyline/services/apm/ISession.cpp

--- a/app/src/main/cpp/skyline/services/base_service.h
+++ b/app/src/main/cpp/skyline/services/base_service.h
@@ -23,6 +23,7 @@ namespace skyline::service {
     enum class Service {
         sm_IUserInterface,
         fatalsrv_IService,
+        settings_ISettingsServer,
         settings_ISystemSettingsServer,
         apm_IManager,
         apm_ISession,
@@ -66,6 +67,7 @@ namespace skyline::service {
      */
     const static std::unordered_map<std::string, Service> ServiceString{
         {"fatal:u", Service::fatalsrv_IService},
+        {"set", Service::settings_ISettingsServer},
         {"set:sys", Service::settings_ISystemSettingsServer},
         {"apm", Service::apm_IManager},
         {"appletOE", Service::am_IApplicationProxyService},

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -3,6 +3,7 @@
 
 #include <kernel/types/KProcess.h>
 #include "sm/IUserInterface.h"
+#include "settings/ISettingsServer.h"
 #include "settings/ISystemSettingsServer.h"
 #include "apm/IManager.h"
 #include "am/IApplicationProxyService.h"
@@ -32,6 +33,9 @@ namespace skyline::service {
                 break;
             case Service::fatalsrv_IService:
                 serviceObj = std::make_shared<fatalsrv::IService>(state, *this);
+                break;
+            case Service::settings_ISettingsServer:
+                serviceObj = std::make_shared<settings::ISettingsServer>(state, *this);
                 break;
             case Service::settings_ISystemSettingsServer:
                 serviceObj = std::make_shared<settings::ISystemSettingsServer>(state, *this);

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <kernel/types/KProcess.h>
+#include "ISettingsServer.h"
+
+namespace skyline::service::settings {
+    ISettingsServer::ISettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::settings_ISettingsServer, "settings:ISettingsServer", {
+        {0x1, SFUNC(ISettingsServer::GetAvailableLanguageCodes)}
+    }) {}
+
+    constexpr std::array<u64, 15> LanguageCodeList = {
+        util::MakeMagic<u64>("ja"),
+        util::MakeMagic<u64>("en-US"),
+        util::MakeMagic<u64>("fr"),
+        util::MakeMagic<u64>("de"),
+        util::MakeMagic<u64>("it"),
+        util::MakeMagic<u64>("es"),
+        util::MakeMagic<u64>("zh-CN"),
+        util::MakeMagic<u64>("ko"),
+        util::MakeMagic<u64>("nl"),
+        util::MakeMagic<u64>("pt"),
+        util::MakeMagic<u64>("ru"),
+        util::MakeMagic<u64>("zh-TW"),
+        util::MakeMagic<u64>("en-GB"),
+        util::MakeMagic<u64>("fr-CA"),
+        util::MakeMagic<u64>("es-419")
+    };
+
+    void ISettingsServer::GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        state.process->WriteMemory(LanguageCodeList.data(), request.outputBuf.at(0).address, LanguageCodeList.size() * sizeof(u64));
+
+        response.Push<i32>(LanguageCodeList.size());
+    }
+}

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/base_service.h>
+#include <services/serviceman.h>
+
+namespace skyline::service::settings {
+    /**
+     * @brief ISettingsServer or 'set' provides access to user settings (https://switchbrew.org/wiki/Settings_services#set)
+     */
+    class ISettingsServer : public BaseService {
+      public:
+        ISettingsServer(const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief This reads the available language codes that an application can use
+         */
+        void GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+    };
+}


### PR DESCRIPTION
The 'set' service is used to obtain user settings such as language.
GetAvailableLanguageCodes is used by Puyo Puyo Tetris.