### PR TITLE
services: Add missing audio functions

### DIFF
--- a/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
@@ -12,7 +12,9 @@ namespace skyline::service::audio {
         {0x3, SFUNC(IAudioOut::AppendAudioOutBuffer)},
         {0x4, SFUNC(IAudioOut::RegisterBufferEvent)},
         {0x5, SFUNC(IAudioOut::GetReleasedAudioOutBuffer)},
-        {0x6, SFUNC(IAudioOut::ContainsAudioOutBuffer)}
+        {0x6, SFUNC(IAudioOut::ContainsAudioOutBuffer)},
+        {0x7, SFUNC(IAudioOut::AppendAudioOutBuffer)},
+        {0x8, SFUNC(IAudioOut::GetReleasedAudioOutBuffer)}
     }) {
         track = state.audio->OpenTrack(channelCount, constant::SampleRate, [this]() { this->releaseEvent->Signal(); });
     }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
@@ -8,7 +8,9 @@
 namespace skyline::service::audio {
     IAudioOutManager::IAudioOutManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::audio_IAudioOutManager, "audio:IAudioOutManager", {
         {0x0, SFUNC(IAudioOutManager::ListAudioOuts)},
-        {0x1, SFUNC(IAudioOutManager::OpenAudioOut)}
+        {0x1, SFUNC(IAudioOutManager::OpenAudioOut)},
+        {0x2, SFUNC(IAudioOutManager::ListAudioOuts)},
+        {0x3, SFUNC(IAudioOutManager::OpenAudioOut)}
     }) {}
 
     void IAudioOutManager::ListAudioOuts(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {

--- a/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
@@ -15,6 +15,7 @@ namespace skyline::service::audio::IAudioRenderer {
         {0x5, SFUNC(IAudioRenderer::Start)},
         {0x6, SFUNC(IAudioRenderer::Stop)},
         {0x7, SFUNC(IAudioRenderer::QuerySystemEvent)},
+        {0xA, SFUNC(IAudioRenderer::RequestUpdate)},
     }) {
         track = state.audio->OpenTrack(constant::ChannelCount, parameters.sampleRate, []() {});
         track->Start();


### PR DESCRIPTION
* Those are needed to run playtone and audren from switch homebrew examples