### PR TITLE
Extend account services and add support for PopLaunchParameters

### DIFF
--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
@@ -6,17 +6,30 @@
 #include <services/base_service.h>
 #include <services/serviceman.h>
 
-namespace skyline::service::account {
-    /**
-     * @brief IAccountServiceForApplication or acc:u0 provides functions for reading user information (https://switchbrew.org/wiki/Account_services#acc:u0)
-     */
-    class IAccountServiceForApplication : public BaseService {
-      public:
-        IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager);
-
+namespace skyline {
+    namespace service::account {
         /**
-         * @brief This provides information about the running application for account services to use (https://switchbrew.org/wiki/Account_services#InitializeApplicationInfoV0)
+         * @brief This hold an account's user ID
          */
-        void InitializeApplicationInfoV0(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
-    };
+        struct UserId {
+            u64 upper; //!< The upper 64 bits of the user ID
+            u64 lower; //!< The lower 64 bits of the user ID
+        };
+        /**
+        * @brief IAccountServiceForApplication or acc:u0 provides functions for reading user information (https://switchbrew.org/wiki/Account_services#acc:u0)
+        */
+        class IAccountServiceForApplication : public BaseService {
+          public:
+            IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager);
+
+            /**
+            * @brief This provides information about the running application for account services to use (https://switchbrew.org/wiki/Account_services#InitializeApplicationInfoV0)
+            */
+            void InitializeApplicationInfoV0(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        };
+    }
+
+    namespace constant {
+        constexpr service::account::UserId DefaultUserId = {0x0000000000000001, 0x0000000000000000}; //!< The default user ID
+    }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -1,12 +1,33 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include <services/account/IAccountServiceForApplication.h>
+#include <services/am/storage/IStorage.h>
 #include "IApplicationFunctions.h"
 
 namespace skyline::service::am {
     IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IApplicationFunctions, "am:IApplicationFunctions", {
+        {0x1, SFUNC(IApplicationFunctions::PopLaunchParameter)},
+        {0x15, SFUNC(IApplicationFunctions::GetDesiredLanguage)},
         {0x28, SFUNC(IApplicationFunctions::NotifyRunning)}
     }) {}
+
+    void IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        constexpr u32 LaunchParameterMagic = 0xc79497ca; //!< This is the magic of the application launch parameters
+        constexpr size_t LaunchParameterSize = 0x88; //!< This is the size of the launch parameter IStorage
+
+        auto storageService = std::make_shared<IStorage>(state, manager, LaunchParameterSize);
+
+        storageService->Push<u32>(LaunchParameterMagic);
+        storageService->Push<u32>(1);
+        storageService->Push(constant::DefaultUserId);
+
+        manager.RegisterService(storageService, session, response);
+    }
+
+    void IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push(util::MakeMagic<u64>("en-US"));
+    }
 
     void IApplicationFunctions::NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u8>(1);

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
@@ -15,6 +15,16 @@ namespace skyline::service::am {
         IApplicationFunctions(const DeviceState &state, ServiceManager &manager);
 
         /**
+         * @brief This returns an Applet Manager IStorage containing the application's launch parameters (https://switchbrew.org/wiki/Applet_Manager_services#PopLaunchParameter)
+         */
+        void PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief This returns the desired language for the application (https://switchbrew.org/wiki/Applet_Manager_services#GetDesiredLanguage)
+         */
+        void GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief This returns if the application is running or not, always returns true (https://switchbrew.org/wiki/Applet_Manager_services#NotifyRunning)
          */
         void NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);


### PR DESCRIPTION
PopLaunchParameters is used to obtain the user who started the application.
These are needed for Puyo Puyo Tetris.