### PR TITLE
Rework Service API to be cleaner with significantly less boilerplate

### DIFF
--- a/app/src/main/cpp/skyline/common.h
+++ b/app/src/main/cpp/skyline/common.h
@@ -25,6 +25,32 @@
 namespace skyline {
     using KHandle = u32; //!< The type of a kernel handle
 
+    /**
+     * @brief The result of an operation in HOS
+     * @url https://switchbrew.org/wiki/Error_codes
+     */
+    union Result {
+        u32 raw{};
+        struct {
+            u16 module : 9;
+            u16 id : 12;
+        };
+
+        /**
+         * @note Success is 0, 0 - it is the only error that's not specific to a module
+         */
+        Result() {}
+
+        constexpr Result(u16 module, u16 id) {
+            this->module = module;
+            this->id = id;
+        }
+
+        constexpr operator u32() const {
+            return raw;
+        }
+    };
+
     namespace constant {
         // Memory
         constexpr u64 BaseAddress = 0x8000000; //!< The address space base
@@ -36,29 +62,6 @@ namespace skyline {
         constexpr u16 DockedResolutionH = 1080; //!< The height component of the docked resolution
         // Time
         constexpr u64 NsInSecond = 1000000000; //!< This is the amount of nanoseconds in a second
-        // Status codes
-        namespace status {
-            constexpr u32 Success = 0x0; //!< "Success"
-            constexpr u32 PathDoesNotExist = 0x202; //!< "Path does not exist"
-            constexpr u32 GenericError = 0x272; //!< "Generic error"
-            constexpr u32 NoMessages = 0x680; //!< "No message available"
-            constexpr u32 ServiceInvName = 0xC15; //!< "Invalid name"
-            constexpr u32 ServiceNotReg = 0xE15; //!< "Service not registered"
-            constexpr u32 InvUser = 0xC87C; //!< Invalid user
-            constexpr u32 InvSize = 0xCA01; //!< "Invalid size"
-            constexpr u32 InvAddress = 0xCC01; //!< "Invalid address"
-            constexpr u32 InvState = 0xD401; //!< "Invalid MemoryState"
-            constexpr u32 InvPermission = 0xD801; //!< "Invalid Permission"
-            constexpr u32 InvMemRange = 0xD801; //!< "Invalid Memory Range"
-            constexpr u32 InvPriority = 0xE001; //!< "Invalid Priority"
-            constexpr u32 InvHandle = 0xE401; //!< "Invalid handle"
-            constexpr u32 InvCombination = 0xE801; //!< "Invalid combination"
-            constexpr u32 Timeout = 0xEA01; //!< "Timeout"
-            constexpr u32 Interrupted = 0xEC01; //!< "Interrupted"
-            constexpr u32 MaxHandles = 0xEE01; //!< "Too many handles"
-            constexpr u32 NotFound = 0xF201; //!< "Not found"
-            constexpr u32 Unimpl = 0x177202; //!< "Unimplemented behaviour"
-        }
     };
 
     namespace util {

--- a/app/src/main/cpp/skyline/kernel/ipc.h
+++ b/app/src/main/cpp/skyline/kernel/ipc.h
@@ -309,7 +309,7 @@ namespace skyline {
             std::vector<u8> payload; //!< This holds all of the contents to be pushed to the payload
 
           public:
-            u32 errorCode{}; //!< The error code to respond with, it is 0 (Success) by default
+            Result errorCode{}; //!< The error code to respond with, it is 0 (Success) by default
             std::vector<KHandle> copyHandles; //!< A vector of handles to copy
             std::vector<KHandle> moveHandles; //!< A vector of handles to move
             std::vector<KHandle> domainObjects; //!< A vector of domain objects to write

--- a/app/src/main/cpp/skyline/kernel/results.h
+++ b/app/src/main/cpp/skyline/kernel/results.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+
+namespace skyline::kernel::result {
+    constexpr Result OutOfSessions(1, 7);
+    constexpr Result InvalidArgument(1, 14);
+    constexpr Result NotImplemented(1, 33);
+    constexpr Result StopProcessingException(1, 54);
+    constexpr Result NoSynchronizationObject(1, 57);
+    constexpr Result TerminationRequested(1, 59);
+    constexpr Result NoEvent(1, 70);
+    constexpr Result InvalidSize(1, 101);
+    constexpr Result InvalidAddress(1, 102);
+    constexpr Result OutOfResource(1, 103);
+    constexpr Result OutOfMemory(1, 104);
+    constexpr Result OutOfHandles(1, 105);
+    constexpr Result InvalidCurrentMemory(1, 106);
+    constexpr Result InvalidNewMemoryPermission(1, 108);
+    constexpr Result InvalidMemoryRegion(1, 110);
+    constexpr Result InvalidPriority(1, 112);
+    constexpr Result InvalidCoreId(1, 113);
+    constexpr Result InvalidHandle(1, 114);
+    constexpr Result InvalidPointer(1, 115);
+    constexpr Result InvalidCombination(1, 116);
+    constexpr Result TimedOut(1, 117);
+    constexpr Result Cancelled(1, 118);
+    constexpr Result OutOfRange(1, 119);
+    constexpr Result InvalidEnumValue(1, 120);
+    constexpr Result NotFound(1, 121);
+    constexpr Result Busy(1, 122);
+    constexpr Result SessionClosed(1, 123);
+    constexpr Result NotHandled(1, 124);
+    constexpr Result InvalidState(1, 125);
+    constexpr Result ReservedUsed(1, 126);
+    constexpr Result NotSupported(1, 127);
+    constexpr Result Debug(1, 128);
+    constexpr Result NoThread(1, 129);
+    constexpr Result UnknownThread(1, 130);
+    constexpr Result PortClosed(1, 131);
+    constexpr Result LimitReached(1, 132);
+    constexpr Result InvalidMemoryPool(1, 133);
+    constexpr Result ReceiveListBroken(1, 258);
+    constexpr Result OutOfAddressSpace(1, 259);
+    constexpr Result MessageTooLarge(1, 260);
+    constexpr Result InvalidProcessId(1, 517);
+    constexpr Result InvalidThreadId(1, 518);
+    constexpr Result InvalidId(1, 519);
+    constexpr Result ProcessTerminated(1, 520);
+}

--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -588,7 +588,7 @@ namespace skyline::kernel::svc {
 
         KHandle handle{};
         if (port.compare("sm:") >= 0) {
-            handle = state.os->serviceManager.NewSession(service::Service::sm_IUserInterface);
+            handle = state.process->NewHandle<type::KSession>(std::static_pointer_cast<service::BaseService>(state.os->serviceManager.smUserInterface)).handle;
         } else {
             state.logger->Warn("svcConnectToNamedPort: Connecting to invalid port: '{}'", port);
             state.ctx->registers.w0 = constant::status::NotFound;

--- a/app/src/main/cpp/skyline/kernel/types/KSession.h
+++ b/app/src/main/cpp/skyline/kernel/types/KSession.h
@@ -16,7 +16,6 @@ namespace skyline::kernel::type {
         std::shared_ptr<service::BaseService> serviceObject; //!< A shared pointer to the service class
         std::unordered_map<KHandle, std::shared_ptr<service::BaseService>> domainTable; //!< This maps from a virtual handle to it's service
         KHandle handleIndex{0x1}; //!< The currently allocated handle index
-        service::Service serviceType; //!< The type of the service
         enum class ServiceStatus { Open, Closed } serviceStatus{ServiceStatus::Open}; //!< If the session is open or closed
         bool isDomain{}; //!< Holds if this is a domain session or not
 
@@ -24,7 +23,7 @@ namespace skyline::kernel::type {
          * @param state The state of the device
          * @param serviceObject A shared pointer to the service class
          */
-        KSession(const DeviceState &state, std::shared_ptr<service::BaseService> &serviceObject) : serviceObject(serviceObject), serviceType(serviceObject->serviceType), KSyncObject(state, KType::KSession) {}
+        KSession(const DeviceState &state, std::shared_ptr<service::BaseService> &serviceObject) : serviceObject(serviceObject), KSyncObject(state, KType::KSession) {}
 
         /**
          * This converts this session into a domain session (https://switchbrew.org/wiki/IPC_Marshalling#Domains)

--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
@@ -7,7 +7,7 @@
 #include "IAccountServiceForApplication.h"
 
 namespace skyline::service::account {
-    IAccountServiceForApplication::IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::account_IAccountServiceForApplication, "account:IAccountServiceForApplication", {
+    IAccountServiceForApplication::IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x1, SFUNC(IAccountServiceForApplication::GetUserExistence)},
         {0x2, SFUNC(IAccountServiceForApplication::ListAllUsers)},
         {0x3, SFUNC(IAccountServiceForApplication::ListOpenUsers)},

--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
@@ -8,6 +8,13 @@
 
 namespace skyline {
     namespace service::account {
+        namespace result {
+            constexpr Result NullArgument(124, 20);
+            constexpr Result InvalidArgument(124, 22);
+            constexpr Result InvalidInputBuffer(124, 32);
+            constexpr Result UserNotFound(124, 100);
+        }
+
         /**
          * @brief This hold an account's user ID
          */
@@ -31,7 +38,7 @@ namespace skyline {
             /**
              * @brief Writes a vector of 128-bit user IDs to an output buffer
              */
-            void WriteUserList(ipc::OutputBuffer buffer, std::vector<UserId> userIds);
+            Result WriteUserList(ipc::OutputBuffer buffer, std::vector<UserId> userIds);
 
           public:
             IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager);
@@ -39,37 +46,37 @@ namespace skyline {
             /**
             * @brief This checks if the given user ID exists
             */
-            void GetUserExistence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetUserExistence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief This returns a list of all user accounts on the console
             */
-            void ListAllUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result ListAllUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief This returns a list of all open user accounts on the console
             */
-            void ListOpenUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result ListOpenUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief This returns the user ID of the last active user on the console
             */
-            void GetLastOpenedUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetLastOpenedUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief This provides information about the running application for account services to use (https://switchbrew.org/wiki/Account_services#InitializeApplicationInfoV0)
             */
-            void InitializeApplicationInfoV0(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result InitializeApplicationInfoV0(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This returns a handle to an IProfile which can be used for reading user information
              */
-            void GetProfile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetProfile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief This returns a handle to an IManagerForApplication which can be used for reading Nintendo Online info
             */
-            void GetBaasAccountManagerForApplication(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetBaasAccountManagerForApplication(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
         };
     }
 

--- a/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
@@ -4,6 +4,6 @@
 #include "IManagerForApplication.h"
 
 namespace skyline::service::account {
-    IManagerForApplication::IManagerForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::account_IManagerForApplication, "account:IManagerForApplication", {
+    IManagerForApplication::IManagerForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/account/IProfile.cpp
+++ b/app/src/main/cpp/skyline/services/account/IProfile.cpp
@@ -10,7 +10,7 @@ namespace skyline::service::account {
         {0x1, SFUNC(IProfile::GetBase)}
     }) {}
 
-    void IProfile::Get(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IProfile::Get(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         struct AccountUserData {
             u32 _unk0_;
             u32 iconID;                        //!< Icon ID (0 = Mii, the rest are character icon IDs)
@@ -23,10 +23,10 @@ namespace skyline::service::account {
         auto userData = state.process->GetPointer<AccountUserData>(request.outputBuf.at(0).address);
         userData->iconBackgroundColorID = 0x1; // Color indexing starts at 0x1
 
-        GetBase(session, request, response);
+        return GetBase(session, request, response);
     }
 
-    void IProfile::GetBase(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IProfile::GetBase(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         struct {
             UserId uid;                        //!< The UID of the corresponding account
             u64 lastEditTimestamp;             //!< A POSIX UTC timestamp denoting the last account edit
@@ -40,5 +40,7 @@ namespace skyline::service::account {
         std::memcpy(accountProfileBase.nickname.data(), username.c_str(), usernameSize);
 
         response.Push(accountProfileBase);
+
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/account/IProfile.cpp
+++ b/app/src/main/cpp/skyline/services/account/IProfile.cpp
@@ -5,7 +5,7 @@
 #include "IProfile.h"
 
 namespace skyline::service::account {
-    IProfile::IProfile(const DeviceState &state, ServiceManager &manager, const UserId &userId) : userId(userId), BaseService(state, manager, Service::account_IProfile, "account:IProfile", {
+    IProfile::IProfile(const DeviceState &state, ServiceManager &manager, const UserId &userId) : userId(userId), BaseService(state, manager, {
         {0x0, SFUNC(IProfile::Get)},
         {0x1, SFUNC(IProfile::GetBase)}
     }) {}

--- a/app/src/main/cpp/skyline/services/account/IProfile.h
+++ b/app/src/main/cpp/skyline/services/account/IProfile.h
@@ -21,11 +21,11 @@ namespace skyline::service::account {
         /**
          * @brief This returns AccountUserData and AccountProfileBase objects that describe the user's information
          */
-        void Get(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Get(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns an AccountProfileBase object that describe the user's information
          */
-        void GetBase(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetBase(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.cpp
+++ b/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.cpp
@@ -16,19 +16,23 @@ namespace skyline::service::am {
         {0x15E, SFUNC(IAllSystemAppletProxiesService::OpenApplicationProxy)}
     }) {}
 
-    void IAllSystemAppletProxiesService::OpenLibraryAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAllSystemAppletProxiesService::OpenLibraryAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ILibraryAppletProxy), session, response);
+        return {};
     }
 
-    void IAllSystemAppletProxiesService::OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAllSystemAppletProxiesService::OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IApplicationProxy), session, response);
+        return {};
     }
 
-    void IAllSystemAppletProxiesService::OpenOverlayAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAllSystemAppletProxiesService::OpenOverlayAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IOverlayAppletProxy), session, response);
+        return {};
     }
 
-    void IAllSystemAppletProxiesService::OpenSystemAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAllSystemAppletProxiesService::OpenSystemAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ISystemAppletProxy), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.cpp
+++ b/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.cpp
@@ -8,7 +8,7 @@
 #include "IAllSystemAppletProxiesService.h"
 
 namespace skyline::service::am {
-    IAllSystemAppletProxiesService::IAllSystemAppletProxiesService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IAllSystemAppletProxiesService, "am:IAllSystemAppletProxiesService", {
+    IAllSystemAppletProxiesService::IAllSystemAppletProxiesService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x64, SFUNC(IAllSystemAppletProxiesService::OpenSystemAppletProxy)},
         {0xC8, SFUNC(IAllSystemAppletProxiesService::OpenLibraryAppletProxy)},
         {0xC9, SFUNC(IAllSystemAppletProxiesService::OpenLibraryAppletProxy)},

--- a/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.h
+++ b/app/src/main/cpp/skyline/services/am/IAllSystemAppletProxiesService.h
@@ -17,21 +17,21 @@ namespace skyline::service::am {
         /**
          * @brief This returns #ILibraryAppletProxy (https://switchbrew.org/wiki/Applet_Manager_services#OpenLibraryAppletProxy)
          */
-        void OpenLibraryAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenLibraryAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IApplicationProxy (https://switchbrew.org/wiki/Applet_Manager_services#OpenApplicationProxy)
          */
-        void OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IOverlayAppletProxy (https://switchbrew.org/wiki/Applet_Manager_services#OpenOverlayAppletProxy)
          */
-        void OpenOverlayAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenOverlayAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #ISystemAppletProxy (https://switchbrew.org/wiki/Applet_Manager_services#OpenSystemAppletProxy)
          */
-        void OpenSystemAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenSystemAppletProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/IApplicationProxyService.cpp
+++ b/app/src/main/cpp/skyline/services/am/IApplicationProxyService.cpp
@@ -5,7 +5,7 @@
 #include "IApplicationProxyService.h"
 
 namespace skyline::service::am {
-    IApplicationProxyService::IApplicationProxyService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IApplicationProxyService, "am:IApplicationProxyService", {
+    IApplicationProxyService::IApplicationProxyService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IApplicationProxyService::OpenApplicationProxy)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/am/IApplicationProxyService.cpp
+++ b/app/src/main/cpp/skyline/services/am/IApplicationProxyService.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::am {
         {0x0, SFUNC(IApplicationProxyService::OpenApplicationProxy)}
     }) {}
 
-    void IApplicationProxyService::OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationProxyService::OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IApplicationProxy), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/IApplicationProxyService.h
+++ b/app/src/main/cpp/skyline/services/am/IApplicationProxyService.h
@@ -17,6 +17,6 @@ namespace skyline::service::am {
         /**
          * @brief This returns #IApplicationProxy (https://switchbrew.org/wiki/Applet_Manager_services#OpenApplicationProxy)
          */
-        void OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenApplicationProxy(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
+++ b/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
@@ -7,7 +7,7 @@
 #include "ILibraryAppletAccessor.h"
 
 namespace skyline::service::am {
-    ILibraryAppletAccessor::ILibraryAppletAccessor(const DeviceState &state, ServiceManager &manager) : stateChangeEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::am_ILibraryAppletAccessor, "am:ILibraryAppletAccessor", {
+    ILibraryAppletAccessor::ILibraryAppletAccessor(const DeviceState &state, ServiceManager &manager) : stateChangeEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(ILibraryAppletAccessor::GetAppletStateChangedEvent)},
         {0xA, SFUNC(ILibraryAppletAccessor::Start)},
         {0x1E, SFUNC(ILibraryAppletAccessor::GetResult)},

--- a/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
+++ b/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
@@ -15,22 +15,29 @@ namespace skyline::service::am {
         {0x65, SFUNC(ILibraryAppletAccessor::PopOutData)},
     }) {}
 
-    void ILibraryAppletAccessor::GetAppletStateChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILibraryAppletAccessor::GetAppletStateChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         stateChangeEvent->Signal();
 
         KHandle handle = state.process->InsertItem(stateChangeEvent);
         state.logger->Debug("Applet State Change Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 
-    void ILibraryAppletAccessor::Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ILibraryAppletAccessor::Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ILibraryAppletAccessor::GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ILibraryAppletAccessor::GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ILibraryAppletAccessor::PushInData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ILibraryAppletAccessor::PushInData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ILibraryAppletAccessor::PopOutData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILibraryAppletAccessor::PopOutData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 LaunchParameterMagic = 0xC79497CA; //!< This is the magic of the application launch parameters
         constexpr size_t LaunchParameterSize = 0x88; //!< This is the size of the launch parameter IStorage
 
@@ -41,5 +48,6 @@ namespace skyline::service::am {
         storageService->Push(constant::DefaultUserId);
 
         manager.RegisterService(storageService, session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.h
+++ b/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.h
@@ -21,26 +21,26 @@ namespace skyline::service::am {
         /**
          * @brief This function returns a handle to the library applet state change event
          */
-        void GetAppletStateChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAppletStateChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function starts the library applet (https://switchbrew.org/wiki/Applet_Manager_services#Start)
          */
-        void Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function returns the exit code of the library applet (https://switchbrew.org/wiki/Applet_Manager_services#GetResult)
          */
-        void GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function pushes in data to the library applet (https://switchbrew.org/wiki/Applet_Manager_services#PushInData)
          */
-        void PushInData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result PushInData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function receives data from the library applet (https://switchbrew.org/wiki/Applet_Manager_services#PopOutData)
          */
-        void PopOutData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result PopOutData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IAppletCommonFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IAppletCommonFunctions.cpp
@@ -4,6 +4,6 @@
 #include "IAppletCommonFunctions.h"
 
 namespace skyline::service::am {
-    IAppletCommonFunctions::IAppletCommonFunctions(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IAppletCommonFunctions, "am:IAppletCommonFunctions", {
+    IAppletCommonFunctions::IAppletCommonFunctions(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -7,7 +7,7 @@
 #include "IApplicationFunctions.h"
 
 namespace skyline::service::am {
-    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager) : gpuErrorEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::am_IApplicationFunctions, "am:IApplicationFunctions", {
+    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager) : gpuErrorEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x1, SFUNC(IApplicationFunctions::PopLaunchParameter)},
         {0x14, SFUNC(IApplicationFunctions::EnsureSaveData)},
         {0x15, SFUNC(IApplicationFunctions::GetDesiredLanguage)},

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -19,7 +19,7 @@ namespace skyline::service::am {
         {0x82, SFUNC(IApplicationFunctions::GetGpuErrorDetectedSystemEvent)},
     }) {}
 
-    void IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 LaunchParameterMagic = 0xC79497CA; //!< This is the magic of the application launch parameters
         constexpr size_t LaunchParameterSize = 0x88; //!< This is the size of the launch parameter IStorage
 
@@ -30,32 +30,42 @@ namespace skyline::service::am {
         storageService->Push(constant::DefaultUserId);
 
         manager.RegisterService(storageService, session, response);
+        return {};
     }
 
-    void IApplicationFunctions::EnsureSaveData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::EnsureSaveData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u8>(0);
+        return {};
     }
 
-    void IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(util::MakeMagic<u64>("en-US"));
+        return {};
     }
 
-    void IApplicationFunctions::NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u8>(1);
+        return {};
     }
 
-    void IApplicationFunctions::GetPseudoDeviceId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::GetPseudoDeviceId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u64>(0L);
         response.Push<u64>(0L);
+        return {};
     }
 
-    void IApplicationFunctions::InitializeGamePlayRecording(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IApplicationFunctions::InitializeGamePlayRecording(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void IApplicationFunctions::SetGamePlayRecordingState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IApplicationFunctions::SetGamePlayRecordingState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void IApplicationFunctions::GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationFunctions::GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem(gpuErrorEvent);
         state.logger->Debug("GPU Error Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
@@ -21,41 +21,41 @@ namespace skyline::service::am {
         /**
          * @brief This returns an Applet Manager IStorage containing the application's launch parameters (https://switchbrew.org/wiki/Applet_Manager_services#PopLaunchParameter)
          */
-        void PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This creates a save data folder for the requesting application (https://switchbrew.org/wiki/Applet_Manager_services#EnsureSaveData)
          */
-        void EnsureSaveData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result EnsureSaveData(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the desired language for the application (https://switchbrew.org/wiki/Applet_Manager_services#GetDesiredLanguage)
          */
-        void GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns if the application is running or not, always returns true (https://switchbrew.org/wiki/Applet_Manager_services#NotifyRunning)
          */
-        void NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result NotifyRunning(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a UUID, however what it refers to is currently unknown (https://switchbrew.org/wiki/Applet_Manager_services#GetPseudoDeviceId)
          */
-        void GetPseudoDeviceId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetPseudoDeviceId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This initializes gameplay recording (https://switchbrew.org/wiki/Applet_Manager_services#InitializeGamePlayRecording)
          */
-        void InitializeGamePlayRecording(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result InitializeGamePlayRecording(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This controls the gameplay recording state (https://switchbrew.org/wiki/Applet_Manager_services#SetGamePlayRecordingState)
          */
-        void SetGamePlayRecordingState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetGamePlayRecordingState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This obtains a handle to the system GPU error KEvent (https://switchbrew.org/wiki/Applet_Manager_services#GetGpuErrorDetectedSystemEvent)
          */
-        void GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IAudioController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IAudioController.cpp
@@ -10,16 +10,19 @@ namespace skyline::service::am {
         {0x2, SFUNC(IAudioController::GetLibraryAppletExpectedMasterVolume)}
     }) {}
 
-    void IAudioController::SetExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioController::SetExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         mainAppletVolume = request.Pop<float>();
         libraryAppletVolume = request.Pop<float>();
+        return {};
     }
 
-    void IAudioController::GetMainAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioController::GetMainAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<float>(mainAppletVolume);
+        return {};
     }
 
-    void IAudioController::GetLibraryAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioController::GetLibraryAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<float>(libraryAppletVolume);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IAudioController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IAudioController.cpp
@@ -4,7 +4,7 @@
 #include "IAudioController.h"
 
 namespace skyline::service::am {
-    IAudioController::IAudioController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IAudioController, "am:IAudioController", {
+    IAudioController::IAudioController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IAudioController::SetExpectedMasterVolume)},
         {0x1, SFUNC(IAudioController::GetMainAppletExpectedMasterVolume)},
         {0x2, SFUNC(IAudioController::GetLibraryAppletExpectedMasterVolume)}

--- a/app/src/main/cpp/skyline/services/am/controller/IAudioController.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IAudioController.h
@@ -21,16 +21,16 @@ namespace skyline::service::am {
         /**
          * @brief This sets the expected volumes for an application (https://switchbrew.org/wiki/Applet_Manager_services#SetExpectedMasterVolume)
          */
-        void SetExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the main applet volume that is expected by the application (https://switchbrew.org/wiki/Applet_Manager_services#GetMainAppletExpectedMasterVolume)
          */
-        void GetMainAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetMainAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the library applet volume that is expected by the application (https://switchbrew.org/wiki/Applet_Manager_services#GetLibraryAppletExpectedMasterVolume)
          */
-        void GetLibraryAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetLibraryAppletExpectedMasterVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
@@ -23,35 +23,38 @@ namespace skyline::service::am {
         QueueMessage(Message::FocusStateChange);
     }
 
-    void ICommonStateGetter::GetEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ICommonStateGetter::GetEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem(messageEvent);
         state.logger->Debug("Applet Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
+        return {};
     }
 
-    void ICommonStateGetter::ReceiveMessage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        if (messageQueue.empty()) {
-            response.errorCode = constant::status::NoMessages;
-            return;
-        }
+    Result ICommonStateGetter::ReceiveMessage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        if (messageQueue.empty())
+            return result::NoMessages;
 
         response.Push(messageQueue.front());
         messageQueue.pop();
+        return {};
     }
 
-    void ICommonStateGetter::GetCurrentFocusState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ICommonStateGetter::GetCurrentFocusState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(focusState);
+        return {};
     }
 
-    void ICommonStateGetter::GetOperationMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ICommonStateGetter::GetOperationMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(operationMode);
+        return {};
     }
 
-    void ICommonStateGetter::GetPerformanceMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ICommonStateGetter::GetPerformanceMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(static_cast<u32>(operationMode));
+        return {};
     }
 
-    void ICommonStateGetter::GetDefaultDisplayResolution(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ICommonStateGetter::GetDefaultDisplayResolution(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         if (operationMode == OperationMode::Handheld) {
             response.Push<u32>(constant::HandheldResolutionW);
             response.Push<u32>(constant::HandheldResolutionH);
@@ -59,5 +62,6 @@ namespace skyline::service::am {
             response.Push<u32>(constant::DockedResolutionW);
             response.Push<u32>(constant::DockedResolutionH);
         }
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
@@ -10,7 +10,7 @@ namespace skyline::service::am {
         messageEvent->Signal();
     }
 
-    ICommonStateGetter::ICommonStateGetter(const DeviceState &state, ServiceManager &manager) : messageEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::am_ICommonStateGetter, "am:ICommonStateGetter", {
+    ICommonStateGetter::ICommonStateGetter(const DeviceState &state, ServiceManager &manager) : messageEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(ICommonStateGetter::GetEventHandle)},
         {0x1, SFUNC(ICommonStateGetter::ReceiveMessage)},
         {0x5, SFUNC(ICommonStateGetter::GetOperationMode)},

--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.h
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.h
@@ -9,6 +9,10 @@
 #include <services/serviceman.h>
 
 namespace skyline::service::am {
+    namespace result {
+        constexpr Result NoMessages(128, 3);
+    }
+
     /**
      * @brief https://switchbrew.org/wiki/Applet_Manager_services#ICommonStateGetter
      */
@@ -53,31 +57,31 @@ namespace skyline::service::am {
         /**
          * @brief This returns the handle to a KEvent object that is signalled whenever RecieveMessage has a message (https://switchbrew.org/wiki/Applet_Manager_services#GetEventHandle)
          */
-        void GetEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns an #AppletMessage or 0x680 to indicate the lack of a message (https://switchbrew.org/wiki/Applet_Manager_services#ReceiveMessage)
          */
-        void ReceiveMessage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ReceiveMessage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns if an application is in focus or not. It always returns in focus on the emulator (https://switchbrew.org/wiki/Applet_Manager_services#GetCurrentFocusState)
          */
-        void GetCurrentFocusState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetCurrentFocusState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the current OperationMode (https://switchbrew.org/wiki/Applet_Manager_services#GetOperationMode)
          */
-        void GetOperationMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetOperationMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the current PerformanceMode (Same as operationMode but u32) (https://switchbrew.org/wiki/Applet_Manager_services#GetPerformanceMode)
          */
-        void GetPerformanceMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetPerformanceMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the current display width and height in two u32s (https://switchbrew.org/wiki/Applet_Manager_services#GetDefaultDisplayResolution)
          */
-        void GetDefaultDisplayResolution(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDefaultDisplayResolution(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IDebugFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IDebugFunctions.cpp
@@ -4,6 +4,6 @@
 #include "IDebugFunctions.h"
 
 namespace skyline::service::am {
-    IDebugFunctions::IDebugFunctions(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IDebugFunctions, "am:IDebugFunctions", {
+    IDebugFunctions::IDebugFunctions(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IDisplayController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IDisplayController.cpp
@@ -4,6 +4,6 @@
 #include "IDisplayController.h"
 
 namespace skyline::service::am {
-    IDisplayController::IDisplayController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IDisplayController, "am:IDisplayController", {
+    IDisplayController::IDisplayController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.cpp
@@ -11,16 +11,18 @@ namespace skyline::service::am {
         {0xA, SFUNC(ILibraryAppletCreator::CreateStorage)}
     }) {}
 
-    void ILibraryAppletCreator::CreateLibraryApplet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILibraryAppletCreator::CreateLibraryApplet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ILibraryAppletAccessor), session, response);
+        return {};
     }
 
-    void ILibraryAppletCreator::CreateStorage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILibraryAppletCreator::CreateStorage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto size = request.Pop<i64>();
 
         if (size < 0)
             throw exception("Cannot create an IStorage with a negative size");
 
         manager.RegisterService(std::make_shared<IStorage>(state, manager, size), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.cpp
@@ -6,7 +6,7 @@
 #include "ILibraryAppletCreator.h"
 
 namespace skyline::service::am {
-    ILibraryAppletCreator::ILibraryAppletCreator(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_ILibraryAppletCreator, "am:ILibraryAppletCreator", {
+    ILibraryAppletCreator::ILibraryAppletCreator(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ILibraryAppletCreator::CreateLibraryApplet)},
         {0xA, SFUNC(ILibraryAppletCreator::CreateStorage)}
     }) {}

--- a/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.h
+++ b/app/src/main/cpp/skyline/services/am/controller/ILibraryAppletCreator.h
@@ -17,11 +17,11 @@ namespace skyline::service::am {
         /**
          * @brief This function returns a handle to a library applet accessor (https://switchbrew.org/wiki/Applet_Manager_services#CreateLibraryApplet)
          */
-        void CreateLibraryApplet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateLibraryApplet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function creates an IStorage that can be used by the application (https://switchbrew.org/wiki/Applet_Manager_services#CreateStorage)
          */
-        void CreateStorage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateStorage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
@@ -20,30 +20,45 @@ namespace skyline::service::am {
         {0x5B, SFUNC(ISelfController::GetLibraryAppletLaunchableEvent)}
     }) {}
 
-    void ISelfController::LockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::LockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::UnlockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::UnlockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::GetLibraryAppletLaunchableEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISelfController::GetLibraryAppletLaunchableEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         libraryAppletLaunchableEvent->Signal();
 
         KHandle handle = state.process->InsertItem(libraryAppletLaunchableEvent);
         state.logger->Debug("Library Applet Launchable Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 
-    void ISelfController::SetOperationModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::SetOperationModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::SetPerformanceModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::SetPerformanceModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::SetFocusHandlingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::SetFocusHandlingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::SetRestartMessageEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::SetRestartMessageEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::SetOutOfFocusSuspendingEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISelfController::SetOutOfFocusSuspendingEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void ISelfController::CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISelfController::CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.logger->Debug("Creating Managed Layer on Default Display");
 
         auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
@@ -52,12 +67,14 @@ namespace skyline::service::am {
         hosBinder->layerStatus = hosbinder::LayerStatus::Managed;
 
         response.Push<u64>(0);
+        return {};
     }
 
-    void ISelfController::GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISelfController::GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem(accumulatedSuspendedTickChangedEvent);
         state.logger->Debug("Accumulated Suspended Tick Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
@@ -7,7 +7,7 @@
 #include "ISelfController.h"
 
 namespace skyline::service::am {
-    ISelfController::ISelfController(const DeviceState &state, ServiceManager &manager) : libraryAppletLaunchableEvent(std::make_shared<type::KEvent>(state)), accumulatedSuspendedTickChangedEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::am_ISelfController, "am:ISelfController", {
+    ISelfController::ISelfController(const DeviceState &state, ServiceManager &manager) : libraryAppletLaunchableEvent(std::make_shared<type::KEvent>(state)), accumulatedSuspendedTickChangedEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x1, SFUNC(ISelfController::LockExit)},
         {0x2, SFUNC(ISelfController::UnlockExit)},
         {0x9, SFUNC(ISelfController::GetLibraryAppletLaunchableEvent)},
@@ -46,7 +46,7 @@ namespace skyline::service::am {
     void ISelfController::CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.logger->Debug("Creating Managed Layer on Default Display");
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus != hosbinder::LayerStatus::Uninitialized)
             throw exception("The application is creating more than one layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Managed;

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.h
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.h
@@ -21,51 +21,51 @@ namespace skyline::service::am {
         /**
          * @brief This function prevents the running application from being quit via the home button (https://switchbrew.org/wiki/Applet_Manager_services#LockExit)
          */
-        void LockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result LockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function allows the running application to be quit via the home button (https://switchbrew.org/wiki/Applet_Manager_services#UnlockExit)
          */
-        void UnlockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result UnlockExit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function obtains a handle to the library applet launchable event (https://switchbrew.org/wiki/Applet_Manager_services#GetLibraryAppletLaunchableEvent)
          */
-        void GetLibraryAppletLaunchableEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetLibraryAppletLaunchableEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function takes a u8 bool flag and no output (Stubbed) (https://switchbrew.org/wiki/Applet_Manager_services#SetOperationModeChangedNotification)
          */
-        void SetOperationModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetOperationModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function takes a u8 bool flag and no output (Stubbed) (https://switchbrew.org/wiki/Applet_Manager_services#SetPerformanceModeChangedNotification)
          */
-        void SetPerformanceModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetPerformanceModeChangedNotification(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function takes 3 unknown u8 values and has no output (Stubbed) (https://switchbrew.org/wiki/Applet_Manager_services#GetCurrentFocusState)
          */
-        void SetFocusHandlingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetFocusHandlingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function toggles whether a restart message should be sent (https://switchbrew.org/wiki/Applet_Manager_services#SetRestartMessageEnabled)
          */
-        void SetRestartMessageEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetRestartMessageEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function takes a u8 bool flag and has no output (Stubbed) (https://switchbrew.org/wiki/Applet_Manager_services#SetOutOfFocusSuspendingEnabled)
          */
-        void SetOutOfFocusSuspendingEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetOutOfFocusSuspendingEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function returns an output u64 LayerId (https://switchbrew.org/wiki/Applet_Manager_services#CreateManagedDisplayLayer)
          */
-        void CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This obtains a handle to the system sleep time change KEvent  (https://switchbrew.org/wiki/Applet_Manager_services#GetAccumulatedSuspendedTickChangedEvent)
          */
-        void GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IWindowController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IWindowController.cpp
@@ -10,9 +10,12 @@ namespace skyline::service::am {
         {0xA, SFUNC(IWindowController::AcquireForegroundRights)}
     }) {}
 
-    void IWindowController::GetAppletResourceUserId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IWindowController::GetAppletResourceUserId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(static_cast<u64>(state.process->pid));
+        return {};
     }
 
-    void IWindowController::AcquireForegroundRights(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IWindowController::AcquireForegroundRights(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IWindowController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IWindowController.cpp
@@ -5,7 +5,7 @@
 #include "IWindowController.h"
 
 namespace skyline::service::am {
-    IWindowController::IWindowController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::am_IWindowController, "am:IWindowController", {
+    IWindowController::IWindowController(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x1, SFUNC(IWindowController::GetAppletResourceUserId)},
         {0xA, SFUNC(IWindowController::AcquireForegroundRights)}
     }) {}

--- a/app/src/main/cpp/skyline/services/am/controller/IWindowController.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IWindowController.h
@@ -17,11 +17,11 @@ namespace skyline::service::am {
         /**
          * @brief This returns the PID of the current application (https://switchbrew.org/wiki/Applet_Manager_services#GetAppletResourceUserId)
          */
-        void GetAppletResourceUserId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAppletResourceUserId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function has mo inputs or outputs (Stubbed) (https://switchbrew.org/wiki/Applet_Manager_services#AcquireForegroundRights)
          */
-        void AcquireForegroundRights(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result AcquireForegroundRights(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.cpp
@@ -5,7 +5,7 @@
 #include "IApplicationProxy.h"
 
 namespace skyline::service::am {
-    IApplicationProxy::IApplicationProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, Service::am_IApplicationProxy, "am:IApplicationProxy", {
+    IApplicationProxy::IApplicationProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, {
         {0x0, SFUNC(BaseProxy::GetCommonStateGetter)},
         {0x1, SFUNC(BaseProxy::GetSelfController)},
         {0x2, SFUNC(BaseProxy::GetWindowController)},

--- a/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.cpp
@@ -16,7 +16,8 @@ namespace skyline::service::am {
         {0x3E8, SFUNC(BaseProxy::GetDebugFunctions)}
     }) {}
 
-    void IApplicationProxy::GetApplicationFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationProxy::GetApplicationFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IApplicationFunctions), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.h
+++ b/app/src/main/cpp/skyline/services/am/proxy/IApplicationProxy.h
@@ -16,6 +16,6 @@ namespace skyline::service::am {
         /**
          * @brief This returns #IApplicationFunctions (https://switchbrew.org/wiki/Applet_Manager_services#IApplicationFunctions)
          */
-        void GetApplicationFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetApplicationFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/proxy/ILibraryAppletProxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/ILibraryAppletProxy.cpp
@@ -4,7 +4,7 @@
 #include "ILibraryAppletProxy.h"
 
 namespace skyline::service::am {
-    ILibraryAppletProxy::ILibraryAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, Service::am_ILibraryAppletProxy, "am:ILibraryAppletProxy", {
+    ILibraryAppletProxy::ILibraryAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, {
         {0x0, SFUNC(BaseProxy::GetCommonStateGetter)},
         {0x1, SFUNC(BaseProxy::GetSelfController)},
         {0x2, SFUNC(BaseProxy::GetWindowController)},

--- a/app/src/main/cpp/skyline/services/am/proxy/IOverlayAppletProxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/IOverlayAppletProxy.cpp
@@ -4,7 +4,7 @@
 #include "IOverlayAppletProxy.h"
 
 namespace skyline::service::am {
-    IOverlayAppletProxy::IOverlayAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, Service::am_IOverlayAppletProxy, "am:IOverlayAppletProxy", {
+    IOverlayAppletProxy::IOverlayAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, {
         {0x0, SFUNC(BaseProxy::GetCommonStateGetter)},
         {0x1, SFUNC(BaseProxy::GetSelfController)},
         {0x2, SFUNC(BaseProxy::GetWindowController)},

--- a/app/src/main/cpp/skyline/services/am/proxy/ISystemAppletProxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/ISystemAppletProxy.cpp
@@ -4,7 +4,7 @@
 #include "ISystemAppletProxy.h"
 
 namespace skyline::service::am {
-    ISystemAppletProxy::ISystemAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, Service::am_ISystemAppletProxy, "am:ISystemAppletProxy", {
+    ISystemAppletProxy::ISystemAppletProxy(const DeviceState &state, ServiceManager &manager) : BaseProxy(state, manager, {
         {0x0, SFUNC(BaseProxy::GetCommonStateGetter)},
         {0x1, SFUNC(BaseProxy::GetSelfController)},
         {0x2, SFUNC(BaseProxy::GetWindowController)},

--- a/app/src/main/cpp/skyline/services/am/proxy/base_proxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/base_proxy.cpp
@@ -12,37 +12,45 @@
 #include "base_proxy.h"
 
 namespace skyline::service::am {
-    BaseProxy::BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
+    BaseProxy::BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<Result(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
 
-    void BaseProxy::GetCommonStateGetter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetCommonStateGetter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ICommonStateGetter), session, response);
+        return {};
     }
 
-    void BaseProxy::GetSelfController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetSelfController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ISelfController), session, response);
+        return {};
     }
 
-    void BaseProxy::GetWindowController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetWindowController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IWindowController), session, response);
+        return {};
     }
 
-    void BaseProxy::GetAudioController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetAudioController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IAudioController), session, response);
+        return {};
     }
 
-    void BaseProxy::GetDisplayController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetDisplayController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IDisplayController), session, response);
+        return {};
     }
 
-    void BaseProxy::GetLibraryAppletCreator(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetLibraryAppletCreator(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ILibraryAppletCreator), session, response);
+        return {};
     }
 
-    void BaseProxy::GetDebugFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetDebugFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IDebugFunctions), session, response);
+        return {};
     }
 
-    void BaseProxy::GetAppletCommonFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result BaseProxy::GetAppletCommonFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IAppletCommonFunctions), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/proxy/base_proxy.cpp
+++ b/app/src/main/cpp/skyline/services/am/proxy/base_proxy.cpp
@@ -12,7 +12,7 @@
 #include "base_proxy.h"
 
 namespace skyline::service::am {
-    BaseProxy::BaseProxy(const DeviceState &state, ServiceManager &manager, const Service serviceType, const std::string &serviceName, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, serviceType, serviceName, vTable) {}
+    BaseProxy::BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
 
     void BaseProxy::GetCommonStateGetter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ICommonStateGetter), session, response);

--- a/app/src/main/cpp/skyline/services/am/proxy/base_proxy.h
+++ b/app/src/main/cpp/skyline/services/am/proxy/base_proxy.h
@@ -12,7 +12,7 @@ namespace skyline::service::am {
      */
     class BaseProxy : public BaseService {
       public:
-        BaseProxy(const DeviceState &state, ServiceManager &manager, const Service serviceType, const std::string &serviceName, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
+        BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
 
         /**
          * @brief This returns #ICommonStateGetter (https://switchbrew.org/wiki/Applet_Manager_services#ICommonStateGetter)

--- a/app/src/main/cpp/skyline/services/am/proxy/base_proxy.h
+++ b/app/src/main/cpp/skyline/services/am/proxy/base_proxy.h
@@ -12,46 +12,46 @@ namespace skyline::service::am {
      */
     class BaseProxy : public BaseService {
       public:
-        BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
+        BaseProxy(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<Result(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
 
         /**
          * @brief This returns #ICommonStateGetter (https://switchbrew.org/wiki/Applet_Manager_services#ICommonStateGetter)
          */
-        void GetCommonStateGetter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetCommonStateGetter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #ISelfController (https://switchbrew.org/wiki/Applet_Manager_services#ISelfController)
          */
-        void GetSelfController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSelfController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IWindowController (https://switchbrew.org/wiki/Applet_Manager_services#IWindowController)
          */
-        void GetWindowController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetWindowController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IAudioController (https://switchbrew.org/wiki/Applet_Manager_services#IAudioController)
          */
-        void GetAudioController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAudioController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IDisplayController (https://switchbrew.org/wiki/Applet_Manager_services#IDisplayController)
          */
-        void GetDisplayController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDisplayController(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #ILibraryAppletCreator (https://switchbrew.org/wiki/Applet_Manager_services#ILibraryAppletCreator)
          */
-        void GetLibraryAppletCreator(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetLibraryAppletCreator(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IDebugFunctions (https://switchbrew.org/wiki/Applet_Manager_services#IDebugFunctions)
          */
-        void GetDebugFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDebugFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns #IAppletCommonFunctions (https://switchbrew.org/wiki/Applet_Manager_services#IAppletCommonFunctions)
          */
-        void GetAppletCommonFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAppletCommonFunctions(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/am/storage/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/am/storage/IStorage.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::am {
         {0x0, SFUNC(IStorage::Open)}
     }) {}
 
-    void IStorage::Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStorage::Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<IStorageAccessor>(state, manager, shared_from_this()), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/storage/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/am/storage/IStorage.cpp
@@ -5,7 +5,7 @@
 #include "IStorage.h"
 
 namespace skyline::service::am {
-    IStorage::IStorage(const DeviceState &state, ServiceManager &manager, size_t size) : content(size), BaseService(state, manager, Service::am_IStorage, "am:IStorage", {
+    IStorage::IStorage(const DeviceState &state, ServiceManager &manager, size_t size) : content(size), BaseService(state, manager, {
         {0x0, SFUNC(IStorage::Open)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/am/storage/IStorage.h
+++ b/app/src/main/cpp/skyline/services/am/storage/IStorage.h
@@ -22,7 +22,7 @@ namespace skyline::service::am {
         /**
          * @brief This returns an IStorageAccessor that can read and write data to an IStorage
          */
-        void Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This function writes an object to the storage

--- a/app/src/main/cpp/skyline/services/am/storage/IStorageAccessor.cpp
+++ b/app/src/main/cpp/skyline/services/am/storage/IStorageAccessor.cpp
@@ -6,7 +6,7 @@
 #include "IStorageAccessor.h"
 
 namespace skyline::service::am {
-    IStorageAccessor::IStorageAccessor(const DeviceState &state, ServiceManager &manager, std::shared_ptr<IStorage> parent) : parent(parent), BaseService(state, manager, Service::am_IStorageAccessor, "am:IStorageAccessor", {
+    IStorageAccessor::IStorageAccessor(const DeviceState &state, ServiceManager &manager, std::shared_ptr<IStorage> parent) : parent(parent), BaseService(state, manager, {
         {0x0, SFUNC(IStorageAccessor::GetSize)},
         {0xA, SFUNC(IStorageAccessor::Write)},
         {0xB, SFUNC(IStorageAccessor::Read)}

--- a/app/src/main/cpp/skyline/services/am/storage/IStorageAccessor.h
+++ b/app/src/main/cpp/skyline/services/am/storage/IStorageAccessor.h
@@ -7,6 +7,9 @@
 #include <services/serviceman.h>
 
 namespace skyline::service::am {
+    namespace result {
+        constexpr Result OutOfBounds(128, 503);
+    }
     class IStorage;
 
     /**
@@ -22,16 +25,16 @@ namespace skyline::service::am {
         /**
          * @brief This returns the size of the storage in bytes
          */
-        void GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This writes a buffer to the storage at the specified offset
          */
-        void Write(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Write(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a buffer containing the contents of the storage at the specified offset
          */
-        void Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
@@ -4,6 +4,6 @@
 #include "IAddOnContentManager.h"
 
 namespace skyline::service::aocsrv {
-    IAddOnContentManager::IAddOnContentManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::aocsrv_IAddOnContentManager, "aocsrv:IAddOnContentManager", {
+    IAddOnContentManager::IAddOnContentManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/apm/IManager.cpp
+++ b/app/src/main/cpp/skyline/services/apm/IManager.cpp
@@ -5,7 +5,7 @@
 #include "IManager.h"
 
 namespace skyline::service::apm {
-    IManager::IManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::apm_IManager, "apm:IManager", {
+    IManager::IManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IManager::OpenSession)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/apm/IManager.cpp
+++ b/app/src/main/cpp/skyline/services/apm/IManager.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::apm {
         {0x0, SFUNC(IManager::OpenSession)}
     }) {}
 
-    void IManager::OpenSession(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IManager::OpenSession(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ISession), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/apm/IManager.h
+++ b/app/src/main/cpp/skyline/services/apm/IManager.h
@@ -17,6 +17,6 @@ namespace skyline::service::apm {
         /**
          * @brief This returns an handle to ISession
          */
-        void OpenSession(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenSession(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/apm/ISession.cpp
+++ b/app/src/main/cpp/skyline/services/apm/ISession.cpp
@@ -9,15 +9,17 @@ namespace skyline::service::apm {
         {0x1, SFUNC(ISession::GetPerformanceConfiguration)}
     }) {}
 
-    void ISession::SetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISession::SetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto mode = request.Pop<u32>();
         auto config = request.Pop<u32>();
         performanceConfig.at(mode) = config;
         state.logger->Info("SetPerformanceConfiguration called with 0x{:X} ({})", config, mode ? "Docked" : "Handheld");
+        return {};
     }
 
-    void ISession::GetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        u32 performanceMode = request.Pop<u32>();
+    Result ISession::GetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto performanceMode = request.Pop<u32>();
         response.Push<u32>(performanceConfig.at(performanceMode));
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/apm/ISession.cpp
+++ b/app/src/main/cpp/skyline/services/apm/ISession.cpp
@@ -4,7 +4,7 @@
 #include "ISession.h"
 
 namespace skyline::service::apm {
-    ISession::ISession(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::apm_ISession, "apm:ISession", {
+    ISession::ISession(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ISession::SetPerformanceConfiguration)},
         {0x1, SFUNC(ISession::GetPerformanceConfiguration)}
     }) {}

--- a/app/src/main/cpp/skyline/services/apm/ISession.h
+++ b/app/src/main/cpp/skyline/services/apm/ISession.h
@@ -20,11 +20,11 @@ namespace skyline::service::apm {
         /**
          * @brief This sets performanceConfig to the given arguments, it doesn't affect anything else (https://switchbrew.org/wiki/PPC_services#SetPerformanceConfiguration)
          */
-        void SetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This retrieves the particular performanceConfig for a mode and returns it to the client (https://switchbrew.org/wiki/PPC_services#SetPerformanceConfiguration)
          */
-        void GetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetPerformanceConfiguration(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
@@ -6,7 +6,7 @@
 #include "IAudioDevice.h"
 
 namespace skyline::service::audio {
-    IAudioDevice::IAudioDevice(const DeviceState &state, ServiceManager &manager) : systemEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::audio_IAudioDevice, "audio:IAudioDevice", {
+    IAudioDevice::IAudioDevice(const DeviceState &state, ServiceManager &manager) : systemEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(IAudioDevice::ListAudioDeviceName)},
         {0x1, SFUNC(IAudioDevice::SetAudioDeviceOutputVolume)},
         {0x3, SFUNC(IAudioDevice::GetActiveAudioDeviceName)},

--- a/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
@@ -17,7 +17,7 @@ namespace skyline::service::audio {
         {0xA, SFUNC(IAudioDevice::GetActiveAudioDeviceName)}
     }) {}
 
-    void IAudioDevice::ListAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioDevice::ListAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         u64 offset{};
         for (std::string deviceName : {"AudioTvOutput", "AudioStereoJackOutput", "AudioBuiltInSpeakerOutput"}) {
             if (offset + deviceName.size() + 1 > request.outputBuf.at(0).size)
@@ -26,26 +26,32 @@ namespace skyline::service::audio {
             state.process->WriteMemory(deviceName.c_str(), request.outputBuf.at(0).address + offset, deviceName.size() + 1);
             offset += deviceName.size() + 1;
         }
+        return {};
     }
 
-    void IAudioDevice::SetAudioDeviceOutputVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IAudioDevice::SetAudioDeviceOutputVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void IAudioDevice::GetActiveAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioDevice::GetActiveAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         std::string deviceName("AudioStereoJackOutput");
 
         if (deviceName.size() > request.outputBuf.at(0).size)
             throw exception("Too small a buffer supplied to GetActiveAudioDeviceName");
 
         state.process->WriteMemory(deviceName.c_str(), request.outputBuf.at(0).address, deviceName.size() + 1);
+        return {};
     }
 
-    void IAudioDevice::QueryAudioDeviceSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioDevice::QueryAudioDeviceSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(systemEvent)};
         state.logger->Debug("Audio Device System Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
+        return {};
     }
 
-    void IAudioDevice::GetActiveChannelCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioDevice::GetActiveChannelCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(constant::ChannelCount);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioDevice.h
+++ b/app/src/main/cpp/skyline/services/audio/IAudioDevice.h
@@ -20,26 +20,26 @@ namespace skyline::service::audio {
         /**
          * @brief This returns a list of the available audio devices (https://switchbrew.org/wiki/Audio_services#ListAudioDeviceName)
          */
-        void ListAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ListAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the volume of an audio output (https://switchbrew.org/wiki/Audio_services#SetAudioDeviceOutputVolume)
          */
-        void SetAudioDeviceOutputVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetAudioDeviceOutputVolume(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the active audio output device
          */
-        void GetActiveAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetActiveAudioDeviceName(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the audio device system event
          */
-        void QueryAudioDeviceSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result QueryAudioDeviceSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the current output devices channel count
          */
-        void GetActiveChannelCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetActiveChannelCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
@@ -5,7 +5,7 @@
 #include "IAudioOut.h"
 
 namespace skyline::service::audio {
-    IAudioOut::IAudioOut(const DeviceState &state, ServiceManager &manager, u8 channelCount, u32 sampleRate) : sampleRate(sampleRate), channelCount(channelCount), releaseEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::audio_IAudioOut, "audio:IAudioOut", {
+    IAudioOut::IAudioOut(const DeviceState &state, ServiceManager &manager, u8 channelCount, u32 sampleRate) : sampleRate(sampleRate), channelCount(channelCount), releaseEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(IAudioOut::GetAudioOutState)},
         {0x1, SFUNC(IAudioOut::StartAudioOut)},
         {0x2, SFUNC(IAudioOut::StopAudioOut)},

--- a/app/src/main/cpp/skyline/services/audio/IAudioOut.h
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOut.h
@@ -37,36 +37,36 @@ namespace skyline::service::audio {
         /**
          * @brief Returns the playback state of the audio output (https://switchbrew.org/wiki/Audio_services#GetAudioOutState)
          */
-        void GetAudioOutState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAudioOutState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
         * @brief Starts playback using data from appended samples (https://switchbrew.org/wiki/Audio_services#StartAudioOut)
         */
-        void StartAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result StartAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
         * @brief Stops playback of audio, waits for all samples to be released (https://switchbrew.org/wiki/Audio_services#StartAudioOut)
         */
-        void StopAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result StopAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
         * @brief Appends sample data to the output buffer (https://switchbrew.org/wiki/Audio_services#AppendAudioOutBuffer)
         */
-        void AppendAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result AppendAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns a handle to the sample release KEvent (https://switchbrew.org/wiki/Audio_services#AppendAudioOutBuffer)
          */
-        void RegisterBufferEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result RegisterBufferEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns the IDs of all pending released buffers (https://switchbrew.org/wiki/Audio_services#GetReleasedAudioOutBuffer)
          */
-        void GetReleasedAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetReleasedAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Checks if the given buffer ID is in the playback queue (https://switchbrew.org/wiki/Audio_services#ContainsAudioOutBuffer)
          */
-        void ContainsAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ContainsAudioOutBuffer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
@@ -13,11 +13,12 @@ namespace skyline::service::audio {
         {0x3, SFUNC(IAudioOutManager::OpenAudioOut)}
     }) {}
 
-    void IAudioOutManager::ListAudioOuts(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioOutManager::ListAudioOuts(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.process->WriteMemory(reinterpret_cast<void *>(const_cast<char *>(constant::DefaultAudioOutName.data())), request.outputBuf.at(0).address, constant::DefaultAudioOutName.size());
+        return {};
     }
 
-    void IAudioOutManager::OpenAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioOutManager::OpenAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto sampleRate{request.Pop<u32>()};
         auto channelCount{static_cast<u16>(request.Pop<u32>())};
 
@@ -32,5 +33,7 @@ namespace skyline::service::audio {
         response.Push<u16>(0);
         response.Push(static_cast<u32>(skyline::audio::AudioFormat::Int16));
         response.Push(static_cast<u32>(skyline::audio::AudioOutState::Stopped));
+
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
@@ -6,7 +6,7 @@
 #include "IAudioOut.h"
 
 namespace skyline::service::audio {
-    IAudioOutManager::IAudioOutManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::audio_IAudioOutManager, "audio:IAudioOutManager", {
+    IAudioOutManager::IAudioOutManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IAudioOutManager::ListAudioOuts)},
         {0x1, SFUNC(IAudioOutManager::OpenAudioOut)},
         {0x2, SFUNC(IAudioOutManager::ListAudioOuts)},

--- a/app/src/main/cpp/skyline/services/audio/IAudioOutManager.h
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOutManager.h
@@ -23,12 +23,12 @@ namespace skyline {
             /**
              * @brief Returns a list of all available audio outputs (https://switchbrew.org/wiki/Audio_services#ListAudioOuts)
              */
-            void ListAudioOuts(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result ListAudioOuts(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief Creates a new audoutU::IAudioOut object and returns a handle to it (https://switchbrew.org/wiki/Audio_services#OpenAudioOut)
              */
-            void OpenAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result OpenAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
         };
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
@@ -6,7 +6,7 @@
 
 namespace skyline::service::audio::IAudioRenderer {
     IAudioRenderer::IAudioRenderer(const DeviceState &state, ServiceManager &manager, AudioRendererParameters &parameters)
-        : systemEvent(std::make_shared<type::KEvent>(state)), parameters(parameters), BaseService(state, manager, Service::audio_IAudioRenderer, "audio:IAudioRenderer", {
+        : systemEvent(std::make_shared<type::KEvent>(state)), parameters(parameters), BaseService(state, manager, {
         {0x0, SFUNC(IAudioRenderer::GetSampleRate)},
         {0x1, SFUNC(IAudioRenderer::GetSampleCount)},
         {0x2, SFUNC(IAudioRenderer::GetMixBufferCount)},

--- a/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
@@ -34,23 +34,27 @@ namespace skyline::service::audio::IAudioRenderer {
         state.audio->CloseTrack(track);
     }
 
-    void IAudioRenderer::GetSampleRate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::GetSampleRate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(parameters.sampleRate);
+        return {};
     }
 
-    void IAudioRenderer::GetSampleCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::GetSampleCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(parameters.sampleCount);
+        return {};
     }
 
-    void IAudioRenderer::GetMixBufferCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::GetMixBufferCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(parameters.subMixCount);
+        return {};
     }
 
-    void IAudioRenderer::GetState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::GetState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(static_cast<u32>(playbackState));
+        return {};
     }
 
-    void IAudioRenderer::RequestUpdate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::RequestUpdate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto inputAddress{request.inputBuf.at(0).address};
 
         auto inputHeader{state.process->GetObject<UpdateDataHeader>(inputAddress)};
@@ -125,6 +129,8 @@ namespace skyline::service::audio::IAudioRenderer {
             state.process->WriteMemory(effect.output, outputAddress);
             outputAddress += sizeof(EffectOut);
         }
+
+        return {};
     }
 
     void IAudioRenderer::UpdateAudio() {
@@ -171,17 +177,20 @@ namespace skyline::service::audio::IAudioRenderer {
         }
     }
 
-    void IAudioRenderer::Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         playbackState = skyline::audio::AudioOutState::Started;
+        return {};
     }
 
-    void IAudioRenderer::Stop(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::Stop(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         playbackState = skyline::audio::AudioOutState::Stopped;
+        return {};
     }
 
-    void IAudioRenderer::QuerySystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRenderer::QuerySystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(systemEvent)};
         state.logger->Debug("Audren System Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.h
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.h
@@ -98,42 +98,42 @@ namespace skyline {
             /**
              * @brief Returns the sample rate (https://switchbrew.org/wiki/Audio_services#GetSampleRate)
              */
-            void GetSampleRate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetSampleRate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief Returns the sample count (https://switchbrew.org/wiki/Audio_services#GetSampleCount)
             */
-            void GetSampleCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetSampleCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Returns the number of mix buffers (https://switchbrew.org/wiki/Audio_services#GetMixBufferCount)
             */
-            void GetMixBufferCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetMixBufferCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Returns the state of the renderer (https://switchbrew.org/wiki/Audio_services#GetAudioRendererState) (stubbed)?
             */
-            void GetState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Updates the audio renderer state and appends new data to playback buffers
             */
-            void RequestUpdate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result RequestUpdate(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Start the audio stream from the renderer
             */
-            void Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result Start(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Stop the audio stream from the renderer
             */
-            void Stop(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result Stop(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
             * @brief Returns a handle to the sample release KEvent
             */
-            void QuerySystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result QuerySystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
         };
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -7,7 +7,7 @@
 #include "IAudioRendererManager.h"
 
 namespace skyline::service::audio {
-    IAudioRendererManager::IAudioRendererManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::audio_IAudioRendererManager, "audio:IAudioRendererManager", {
+    IAudioRendererManager::IAudioRendererManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IAudioRendererManager::OpenAudioRenderer)},
         {0x1, SFUNC(IAudioRendererManager::GetAudioRendererWorkBufferSize)},
         {0x2, SFUNC(IAudioRendererManager::GetAudioDeviceService)},

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -14,15 +14,17 @@ namespace skyline::service::audio {
         {0x4, SFUNC(IAudioRendererManager::GetAudioDeviceService)}
     }) {}
 
-    void IAudioRendererManager::OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRendererManager::OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         IAudioRenderer::AudioRendererParameters params = request.Pop<IAudioRenderer::AudioRendererParameters>();
 
         state.logger->Debug("IAudioRendererManager: Opening a rev {} IAudioRenderer with sample rate: {}, voice count: {}, effect count: {}", IAudioRenderer::ExtractVersionFromRevision(params.revision), params.sampleRate, params.voiceCount, params.effectCount);
 
         manager.RegisterService(std::make_shared<IAudioRenderer::IAudioRenderer>(state, manager, params), session, response);
+
+        return {};
     }
 
-    void IAudioRendererManager::GetAudioRendererWorkBufferSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRendererManager::GetAudioRendererWorkBufferSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         IAudioRenderer::AudioRendererParameters params = request.Pop<IAudioRenderer::AudioRendererParameters>();
 
         IAudioRenderer::RevisionInfo revisionInfo{};
@@ -86,9 +88,11 @@ namespace skyline::service::audio {
 
         state.logger->Debug("IAudioRendererManager: Work buffer size: 0x{:X}", size);
         response.Push<i64>(size);
+        return {};
     }
 
-    void IAudioRendererManager::GetAudioDeviceService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAudioRendererManager::GetAudioDeviceService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IAudioDevice), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.h
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.h
@@ -17,16 +17,16 @@ namespace skyline::service::audio {
         /**
          * @brief Creates a new IAudioRenderer object and returns a handle to it
          */
-        void OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Calculates the size of the buffer the guest needs to allocate for IAudioRendererManager
          */
-        void GetAudioRendererWorkBufferSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAudioRendererWorkBufferSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to an instance of an IAudioDevice (https://switchbrew.org/wiki/Audio_services#GetAudioDeviceService)
          */
-        void GetAudioDeviceService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetAudioDeviceService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fatalsrv/IService.cpp
+++ b/app/src/main/cpp/skyline/services/fatalsrv/IService.cpp
@@ -10,7 +10,7 @@ namespace skyline::service::fatalsrv {
         {0x2, SFUNC(IService::ThrowFatal)}
     }) {}
 
-    void IService::ThrowFatal(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IService::ThrowFatal(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         throw exception("A fatal error with code: 0x{:X} has caused emulation to stop", request.Pop<u32>());
     }
 }

--- a/app/src/main/cpp/skyline/services/fatalsrv/IService.cpp
+++ b/app/src/main/cpp/skyline/services/fatalsrv/IService.cpp
@@ -4,7 +4,7 @@
 #include "IService.h"
 
 namespace skyline::service::fatalsrv {
-    IService::IService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::fatalsrv_IService, "fatalsrv:IService", {
+    IService::IService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IService::ThrowFatal)},
         {0x1, SFUNC(IService::ThrowFatal)},
         {0x2, SFUNC(IService::ThrowFatal)}

--- a/app/src/main/cpp/skyline/services/fatalsrv/IService.h
+++ b/app/src/main/cpp/skyline/services/fatalsrv/IService.h
@@ -17,6 +17,6 @@ namespace skyline::service::fatalsrv {
         /**
          * @brief This throws an exception that causes emulation to quit
          */
-        void ThrowFatal(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ThrowFatal(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
@@ -4,6 +4,6 @@
 #include "IFriendService.h"
 
 namespace skyline::service::friends {
-    IFriendService::IFriendService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::friends_IFriendService, "friends:IFriendService", {
+    IFriendService::IFriendService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
@@ -9,10 +9,11 @@ namespace skyline::service::friends {
         {0x0, SFUNC(INotificationService::GetEvent)},
     }) {}
 
-    void INotificationService::GetEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result INotificationService::GetEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         KHandle handle = state.process->InsertItem(notificationEvent);
         state.logger->Debug("Friend Notification Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
@@ -5,7 +5,7 @@
 #include "INotificationService.h"
 
 namespace skyline::service::friends {
-    INotificationService::INotificationService(const DeviceState &state, ServiceManager &manager) : notificationEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::friends_INotificationService, "friends:INotificationService", {
+    INotificationService::INotificationService(const DeviceState &state, ServiceManager &manager) : notificationEvent(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(INotificationService::GetEvent)},
     }) {}
 

--- a/app/src/main/cpp/skyline/services/friends/INotificationService.h
+++ b/app/src/main/cpp/skyline/services/friends/INotificationService.h
@@ -21,6 +21,6 @@ namespace skyline::service::friends {
         /**
          * @brief This returns a handle to the notification event
          */
-        void GetEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/friends/IServiceCreator.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IServiceCreator.cpp
@@ -6,7 +6,7 @@
 #include "IServiceCreator.h"
 
 namespace skyline::service::friends {
-    IServiceCreator::IServiceCreator(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::friends_IServiceCreator, "friends:IServiceCreator", {
+    IServiceCreator::IServiceCreator(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IServiceCreator::CreateFriendService)},
         {0x1, SFUNC(IServiceCreator::CreateNotificationService)},
     }) {}

--- a/app/src/main/cpp/skyline/services/friends/IServiceCreator.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IServiceCreator.cpp
@@ -11,11 +11,13 @@ namespace skyline::service::friends {
         {0x1, SFUNC(IServiceCreator::CreateNotificationService)},
     }) {}
 
-    void IServiceCreator::CreateFriendService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IServiceCreator::CreateFriendService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IFriendService), session, response);
+        return {};
     }
 
-    void IServiceCreator::CreateNotificationService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IServiceCreator::CreateNotificationService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(INotificationService), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/friends/IServiceCreator.h
+++ b/app/src/main/cpp/skyline/services/friends/IServiceCreator.h
@@ -17,11 +17,11 @@ namespace skyline::service::friends {
         /**
          * @brief This opens an IFriendService that can be used by applications to access user friend info
          */
-        void CreateFriendService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateFriendService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This opens an INotificationService that can be used by applications to receive notifications
          */
-        void CreateNotificationService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateNotificationService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IFile.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFile.cpp
@@ -5,7 +5,7 @@
 #include "IFile.h"
 
 namespace skyline::service::fssrv {
-    IFile::IFile(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, Service::fssrv_IFile, "fssrv:IFile", {
+    IFile::IFile(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, {
         {0x0, SFUNC(IFile::Read)},
         {0x1, SFUNC(IFile::Write)},
         {0x2, SFUNC(IFile::Flush)},

--- a/app/src/main/cpp/skyline/services/fssrv/IFile.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IFile.h
@@ -21,26 +21,26 @@ namespace skyline::service::fssrv {
         /**
          * @brief This reads a buffer from a region of an IFile
          */
-        void Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This writes a buffer to a region of an IFile
          */
-        void Write(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Write(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This flushes any written data to the IFile on the Switch, however the emulator processes any FS event immediately so this does nothing
          */
-        void Flush(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Flush(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the size of an IFile
          */
-        void SetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This obtains the size of an IFile
          */
-        void GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystem.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystem.cpp
@@ -7,7 +7,7 @@
 #include "IFileSystem.h"
 
 namespace skyline::service::fssrv {
-    IFileSystem::IFileSystem(std::shared_ptr<vfs::FileSystem> backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, Service::fssrv_IFileSystem, "fssrv:IFileSystem", {
+    IFileSystem::IFileSystem(std::shared_ptr<vfs::FileSystem> backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, {
         {0x0, SFUNC(IFileSystem::CreateFile)},
         {0x7, SFUNC(IFileSystem::GetEntryType)},
         {0x8, SFUNC(IFileSystem::OpenFile)},

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystem.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystem.h
@@ -21,21 +21,21 @@ namespace skyline::service::fssrv {
         /**
          * @brief This creates a file at the specified path in the filesystem
          */
-        void CreateFile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateFile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This queries the DirectoryEntryType of the given path (https://switchbrew.org/wiki/Filesystem_services#GetEntryType)
          */
-        void GetEntryType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetEntryType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns an IFile handle for the requested path (https://switchbrew.org/wiki/Filesystem_services#OpenFile)
          */
-        void OpenFile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenFile(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This commits all changes to the filesystem (https://switchbrew.org/wiki/Filesystem_services#Commit)
          */
-        void Commit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Commit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
@@ -8,7 +8,7 @@
 #include "IStorage.h"
 
 namespace skyline::service::fssrv {
-    IFileSystemProxy::IFileSystemProxy(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::fssrv_IFileSystemProxy, "fssrv:IFileSystemProxy", {
+    IFileSystemProxy::IFileSystemProxy(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x1, SFUNC(IFileSystemProxy::SetCurrentProcess)},
         {0x12, SFUNC(IFileSystemProxy::OpenSdCardFileSystem)},
         {0x33, SFUNC(IFileSystemProxy::OpenSaveDataFileSystem)},

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
@@ -4,8 +4,9 @@
 #include <os.h>
 #include <vfs/os_filesystem.h>
 #include <loader/loader.h>
-#include "IFileSystemProxy.h"
+#include "results.h"
 #include "IStorage.h"
+#include "IFileSystemProxy.h"
 
 namespace skyline::service::fssrv {
     IFileSystemProxy::IFileSystemProxy(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
@@ -16,15 +17,17 @@ namespace skyline::service::fssrv {
         {0x3ED, SFUNC(IFileSystemProxy::GetGlobalAccessLogMode)},
     }) {}
 
-    void IFileSystemProxy::SetCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IFileSystemProxy::SetCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         process = request.Pop<pid_t>();
+        return {};
     }
 
-    void IFileSystemProxy::OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IFileSystemProxy::OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<IFileSystem>(std::make_shared<vfs::OsFileSystem>(state.os->appFilesPath + "/switch/sdmc/"), state, manager), session, response);
+        return {};
     }
 
-    void IFileSystemProxy::OpenSaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IFileSystemProxy::OpenSaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto spaceId = request.Pop<SaveDataSpaceId>();
         auto attribute = request.Pop<SaveDataAttribute>();
 
@@ -61,16 +64,20 @@ namespace skyline::service::fssrv {
         }();
 
         manager.RegisterService(std::make_shared<IFileSystem>(std::make_shared<vfs::OsFileSystem>(state.os->appFilesPath + "/switch" + saveDataPath), state, manager), session, response);
+        return {};
+
     }
 
-    void IFileSystemProxy::OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        if (state.loader->romFs)
-            manager.RegisterService(std::make_shared<IStorage>(state.loader->romFs, state, manager), session, response);
-        else
-            throw exception("Tried to call OpenDataStorageByCurrentProcess without a valid RomFS");
+    Result IFileSystemProxy::OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        if (!state.loader->romFs)
+            return result::NoRomFsAvailable;
+
+        manager.RegisterService(std::make_shared<IStorage>(state.loader->romFs, state, manager), session, response);
+        return {};
     }
 
-    void IFileSystemProxy::GetGlobalAccessLogMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IFileSystemProxy::GetGlobalAccessLogMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(0);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
@@ -68,26 +68,26 @@ namespace skyline::service::fssrv {
         /**
          * @brief This sets the PID of the process using FS currently (https://switchbrew.org/wiki/Filesystem_services#SetCurrentProcess)
          */
-        void SetCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to an instance of #IFileSystem (https://switchbrew.org/wiki/Filesystem_services#IFileSystem) with type SDCard
          */
-        void OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenSdCardFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to an instance of #IFileSystem (https://switchbrew.org/wiki/Filesystem_services#IFileSystem) for the requested save data area
          */
-        void OpenSaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenSaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to an instance of #IStorage (https://switchbrew.org/wiki/Filesystem_services#IStorage) for the application's data storage
          */
-        void OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
           * @brief This returns the filesystem log access mode (https://switchbrew.org/wiki/Filesystem_services#GetGlobalAccessLogMode)
           */
-        void GetGlobalAccessLogMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetGlobalAccessLogMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
@@ -2,6 +2,7 @@
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
 #include <kernel/types/KProcess.h>
+#include "results.h"
 #include "IStorage.h"
 
 namespace skyline::service::fssrv {
@@ -10,26 +11,26 @@ namespace skyline::service::fssrv {
         {0x4, SFUNC(IStorage::GetSize)}
     }) {}
 
-    void IStorage::Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStorage::Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto offset = request.Pop<i64>();
         auto size = request.Pop<i64>();
 
         if (offset < 0) {
             state.logger->Warn("Trying to read a file with a negative offset");
-            response.errorCode = constant::status::InvAddress;
-            return;
+            return result::InvalidOffset;
         }
 
         if (size < 0) {
             state.logger->Warn("Trying to read a file with a negative size");
-            response.errorCode = constant::status::InvSize;
-            return;
+            return result::InvalidSize;
         }
 
         backing->Read(state.process->GetPointer<u8>(request.outputBuf.at(0).address), offset, size);
+        return {};
     }
 
-    void IStorage::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStorage::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u64>(backing->size);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
@@ -5,7 +5,7 @@
 #include "IStorage.h"
 
 namespace skyline::service::fssrv {
-    IStorage::IStorage(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, Service::fssrv_IStorage, "fssrv:IStorage", {
+    IStorage::IStorage(std::shared_ptr<vfs::Backing> &backing, const DeviceState &state, ServiceManager &manager) : backing(backing), BaseService(state, manager, {
         {0x0, SFUNC(IStorage::Read)},
         {0x4, SFUNC(IStorage::GetSize)}
     }) {}

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.h
@@ -21,11 +21,11 @@ namespace skyline::service::fssrv {
         /**
          * @brief This reads a buffer from a region of an IStorage (https://switchbrew.org/wiki/Filesystem_services#Read)
          */
-        void Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Read(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This obtains the size of an IStorage (https://switchbrew.org/wiki/Filesystem_services#GetSize)
          */
-        void GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/fssrv/results.h
+++ b/app/src/main/cpp/skyline/services/fssrv/results.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+
+namespace skyline::service::fssrv::result {
+    constexpr Result PathDoesNotExist(2, 1);
+    constexpr Result NoRomFsAvailable(2, 1001);
+    constexpr Result UnexpectedFailure(2, 5000);
+    constexpr Result InvalidArgument(2, 6001);
+    constexpr Result InvalidOffset(2, 6061);
+    constexpr Result InvalidSize(2, 6062);
+}

--- a/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
@@ -11,10 +11,12 @@ namespace skyline::service::hid {
         {0x0, SFUNC(IActiveVibrationDeviceList::ActivateVibrationDevice)}
     }) {}
 
-    void IActiveVibrationDeviceList::ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IActiveVibrationDeviceList::ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = request.Pop<NpadDeviceHandle>();
 
         if (!handle.isRight)
             state.input->npad.at(handle.id).vibrationRight = NpadVibrationValue{};
+
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
@@ -7,7 +7,7 @@
 using namespace skyline::input;
 
 namespace skyline::service::hid {
-    IActiveVibrationDeviceList::IActiveVibrationDeviceList(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::hid_IActiveVibrationDeviceList, "hid:IActiveVibrationDeviceList", {
+    IActiveVibrationDeviceList::IActiveVibrationDeviceList(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IActiveVibrationDeviceList::ActivateVibrationDevice)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.h
+++ b/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.h
@@ -18,6 +18,6 @@ namespace skyline::service::hid {
         /**
          * @brief Activates a vibration device with the specified #VibrationDeviceHandle (https://switchbrew.org/wiki/HID_services#ActivateVibrationDevice)
          */
-        void ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
@@ -5,7 +5,7 @@
 #include "IAppletResource.h"
 
 namespace skyline::service::hid {
-    IAppletResource::IAppletResource(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::hid_IAppletResource, "hid:IAppletResource", {
+    IAppletResource::IAppletResource(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IAppletResource::GetSharedMemoryHandle)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
@@ -9,10 +9,11 @@ namespace skyline::service::hid {
         {0x0, SFUNC(IAppletResource::GetSharedMemoryHandle)}
     }) {}
 
-    void IAppletResource::GetSharedMemoryHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IAppletResource::GetSharedMemoryHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem<type::KSharedMemory>(state.input->kHid);
         state.logger->Debug("HID Shared Memory Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/hid/IAppletResource.h
+++ b/app/src/main/cpp/skyline/services/hid/IAppletResource.h
@@ -18,6 +18,6 @@ namespace skyline::service::hid {
         /**
          * @brief This opens a handle to HID shared memory (https://switchbrew.org/wiki/HID_services#GetSharedMemoryHandle)
          */
-        void GetSharedMemoryHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSharedMemoryHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -26,11 +26,12 @@ namespace skyline::service::hid {
         {0xCE, SFUNC(IHidServer::SendVibrationValues)}
     }) {}
 
-    void IHidServer::CreateAppletResource(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::CreateAppletResource(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IAppletResource), session, response);
+        return {};
     }
 
-    void IHidServer::SetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto styleSet = request.Pop<NpadStyleSet>();
         std::lock_guard lock(state.input->npad.mutex);
         state.input->npad.styles = styleSet;
@@ -38,13 +39,15 @@ namespace skyline::service::hid {
 
         state.logger->Debug("Controller Support:\nPro-Controller: {}\nJoy-Con: Handheld: {}, Dual: {}, L: {}, R: {}\nGameCube: {}\nPokeBall: {}\nNES: {}, NES Handheld: {}, SNES: {}", static_cast<bool>(styleSet.proController), static_cast<bool>(styleSet.joyconHandheld), static_cast<bool>(styleSet.joyconDual), static_cast<bool>(styleSet.joyconLeft), static_cast<bool>
         (styleSet.joyconRight), static_cast<bool>(styleSet.gamecube), static_cast<bool>(styleSet.palma), static_cast<bool>(styleSet.nes), static_cast<bool>(styleSet.nesHandheld), static_cast<bool>(styleSet.snes));
+        return {};
     }
 
-    void IHidServer::GetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::GetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(state.input->npad.styles);
+        return {};
     }
 
-    void IHidServer::SetSupportedNpadIdType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetSupportedNpadIdType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         const auto &buffer = request.inputBuf.at(0);
         u64 address = buffer.address;
         size_t size = buffer.size / sizeof(NpadId);
@@ -58,62 +61,73 @@ namespace skyline::service::hid {
         std::lock_guard lock(state.input->npad.mutex);
         state.input->npad.supportedIds = supportedIds;
         state.input->npad.Update();
+        return {};
     }
 
-    void IHidServer::ActivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::ActivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.input->npad.Activate();
+        return {};
     }
 
-    void IHidServer::DeactivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::DeactivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.input->npad.Deactivate();
+        return {};
     }
 
-    void IHidServer::AcquireNpadStyleSetUpdateEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::AcquireNpadStyleSetUpdateEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto id = request.Pop<NpadId>();
         request.copyHandles.push_back(state.process->InsertItem(state.input->npad.at(id).updateEvent));
+        return {};
     }
 
-    void IHidServer::ActivateNpadWithRevision(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::ActivateNpadWithRevision(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.input->npad.Activate();
+        return {};
     }
 
-    void IHidServer::SetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         std::lock_guard lock(state.input->npad.mutex);
         request.Skip<u64>();
         state.input->npad.orientation = request.Pop<NpadJoyOrientation>();
         state.input->npad.Update();
+        return {};
     }
 
-    void IHidServer::GetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::GetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(state.input->npad.orientation);
+        return {};
     }
 
-    void IHidServer::SetNpadJoyAssignmentModeSingleByDefault(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetNpadJoyAssignmentModeSingleByDefault(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto id = request.Pop<NpadId>();
         std::lock_guard lock(state.input->npad.mutex);
         state.input->npad.at(id).SetAssignment(NpadJoyAssignment::Single);
         state.input->npad.Update();
+        return {};
     }
 
-    void IHidServer::SetNpadJoyAssignmentModeSingle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetNpadJoyAssignmentModeSingle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto id = request.Pop<NpadId>();
         std::lock_guard lock(state.input->npad.mutex);
         state.input->npad.at(id).SetAssignment(NpadJoyAssignment::Single);
         state.input->npad.Update();
+        return {};
     }
 
-    void IHidServer::SetNpadJoyAssignmentModeDual(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SetNpadJoyAssignmentModeDual(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto id = request.Pop<NpadId>();
         std::lock_guard lock(state.input->npad.mutex);
         state.input->npad.at(id).SetAssignment(NpadJoyAssignment::Dual);
         state.input->npad.Update();
+        return {};
     }
 
-    void IHidServer::CreateActiveVibrationDeviceList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::CreateActiveVibrationDeviceList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IActiveVibrationDeviceList), session, response);
+        return {};
     }
 
-    void IHidServer::SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHidServer::SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.Skip<u64>(); // appletResourceUserId
 
         auto &handleBuf = request.inputBuf.at(0);
@@ -136,5 +150,7 @@ namespace skyline::service::hid {
                 }
             }
         }
+
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -8,7 +8,7 @@
 using namespace skyline::input;
 
 namespace skyline::service::hid {
-    IHidServer::IHidServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::hid_IHidServer, "hid:IHidServer", {
+    IHidServer::IHidServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IHidServer::CreateAppletResource)},
         {0x64, SFUNC(IHidServer::SetSupportedNpadStyleSet)},
         {0x64, SFUNC(IHidServer::GetSupportedNpadStyleSet)},

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.h
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.h
@@ -18,76 +18,76 @@ namespace skyline::service::hid {
         /**
          * @brief This returns an IAppletResource (https://switchbrew.org/wiki/HID_services#CreateAppletResource)
          */
-        void CreateAppletResource(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateAppletResource(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the style of controllers supported (https://switchbrew.org/wiki/HID_services#SetSupportedNpadStyleSet)
          */
-        void SetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This gets the style of controllers supported (https://switchbrew.org/wiki/HID_services#GetSupportedNpadStyleSet)
          */
-        void GetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSupportedNpadStyleSet(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the NpadIds which are supported (https://switchbrew.org/wiki/HID_services#SetSupportedNpadIdType)
          */
-        void SetSupportedNpadIdType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetSupportedNpadIdType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This requests the activation of controllers (https://switchbrew.org/wiki/HID_services#ActivateNpad)
          */
-        void ActivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ActivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This requests the deactivation of controllers (https://switchbrew.org/wiki/HID_services#DeactivateNpad)
          */
-        void DeactivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result DeactivateNpad(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This requests an event that's signalled on a specific NpadId changing (https://switchbrew.org/wiki/HID_services#AcquireNpadStyleSetUpdateEventHandle)
          */
-        void AcquireNpadStyleSetUpdateEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result AcquireNpadStyleSetUpdateEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This requests the activation of controllers with a specific HID revision (https://switchbrew.org/wiki/HID_services#ActivateNpadWithRevision)
          */
-        void ActivateNpadWithRevision(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ActivateNpadWithRevision(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the Joy-Con hold mode (https://switchbrew.org/wiki/HID_services#SetNpadJoyHoldType)
          */
-        void SetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the Joy-Con hold mode (https://switchbrew.org/wiki/HID_services#GetNpadJoyHoldType)
          */
-        void GetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetNpadJoyHoldType(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the Joy-Con assignment mode to Single by default (https://switchbrew.org/wiki/HID_services#SetNpadJoyAssignmentModeSingleByDefault)
          */
-        void SetNpadJoyAssignmentModeSingleByDefault(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetNpadJoyAssignmentModeSingleByDefault(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the Joy-Con assignment mode to Single (https://switchbrew.org/wiki/HID_services#SetNpadJoyAssignmentModeSingle)
          */
-        void SetNpadJoyAssignmentModeSingle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetNpadJoyAssignmentModeSingle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the Joy-Con assignment mode to Dual (https://switchbrew.org/wiki/HID_services#SetNpadJoyAssignmentModeDual)
          */
-        void SetNpadJoyAssignmentModeDual(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetNpadJoyAssignmentModeDual(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns an instance of #IActiveVibrationDeviceList (https://switchbrew.org/wiki/HID_services#CreateActiveVibrationDeviceList)
          */
-        void CreateActiveVibrationDeviceList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateActiveVibrationDeviceList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Send vibration values to an NPad (https://switchbrew.org/wiki/HID_services#SendVibrationValues)
          */
-        void SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
@@ -11,7 +11,7 @@
 #include "display.h"
 
 namespace skyline::service::hosbinder {
-    IHOSBinderDriver::IHOSBinderDriver(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::hosbinder_IHOSBinderDriver, "hosbinder_IHOSBinderDriver", {
+    IHOSBinderDriver::IHOSBinderDriver(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IHOSBinderDriver::TransactParcel)},
         {0x1, SFUNC(IHOSBinderDriver::AdjustRefcount)},
         {0x2, SFUNC(IHOSBinderDriver::GetNativeHandle)},
@@ -124,7 +124,7 @@ namespace skyline::service::hosbinder {
         auto gbpBuffer = reinterpret_cast<GbpBuffer *>(pointer);
 
         std::shared_ptr<nvdrv::device::NvMap::NvMapObject> nvBuffer{};
-        auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap);
+        auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap);
 
         if (gbpBuffer->nvmapHandle) {
             nvBuffer = nvmap->handleTable.at(gbpBuffer->nvmapHandle);

--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
@@ -161,7 +161,7 @@ namespace skyline::service::hosbinder {
                             gbpBuffer->nvmapHandle, gbpBuffer->offset, (1U << gbpBuffer->blockHeightLog2), gbpBuffer->size);
     }
 
-    void IHOSBinderDriver::TransactParcel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHOSBinderDriver::TransactParcel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId = request.Pop<u32>();
         auto code = request.Pop<TransactionCode>();
 
@@ -192,7 +192,7 @@ namespace skyline::service::hosbinder {
                     .height = constant::HandheldResolutionH,
                     .transformHint = 0,
                     .pendingBuffers = 0,
-                    .status = constant::status::Success,
+                    .status = 0,
                 };
                 out.WriteData(connect);
                 break;
@@ -207,20 +207,24 @@ namespace skyline::service::hosbinder {
         }
 
         out.WriteParcel(request.outputBuf.at(0));
+        return {};
     }
 
-    void IHOSBinderDriver::AdjustRefcount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHOSBinderDriver::AdjustRefcount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.Skip<u32>();
         auto addVal = request.Pop<i32>();
         auto type = request.Pop<i32>();
         state.logger->Debug("Reference Change: {} {} reference", addVal, type ? "strong" : "weak");
+
+        return {};
     }
 
-    void IHOSBinderDriver::GetNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IHOSBinderDriver::GetNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         KHandle handle = state.process->InsertItem(state.gpu->bufferEvent);
         state.logger->Debug("Display Buffer Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
-        response.Push<u32>(constant::status::Success);
+
+        return {};
     }
 
     void IHOSBinderDriver::SetDisplay(const std::string &name) {

--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.h
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.h
@@ -48,6 +48,7 @@ namespace skyline::service::hosbinder {
         };
 
         std::unordered_map<u32, std::shared_ptr<Buffer>> queue; //!< A vector of shared pointers to all the queued buffers
+
         /**
          * @brief This the GbpBuffer struct of the specified buffer
          */
@@ -90,17 +91,17 @@ namespace skyline::service::hosbinder {
         /**
          * @brief This emulates the transaction of parcels between a IGraphicBufferProducer and the application (https://switchbrew.org/wiki/Nvnflinger_services#TransactParcel)
          */
-        void TransactParcel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result TransactParcel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This adjusts the reference counts to the underlying binder, it is stubbed as we aren't using the real symbols (https://switchbrew.org/wiki/Nvnflinger_services#AdjustRefcount)
          */
-        void AdjustRefcount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result AdjustRefcount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This adjusts the reference counts to the underlying binder, it is stubbed as we aren't using the real symbols (https://switchbrew.org/wiki/Nvnflinger_services#GetNativeHandle)
          */
-        void GetNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets displayId to a specific display type

--- a/app/src/main/cpp/skyline/services/lm/ILogService.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogService.cpp
@@ -5,7 +5,7 @@
 #include "ILogService.h"
 
 namespace skyline::service::lm {
-    ILogService::ILogService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::lm_ILogService, "lm:ILogService", {
+    ILogService::ILogService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ILogService::OpenLogger)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/lm/ILogService.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogService.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::lm {
         {0x0, SFUNC(ILogService::OpenLogger)}
     }) {}
 
-    void ILogService::OpenLogger(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILogService::OpenLogger(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ILogger), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/lm/ILogService.h
+++ b/app/src/main/cpp/skyline/services/lm/ILogService.h
@@ -17,6 +17,6 @@ namespace skyline::service::lm {
         /**
          * @brief This opens an ILogger that can be used by applications to print log messages (https://switchbrew.org/wiki/Log_services#OpenLogger)
          */
-        void OpenLogger(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenLogger(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/lm/ILogger.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogger.cpp
@@ -35,7 +35,7 @@ namespace skyline::service::lm {
         }
     }
 
-    void ILogger::Log(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ILogger::Log(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         struct Data {
             u64 pid;
             u64 threadContext;
@@ -98,7 +98,10 @@ namespace skyline::service::lm {
                 break;
         }
 
+        return {};
     }
 
-    void ILogger::SetDestination(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ILogger::SetDestination(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/lm/ILogger.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogger.cpp
@@ -5,7 +5,7 @@
 #include "ILogger.h"
 
 namespace skyline::service::lm {
-    ILogger::ILogger(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::lm_ILogger, "lm:ILogger", {
+    ILogger::ILogger(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ILogger::Log)},
         {0x1, SFUNC(ILogger::SetDestination)}
     }) {}

--- a/app/src/main/cpp/skyline/services/lm/ILogger.h
+++ b/app/src/main/cpp/skyline/services/lm/ILogger.h
@@ -53,11 +53,11 @@ namespace skyline::service::lm {
         /**
          * @brief This prints a message to the log (https://switchbrew.org/wiki/Log_services#Log)
          */
-        void Log(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Log(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the log destination (https://switchbrew.org/wiki/Log_services#SetDestination)
          */
-        void SetDestination(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetDestination(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nfp/IUser.cpp
+++ b/app/src/main/cpp/skyline/services/nfp/IUser.cpp
@@ -5,7 +5,7 @@
 #include "IUserManager.h"
 
 namespace skyline::service::nfp {
-    IUser::IUser(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::nfp_IUser, "nfp:IUser", {
+    IUser::IUser(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IUser::Initialize)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/nfp/IUser.cpp
+++ b/app/src/main/cpp/skyline/services/nfp/IUser.cpp
@@ -9,5 +9,7 @@ namespace skyline::service::nfp {
         {0x0, SFUNC(IUser::Initialize)}
     }) {}
 
-    void IUser::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IUser::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/nfp/IUser.h
+++ b/app/src/main/cpp/skyline/services/nfp/IUser.h
@@ -17,6 +17,6 @@ namespace skyline::service::nfp {
         /**
          * @brief This initializes an NFP session
          */
-        void Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nfp/IUserManager.cpp
+++ b/app/src/main/cpp/skyline/services/nfp/IUserManager.cpp
@@ -5,7 +5,7 @@
 #include "IUserManager.h"
 
 namespace skyline::service::nfp {
-    IUserManager::IUserManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::nfp_IUserManager, "nfp:IUserManager", {
+    IUserManager::IUserManager(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IUserManager::CreateUserInterface)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/nfp/IUserManager.cpp
+++ b/app/src/main/cpp/skyline/services/nfp/IUserManager.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::nfp {
         {0x0, SFUNC(IUserManager::CreateUserInterface)}
     }) {}
 
-    void IUserManager::CreateUserInterface(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IUserManager::CreateUserInterface(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IUser), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/nfp/IUserManager.h
+++ b/app/src/main/cpp/skyline/services/nfp/IUserManager.h
@@ -17,6 +17,6 @@ namespace skyline::service::nfp {
         /**
          * @brief This opens an IUser that can be used by applications to access NFC devices
          */
-        void CreateUserInterface(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateUserInterface(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nifm/IGeneralService.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IGeneralService.cpp
@@ -9,7 +9,8 @@ namespace skyline::service::nifm {
         {0x4, SFUNC(IGeneralService::CreateRequest)}
     }) {}
 
-    void IGeneralService::CreateRequest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IGeneralService::CreateRequest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IRequest), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/nifm/IGeneralService.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IGeneralService.cpp
@@ -5,7 +5,7 @@
 #include "IGeneralService.h"
 
 namespace skyline::service::nifm {
-    IGeneralService::IGeneralService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::nifm_IGeneralService, "nifm:IGeneralService", {
+    IGeneralService::IGeneralService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x4, SFUNC(IGeneralService::CreateRequest)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/nifm/IGeneralService.h
+++ b/app/src/main/cpp/skyline/services/nifm/IGeneralService.h
@@ -17,6 +17,6 @@ namespace skyline::service::nifm {
         /**
          * @brief This creates an IRequest instance that can be used to bring up the network (https://switchbrew.org/wiki/Network_Interface_services#CreateRequest)
          */
-        void CreateRequest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateRequest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
@@ -12,14 +12,17 @@ namespace skyline::service::nifm {
         {0x4, SFUNC(IRequest::Submit)},
     }) {}
 
-    void IRequest::GetRequestState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IRequest::GetRequestState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 Unsubmitted = 1; //!< The request has not been submitted
         response.Push<u32>(Unsubmitted);
+        return {};
     }
 
-    void IRequest::GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IRequest::GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void IRequest::GetSystemEventReadableHandles(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IRequest::GetSystemEventReadableHandles(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem(event0);
         state.logger->Debug("Request Event 0 Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
@@ -27,7 +30,11 @@ namespace skyline::service::nifm {
         handle = state.process->InsertItem(event1);
         state.logger->Debug("Request Event 1 Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
+
+        return {};
     }
 
-    void IRequest::Submit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IRequest::Submit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
@@ -5,7 +5,7 @@
 #include "IRequest.h"
 
 namespace skyline::service::nifm {
-    IRequest::IRequest(const DeviceState &state, ServiceManager &manager) : event0(std::make_shared<type::KEvent>(state)), event1(std::make_shared<type::KEvent>(state)), BaseService(state, manager, Service::nifm_IRequest, "nifm:IRequest", {
+    IRequest::IRequest(const DeviceState &state, ServiceManager &manager) : event0(std::make_shared<type::KEvent>(state)), event1(std::make_shared<type::KEvent>(state)), BaseService(state, manager, {
         {0x0, SFUNC(IRequest::GetRequestState)},
         {0x1, SFUNC(IRequest::GetResult)},
         {0x2, SFUNC(IRequest::GetSystemEventReadableHandles)},

--- a/app/src/main/cpp/skyline/services/nifm/IRequest.h
+++ b/app/src/main/cpp/skyline/services/nifm/IRequest.h
@@ -22,21 +22,21 @@ namespace skyline::service::nifm {
         /**
          * @brief This returns the current state of the request (https://switchbrew.org/wiki/Network_Interface_services#GetRequestState)
          */
-        void GetRequestState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetRequestState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the error code if a network bring up request fails (https://switchbrew.org/wiki/Network_Interface_services#GetResult)
          */
-        void GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetResult(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns two KEvent handles that signal request on request updates (https://switchbrew.org/wiki/Network_Interface_services#GetSystemEventReadableHandles)
          */
-        void GetSystemEventReadableHandles(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSystemEventReadableHandles(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This submits a request to bring up a network (https://switchbrew.org/wiki/Network_Interface_services#Submit)
          */
-        void Submit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Submit(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nifm/IStaticService.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IStaticService.cpp
@@ -10,7 +10,8 @@ namespace skyline::service::nifm {
         {0x5, SFUNC(IStaticService::CreateGeneralService)}
     }) {}
 
-    void IStaticService::CreateGeneralService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::CreateGeneralService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IGeneralService), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/nifm/IStaticService.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IStaticService.cpp
@@ -5,7 +5,7 @@
 #include "IStaticService.h"
 
 namespace skyline::service::nifm {
-    IStaticService::IStaticService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::nifm_IStaticService, "nifm:IStaticService", {
+    IStaticService::IStaticService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x4, SFUNC(IStaticService::CreateGeneralService)},
         {0x5, SFUNC(IStaticService::CreateGeneralService)}
     }) {}

--- a/app/src/main/cpp/skyline/services/nifm/IStaticService.h
+++ b/app/src/main/cpp/skyline/services/nifm/IStaticService.h
@@ -17,6 +17,6 @@ namespace skyline::service::nifm {
         /**
          * @brief This opens an IGeneralService that can be used by applications to control the network connection (https://switchbrew.org/wiki/Network_Interface_services#CreateGeneralServiceOld)
          */
-        void CreateGeneralService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateGeneralService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.cpp
@@ -54,7 +54,7 @@ namespace skyline::service::nvdrv {
         return fdIndex++;
     }
 
-    INvDrvServices::INvDrvServices(const DeviceState &state, ServiceManager &manager) : hostSyncpoint(state), BaseService(state, manager, Service::nvdrv_INvDrvServices, "INvDrvServices", {
+    INvDrvServices::INvDrvServices(const DeviceState &state, ServiceManager &manager) : hostSyncpoint(state), BaseService(state, manager, {
         {0x0, SFUNC(INvDrvServices::Open)},
         {0x1, SFUNC(INvDrvServices::Ioctl)},
         {0x2, SFUNC(INvDrvServices::Close)},

--- a/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.h
+++ b/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.h
@@ -67,36 +67,36 @@ namespace skyline::service::nvdrv {
         /**
          * @brief Open a specific device and return a FD (https://switchbrew.org/wiki/NV_services#Open)
          */
-        void Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Close the specified FD (https://switchbrew.org/wiki/NV_services#Close)
          */
-        void Ioctl(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Ioctl(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Close the specified FD (https://switchbrew.org/wiki/NV_services#Close)
          */
-        void Close(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Close(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This initializes the driver (https://switchbrew.org/wiki/NV_services#Initialize)
          */
-        void Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a specific event from a device (https://switchbrew.org/wiki/NV_services#QueryEvent)
          */
-        void QueryEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result QueryEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the AppletResourceUserId which matches the PID (https://switchbrew.org/wiki/NV_services#SetAruidByPID)
          */
-        void SetAruidByPID(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetAruidByPID(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This enables the graphics firmware memory margin (https://switchbrew.org/wiki/NV_services#SetGraphicsFirmwareMemoryMarginEnabled)
          */
-        void SetGraphicsFirmwareMemoryMarginEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetGraphicsFirmwareMemoryMarginEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvdevice.h
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvdevice.h
@@ -61,7 +61,7 @@ namespace skyline::service::nvdrv::device {
     /**
      * @brief This enumerates all the possible error codes returned by the Nvidia driver (https://switchbrew.org/wiki/NV_services#Errors)
      */
-    enum NvStatus : u32 {
+    enum class NvStatus : u32 {
         Success = 0x0, //!< The operation has succeeded
         NotImplemented = 0x1, //!< The operation is not implemented
         NotSupported = 0x2, //!< The operation is not supported

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_as_gpu.cpp
@@ -70,7 +70,7 @@ namespace skyline::service::nvdrv::device {
         if (!region.nvmapHandle)
             return;
 
-        auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap)->handleTable.at(region.nvmapHandle);
+        auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap)->handleTable.at(region.nvmapHandle);
 
         u64 mapPhysicalAddress = region.bufferOffset + nvmap->address;
         u64 mapSize = region.mappingSize ? region.mappingSize : nvmap->size;
@@ -133,7 +133,7 @@ namespace skyline::service::nvdrv::device {
 
         for (auto entry : entries) {
             try {
-                auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap)->handleTable.at(entry.nvmapHandle);
+                auto nvmap = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->GetDevice<nvdrv::device::NvMap>(nvdrv::device::NvDeviceType::nvmap)->handleTable.at(entry.nvmapHandle);
 
                 u64 mapAddress = static_cast<u64>(entry.gpuOffset) << MinAlignmentShift;
                 u64 mapPhysicalAddress = nvmap->address + (static_cast<u64>(entry.mapOffset) << MinAlignmentShift);

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_channel.cpp
@@ -19,7 +19,7 @@ namespace skyline::service::nvdrv::device {
         {0x481A, NFUNC(NvHostChannel::AllocGpfifoEx2)},
         {0x4714, NFUNC(NvHostChannel::SetUserData)},
     }) {
-        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->hostSyncpoint;
+        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->hostSyncpoint;
 
         channelFence.id = hostSyncpoint.AllocateSyncpoint(false);
         channelFence.UpdateValue(hostSyncpoint);
@@ -48,7 +48,7 @@ namespace skyline::service::nvdrv::device {
             Fence fence;
         } &args = state.process->GetReference<Data>(buffer.output.at(0).address);
 
-        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->hostSyncpoint;
+        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->hostSyncpoint;
 
         if (args.flags.fenceWait) {
             if (args.flags.incrementWithValue) {
@@ -104,7 +104,7 @@ namespace skyline::service::nvdrv::device {
             u32 reserved[3];
         } &args = state.process->GetReference<Data>(buffer.input.at(0).address);
 
-        channelFence.UpdateValue(state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->hostSyncpoint);
+        channelFence.UpdateValue(state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->hostSyncpoint);
         args.fence = channelFence;
     }
 

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_ctrl.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_ctrl.cpp
@@ -95,7 +95,7 @@ namespace skyline::service::nvdrv::device {
             return;
         }
 
-        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->hostSyncpoint;
+        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->hostSyncpoint;
 
         // Check if the syncpoint has already expired using the last known values
         if (hostSyncpoint.HasSyncpointExpired(args.fence.id, args.fence.value)) {
@@ -173,7 +173,7 @@ namespace skyline::service::nvdrv::device {
 
         event.state = NvHostEvent::State::Cancelled;
 
-        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>(Service::nvdrv_INvDrvServices)->hostSyncpoint;
+        auto &hostSyncpoint = state.os->serviceManager.GetService<nvdrv::INvDrvServices>("nvdrv")->hostSyncpoint;
         hostSyncpoint.UpdateMin(event.fence.id);
     }
 

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlService.cpp
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlService.cpp
@@ -4,6 +4,6 @@
 #include "IParentalControlService.h"
 
 namespace skyline::service::pctl {
-    IParentalControlService::IParentalControlService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::pctl_IParentalControlService, "pctl:IParentalControlService", {
+    IParentalControlService::IParentalControlService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
@@ -5,7 +5,7 @@
 #include "IParentalControlServiceFactory.h"
 
 namespace skyline::service::pctl {
-    IParentalControlServiceFactory::IParentalControlServiceFactory(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::pctl_IParentalControlServiceFactory, "pctl:IParentalControlServiceFactory", {
+    IParentalControlServiceFactory::IParentalControlServiceFactory(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IParentalControlServiceFactory::CreateService)},
         {0x1, SFUNC(IParentalControlServiceFactory::CreateService)}
     }) {}

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.cpp
@@ -10,7 +10,8 @@ namespace skyline::service::pctl {
         {0x1, SFUNC(IParentalControlServiceFactory::CreateService)}
     }) {}
 
-    void IParentalControlServiceFactory::CreateService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IParentalControlServiceFactory::CreateService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IParentalControlService), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.h
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlServiceFactory.h
@@ -17,6 +17,6 @@ namespace skyline::service::pctl {
         /**
          * @brief This creates and initializes an IParentalControlService instance that can be used to read parental control configuration
          */
-        void CreateService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
+++ b/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
@@ -29,7 +29,7 @@ namespace skyline::service::pl {
                                               {FontStandard, FontStandardLength}
                                           }};
 
-    IPlatformServiceManager::IPlatformServiceManager(const DeviceState &state, ServiceManager &manager) : fontSharedMem(std::make_shared<kernel::type::KSharedMemory>(state, NULL, constant::FontSharedMemSize, memory::Permission{true, false, false})), BaseService(state, manager, Service::pl_IPlatformServiceManager, "pl:IPlatformServiceManager", {
+    IPlatformServiceManager::IPlatformServiceManager(const DeviceState &state, ServiceManager &manager) : fontSharedMem(std::make_shared<kernel::type::KSharedMemory>(state, NULL, constant::FontSharedMemSize, memory::Permission{true, false, false})), BaseService(state, manager, {
         {0x1, SFUNC(IPlatformServiceManager::GetLoadState)},
         {0x2, SFUNC(IPlatformServiceManager::GetSize)},
         {0x3, SFUNC(IPlatformServiceManager::GetSharedMemoryAddressOffset)},

--- a/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
+++ b/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
@@ -50,26 +50,30 @@ namespace skyline::service::pl {
         }
     }
 
-    void IPlatformServiceManager::GetLoadState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IPlatformServiceManager::GetLoadState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 FontLoaded = 1; //!< This is returned to show that all fonts have been loaded into memory
 
         response.Push(FontLoaded);
+        return {};
     }
 
-    void IPlatformServiceManager::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IPlatformServiceManager::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto fontId = request.Pop<u32>();
 
         response.Push<u32>(fontTable.at(fontId).length);
+        return {};
     }
 
-    void IPlatformServiceManager::GetSharedMemoryAddressOffset(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IPlatformServiceManager::GetSharedMemoryAddressOffset(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto fontId = request.Pop<u32>();
 
         response.Push<u32>(fontTable.at(fontId).offset);
+        return {};
     }
 
-    void IPlatformServiceManager::GetSharedMemoryNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IPlatformServiceManager::GetSharedMemoryNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle = state.process->InsertItem<type::KSharedMemory>(fontSharedMem);
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.h
+++ b/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.h
@@ -25,22 +25,22 @@ namespace skyline {
             /**
              * @brief This returns the loading state of the requested font (https://switchbrew.org/wiki/Shared_Database_services#GetLoadState)
              */
-            void GetLoadState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetLoadState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This returns the size of the requested font (https://switchbrew.org/wiki/Shared_Database_services#GetSize)
              */
-            void GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This returns the offset in shared memory of the requested font (https://switchbrew.org/wiki/Shared_Database_services#GetSharedMemoryAddressOffset)
              */
-            void GetSharedMemoryAddressOffset(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetSharedMemoryAddressOffset(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This returns a handle to the whole font shared memory (https://switchbrew.org/wiki/Shared_Database_services#GetSharedMemoryNativeHandle)
              */
-            void GetSharedMemoryNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetSharedMemoryNativeHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
         };
     }
 }

--- a/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
+++ b/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
@@ -8,5 +8,7 @@ namespace skyline::service::prepo {
         {0x2775, SFUNC(IPrepoService::SaveReportWithUser)},
     }) {}
 
-    void IPrepoService::SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IPrepoService::SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
+++ b/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
@@ -4,7 +4,7 @@
 #include "IPrepoService.h"
 
 namespace skyline::service::prepo {
-    IPrepoService::IPrepoService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::prepo_IPrepoService, "prepo:IPrepoService", {
+    IPrepoService::IPrepoService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x2775, SFUNC(IPrepoService::SaveReportWithUser)},
     }) {}
 

--- a/app/src/main/cpp/skyline/services/prepo/IPrepoService.h
+++ b/app/src/main/cpp/skyline/services/prepo/IPrepoService.h
@@ -17,6 +17,6 @@ namespace skyline::service::prepo {
         /**
          * @brief This saves a play report for the given user
          */
-        void SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -154,7 +154,7 @@ namespace skyline::service {
                             auto service = session->domainTable.at(request.domain->objectId);
                             switch (static_cast<ipc::DomainCommand>(request.domain->command)) {
                                 case ipc::DomainCommand::SendMessage:
-                                    service->HandleRequest(*session, request, response);
+                                    response.errorCode = service->HandleRequest(*session, request, response);
                                     break;
                                 case ipc::DomainCommand::CloseVHandle:
                                     std::erase_if(serviceMap, [service](const auto &entry) {
@@ -167,7 +167,7 @@ namespace skyline::service {
                             throw exception("Invalid object ID was used with domain request");
                         }
                     } else {
-                        session->serviceObject->HandleRequest(*session, request, response);
+                        response.errorCode = session->serviceObject->HandleRequest(*session, request, response);
                     }
                     response.WriteResponse(session->isDomain);
                     break;

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -29,106 +29,64 @@
 #include "prepo/IPrepoService.h"
 #include "serviceman.h"
 
-namespace skyline::service {
-    ServiceManager::ServiceManager(const DeviceState &state) : state(state) {}
+#define SERVICE_CASE(class, name) \
+    case util::MakeMagic<ServiceName>(name): { \
+            std::shared_ptr<BaseService> serviceObject = std::make_shared<class>(state, *this); \
+            serviceMap[util::MakeMagic<ServiceName>(name)] = serviceObject; \
+            return serviceObject; \
+        }
 
-    std::shared_ptr<BaseService> ServiceManager::CreateService(Service serviceType) {
-        auto serviceIter = serviceMap.find(serviceType);
+namespace skyline::service {
+    ServiceManager::ServiceManager(const DeviceState &state) : state(state), smUserInterface(std::make_shared<sm::IUserInterface>(state, *this)) {}
+
+    std::shared_ptr<BaseService> ServiceManager::CreateService(ServiceName name) {
+        auto serviceIter = serviceMap.find(name);
         if (serviceIter != serviceMap.end())
             return (*serviceIter).second;
 
-        std::shared_ptr<BaseService> serviceObj;
-        switch (serviceType) {
-            case Service::sm_IUserInterface:
-                serviceObj = std::make_shared<sm::IUserInterface>(state, *this);
-                break;
-            case Service::fatalsrv_IService:
-                serviceObj = std::make_shared<fatalsrv::IService>(state, *this);
-                break;
-            case Service::settings_ISettingsServer:
-                serviceObj = std::make_shared<settings::ISettingsServer>(state, *this);
-                break;
-            case Service::settings_ISystemSettingsServer:
-                serviceObj = std::make_shared<settings::ISystemSettingsServer>(state, *this);
-                break;
-            case Service::apm_IManager:
-                serviceObj = std::make_shared<apm::IManager>(state, *this);
-                break;
-            case Service::am_IApplicationProxyService:
-                serviceObj = std::make_shared<am::IApplicationProxyService>(state, *this);
-                break;
-            case Service::am_IAllSystemAppletProxiesService:
-                serviceObj = std::make_shared<am::IAllSystemAppletProxiesService>(state, *this);
-                break;
-            case Service::audio_IAudioOutManager:
-                serviceObj = std::make_shared<audio::IAudioOutManager>(state, *this);
-                break;
-            case Service::audio_IAudioRendererManager:
-                serviceObj = std::make_shared<audio::IAudioRendererManager>(state, *this);
-                break;
-            case Service::hid_IHidServer:
-                serviceObj = std::make_shared<hid::IHidServer>(state, *this);
-                break;
-            case Service::timesrv_IStaticService:
-                serviceObj = std::make_shared<timesrv::IStaticService>(state, *this);
-                break;
-            case Service::fssrv_IFileSystemProxy:
-                serviceObj = std::make_shared<fssrv::IFileSystemProxy>(state, *this);
-                break;
-            case Service::nvdrv_INvDrvServices:
-                serviceObj = std::make_shared<nvdrv::INvDrvServices>(state, *this);
-                break;
-            case Service::visrv_IManagerRootService:
-                serviceObj = std::make_shared<visrv::IManagerRootService>(state, *this);
-                break;
-            case Service::pl_IPlatformServiceManager:
-                serviceObj = std::make_shared<pl::IPlatformServiceManager>(state, *this);
-                break;
-            case Service::aocsrv_IAddOnContentManager:
-                serviceObj = std::make_shared<aocsrv::IAddOnContentManager>(state, *this);
-                break;
-            case Service::pctl_IParentalControlServiceFactory:
-                serviceObj = std::make_shared<pctl::IParentalControlServiceFactory>(state, *this);
-                break;
-            case Service::lm_ILogService:
-                serviceObj = std::make_shared<lm::ILogService>(state, *this);
-                break;
-            case Service::account_IAccountServiceForApplication:
-                serviceObj = std::make_shared<account::IAccountServiceForApplication>(state, *this);
-                break;
-            case Service::friends_IServiceCreator:
-                serviceObj = std::make_shared<friends::IServiceCreator>(state, *this);
-                break;
-            case Service::nfp_IUserManager:
-                serviceObj = std::make_shared<nfp::IUserManager>(state, *this);
-                break;
-            case Service::nifm_IStaticService:
-                serviceObj = std::make_shared<nifm::IStaticService>(state, *this);
-                break;
-            case Service::socket_IClient:
-                serviceObj = std::make_shared<socket::IClient>(state, *this);
-                break;
-            case Service::ssl_ISslService:
-                serviceObj = std::make_shared<ssl::ISslService>(state, *this);
-                break;
-            case Service::prepo_IPrepoService:
-                serviceObj = std::make_shared<prepo::IPrepoService>(state, *this);
-                break;
+        switch (name) {
+            SERVICE_CASE(fatalsrv::IService, "fatal:u")
+            SERVICE_CASE(settings::ISettingsServer, "set")
+            SERVICE_CASE(settings::ISystemSettingsServer, "set:sys")
+            SERVICE_CASE(apm::IManager, "apm")
+            SERVICE_CASE(am::IApplicationProxyService, "appletOE")
+            SERVICE_CASE(am::IAllSystemAppletProxiesService, "appletAE")
+            SERVICE_CASE(audio::IAudioOutManager, "audout:u")
+            SERVICE_CASE(audio::IAudioRendererManager, "audren:u")
+            SERVICE_CASE(hid::IHidServer, "hid")
+            SERVICE_CASE(timesrv::IStaticService, "time:s")
+            SERVICE_CASE(timesrv::IStaticService, "time:a")
+            SERVICE_CASE(timesrv::IStaticService, "time:u")
+            SERVICE_CASE(fssrv::IFileSystemProxy, "fsp-srv")
+            SERVICE_CASE(nvdrv::INvDrvServices, "nvdrv")
+            SERVICE_CASE(nvdrv::INvDrvServices, "nvdrv:a")
+            SERVICE_CASE(nvdrv::INvDrvServices, "nvdrv:s")
+            SERVICE_CASE(nvdrv::INvDrvServices, "nvdrv:t")
+            SERVICE_CASE(visrv::IManagerRootService, "vi:m")
+            SERVICE_CASE(visrv::IManagerRootService, "vi:u")
+            SERVICE_CASE(visrv::IManagerRootService, "vi:s")
+            SERVICE_CASE(pl::IPlatformServiceManager, "pl:u")
+            SERVICE_CASE(aocsrv::IAddOnContentManager, "aoc:u")
+            SERVICE_CASE(pctl::IParentalControlServiceFactory, "pctl")
+            SERVICE_CASE(pctl::IParentalControlServiceFactory, "pctl:a")
+            SERVICE_CASE(pctl::IParentalControlServiceFactory, "pctl:s")
+            SERVICE_CASE(pctl::IParentalControlServiceFactory, "pctl:r")
+            SERVICE_CASE(lm::ILogService, "lm")
+            SERVICE_CASE(account::IAccountServiceForApplication, "acc:u0")
+            SERVICE_CASE(friends::IServiceCreator, "friend")
+            SERVICE_CASE(nfp::IUserManager, "nfp:user")
+            SERVICE_CASE(nifm::IStaticService, "nifm:u")
+            SERVICE_CASE(socket::IClient, "bsd:u")
+            SERVICE_CASE(ssl::ISslService, "ssl")
+            SERVICE_CASE(prepo::IPrepoService, "prepo:u")
             default:
-                throw exception("CreateService called on missing object, type: {}", serviceType);
+                throw exception("CreateService called with an unknown service name: {}", name);
         }
-        serviceMap[serviceType] = serviceObj;
-        return serviceObj;
     }
 
-    KHandle ServiceManager::NewSession(Service serviceType) {
+    std::shared_ptr<BaseService> ServiceManager::NewService(ServiceName name, type::KSession &session, ipc::IpcResponse &response) {
         std::lock_guard serviceGuard(mutex);
-        return state.process->NewHandle<type::KSession>(CreateService(serviceType)).handle;
-    }
-
-    std::shared_ptr<BaseService> ServiceManager::NewService(const std::string &serviceName, type::KSession &session, ipc::IpcResponse &response) {
-        std::lock_guard serviceGuard(mutex);
-        auto serviceObject = CreateService(ServiceString.at(serviceName));
+        auto serviceObject = CreateService(name);
         KHandle handle{};
         if (session.isDomain) {
             session.domainTable[++session.handleIndex] = serviceObject;
@@ -138,13 +96,14 @@ namespace skyline::service {
             handle = state.process->NewHandle<type::KSession>(serviceObject).handle;
             response.moveHandles.push_back(handle);
         }
-        state.logger->Debug("Service has been created: \"{}\" (0x{:X})", serviceName, handle);
+        state.logger->Debug("Service has been created: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
         return serviceObject;
     }
 
-    void ServiceManager::RegisterService(std::shared_ptr<BaseService> serviceObject, type::KSession &session, ipc::IpcResponse &response, bool submodule) { // NOLINT(performance-unnecessary-value-param)
+    void ServiceManager::RegisterService(std::shared_ptr<BaseService> serviceObject, type::KSession &session, ipc::IpcResponse &response, bool submodule, ServiceName name) { // NOLINT(performance-unnecessary-value-param)
         std::lock_guard serviceGuard(mutex);
         KHandle handle{};
+
         if (session.isDomain) {
             session.domainTable[session.handleIndex] = serviceObject;
             response.domainObjects.push_back(session.handleIndex);
@@ -153,9 +112,11 @@ namespace skyline::service {
             handle = state.process->NewHandle<type::KSession>(serviceObject).handle;
             response.moveHandles.push_back(handle);
         }
+
         if (!submodule)
-            serviceMap[serviceObject->serviceType] = serviceObject;
-        state.logger->Debug("Service has been registered: \"{}\" (0x{:X})", serviceObject->serviceName, handle);
+            serviceMap[name] = serviceObject;
+
+        state.logger->Debug("Service has been registered: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
     }
 
     void ServiceManager::CloseSession(KHandle handle) {
@@ -163,10 +124,14 @@ namespace skyline::service {
         auto session = state.process->GetHandle<type::KSession>(handle);
         if (session->serviceStatus == type::KSession::ServiceStatus::Open) {
             if (session->isDomain) {
-                for (const auto &[objectId, service] : session->domainTable)
-                    serviceMap.erase(service->serviceType);
+                for (const auto &domainEntry : session->domainTable)
+                    std::erase_if(serviceMap, [domainEntry](const auto &entry) {
+                        return entry.second == domainEntry.second;
+                    });
             } else {
-                serviceMap.erase(session->serviceObject->serviceType);
+                std::erase_if(serviceMap, [session](const auto &entry) {
+                    return entry.second == session->serviceObject;
+                });
             }
             session->serviceStatus = type::KSession::ServiceStatus::Closed;
         }
@@ -192,7 +157,9 @@ namespace skyline::service {
                                     service->HandleRequest(*session, request, response);
                                     break;
                                 case ipc::DomainCommand::CloseVHandle:
-                                    serviceMap.erase(service->serviceType);
+                                    std::erase_if(serviceMap, [service](const auto &entry) {
+                                        return entry.second == service;
+                                    });
                                     session->domainTable.erase(request.domain->objectId);
                                     break;
                             }

--- a/app/src/main/cpp/skyline/services/serviceman.h
+++ b/app/src/main/cpp/skyline/services/serviceman.h
@@ -10,40 +10,36 @@
 namespace skyline::service {
     /**
      * @brief The ServiceManager class manages passing IPC requests to the right Service and running event loops of Services
+     * @todo This implementation varies significantly from HOS, this should be rectified much later on
      */
     class ServiceManager {
       private:
         const DeviceState &state; //!< The state of the device
-        std::unordered_map<Service, std::shared_ptr<BaseService>> serviceMap; //!< A mapping from a Service to the underlying object
+        std::unordered_map<ServiceName, std::shared_ptr<BaseService>> serviceMap; //!< A mapping from a Service to the underlying object
         Mutex mutex; //!< This mutex is used to ensure concurrent access to services doesn't cause crashes
 
         /**
          * @brief Creates an instance of the service if it doesn't already exist, otherwise returns an existing instance
-         * @param serviceType The type of service requested
+         * @param name The name of the service to create
          * @return A shared pointer to an instance of the service
          */
-        std::shared_ptr<BaseService> CreateService(Service serviceType);
+        std::shared_ptr<BaseService> CreateService(ServiceName name);
 
       public:
+        std::shared_ptr<BaseService> smUserInterface; //!< This is used by applications to open connections to services
+
         /**
          * @param state The state of the device
          */
         ServiceManager(const DeviceState &state);
 
         /**
-         * @brief Creates a new service and returns it's handle
-         * @param serviceType The type of the service
-         * @return Handle to KService object of the service
-         */
-        KHandle NewSession(Service serviceType);
-
-        /**
          * @brief Creates a new service using it's type enum and writes it's handle or virtual handle (If it's a domain request) to IpcResponse
-         * @param serviceName The name of the service
+         * @param name The service's name
          * @param session The session object of the command
          * @param response The response object to write the handle or virtual handle to
          */
-        std::shared_ptr<BaseService> NewService(const std::string &serviceName, type::KSession &session, ipc::IpcResponse &response);
+        std::shared_ptr<BaseService> NewService(ServiceName name, type::KSession &session, ipc::IpcResponse &response);
 
         /**
          * @brief Registers a service object in the manager and writes it's handle or virtual handle (If it's a domain request) to IpcResponse
@@ -51,8 +47,9 @@ namespace skyline::service {
          * @param session The session object of the command
          * @param response The response object to write the handle or virtual handle to
          * @param submodule If the registered service is a submodule or not
+         * @param name The name of the service to register if it's not a submodule - it will be added to the service map
          */
-        void RegisterService(std::shared_ptr<BaseService> serviceObject, type::KSession &session, ipc::IpcResponse &response, bool submodule = true);
+        void RegisterService(std::shared_ptr<BaseService> serviceObject, type::KSession &session, ipc::IpcResponse &response, bool submodule = true, ServiceName name = {});
 
         /**
          * @param serviceType The type of the service
@@ -61,8 +58,13 @@ namespace skyline::service {
          * @note This only works for services created with `NewService` as sub-interfaces used with `RegisterService` can have multiple instances
          */
         template<typename Type>
-        inline std::shared_ptr<Type> GetService(Service serviceType) {
-            return std::static_pointer_cast<Type>(serviceMap.at(serviceType));
+        std::shared_ptr<Type> GetService(ServiceName name) {
+            return std::static_pointer_cast<Type>(serviceMap.at(name));
+        }
+
+        template<typename Type>
+        constexpr std::shared_ptr<Type> GetService(std::string_view name) {
+            return GetService<Type>(util::MakeMagic<ServiceName>(name));
         }
 
         /**

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -31,19 +31,22 @@ namespace skyline::service::settings {
         util::MakeMagic<u64>("zh-Hant"),
     };
 
-    void ISettingsServer::GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISettingsServer::GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.process->WriteMemory(LanguageCodeList.data(), request.outputBuf.at(0).address, constant::OldLanguageCodeListSize * sizeof(u64));
 
         response.Push<i32>(constant::OldLanguageCodeListSize);
+        return {};
     }
 
-    void ISettingsServer::MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISettingsServer::MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u64>(LanguageCodeList.at(request.Pop<i32>()));
+        return {};
     }
 
-    void ISettingsServer::GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISettingsServer::GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.process->WriteMemory(LanguageCodeList.data(), request.outputBuf.at(0).address, constant::NewLanguageCodeListSize * sizeof(u64));
 
         response.Push<i32>(constant::NewLanguageCodeListSize);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -5,7 +5,7 @@
 #include "ISettingsServer.h"
 
 namespace skyline::service::settings {
-    ISettingsServer::ISettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::settings_ISettingsServer, "settings:ISettingsServer", {
+    ISettingsServer::ISettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x1, SFUNC(ISettingsServer::GetAvailableLanguageCodes)},
         {0x2, SFUNC(ISettingsServer::MakeLanguageCode)},
         {0x5, SFUNC(ISettingsServer::GetAvailableLanguageCodes2)}

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
@@ -23,17 +23,17 @@ namespace skyline::service {
             /**
              * @brief This reads the available language codes that an application can use (pre 4.0.0)
              */
-            void GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This converts a language code list index to it's corresponding language code
              */
-            void MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
             /**
              * @brief This reads the available language codes that an application can use (post 4.0.0)
              */
-            void GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+            Result GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
         };
     }
 }

--- a/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.cpp
@@ -5,7 +5,7 @@
 #include "ISystemSettingsServer.h"
 
 namespace skyline::service::settings {
-    ISystemSettingsServer::ISystemSettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::settings_ISystemSettingsServer, "settings:ISystemSettingsServer", {
+    ISystemSettingsServer::ISystemSettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x3, SFUNC(ISystemSettingsServer::GetFirmwareVersion)}}) {}
 
     void ISystemSettingsServer::GetFirmwareVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {

--- a/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.cpp
@@ -8,8 +8,9 @@ namespace skyline::service::settings {
     ISystemSettingsServer::ISystemSettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x3, SFUNC(ISystemSettingsServer::GetFirmwareVersion)}}) {}
 
-    void ISystemSettingsServer::GetFirmwareVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISystemSettingsServer::GetFirmwareVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         SysVerTitle title{.major=9, .minor=0, .micro=0, .revMajor=4, .revMinor=0, .platform="NX", .verHash="4de65c071fd0869695b7629f75eb97b2551dbf2f", .dispVer="9.0.0", .dispTitle="NintendoSDK Firmware for NX 9.0.0-4.0"};
         state.process->WriteMemory(title, request.outputBuf.at(0).address);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.h
+++ b/app/src/main/cpp/skyline/services/settings/ISystemSettingsServer.h
@@ -36,6 +36,6 @@ namespace skyline::service::settings {
         /**
          * @brief Writes the Firmware version to a 0xA buffer (https://switchbrew.org/wiki/Settings_services#GetFirmwareVersion)
          */
-        void GetFirmwareVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetFirmwareVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
+++ b/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
@@ -9,21 +9,23 @@ namespace skyline::service::sm {
         {0x1, SFUNC(IUserInterface::GetService)}
     }) {}
 
-    void IUserInterface::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IUserInterface::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 
-    void IUserInterface::GetService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IUserInterface::GetService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto name = request.Pop<ServiceName>();
 
-        if (name) {
-            try {
-                manager.NewService(name, session, response);
-            } catch (std::out_of_range &) {
-                response.errorCode = constant::status::ServiceNotReg;
-                std::string_view stringName(reinterpret_cast<char *>(&name), sizeof(u64));
-                state.logger->Warn("Service has not been implemented: \"{}\"", stringName);
-            }
-        } else {
-            response.errorCode = constant::status::ServiceInvName;
+        if (!name)
+            return result::InvalidServiceName;
+
+        try {
+            manager.NewService(name, session, response);
+        } catch (std::out_of_range &) {
+            std::string_view stringName(reinterpret_cast<char *>(&name), sizeof(u64));
+            state.logger->Warn("Service has not been implemented: \"{}\"", stringName);
         }
+
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
+++ b/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
@@ -4,7 +4,7 @@
 #include "IUserInterface.h"
 
 namespace skyline::service::sm {
-    IUserInterface::IUserInterface(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::sm_IUserInterface, "sm:IUserInterface", {
+    IUserInterface::IUserInterface(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IUserInterface::Initialize)},
         {0x1, SFUNC(IUserInterface::GetService)}
     }) {}
@@ -12,18 +12,18 @@ namespace skyline::service::sm {
     void IUserInterface::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
 
     void IUserInterface::GetService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        std::string serviceName(request.PopString());
-        serviceName.resize(std::min(8UL, serviceName.size()));
+        auto name = request.Pop<ServiceName>();
 
-        if (serviceName.empty()) {
-            response.errorCode = constant::status::ServiceInvName;
-        } else {
+        if (name) {
             try {
-                manager.NewService(serviceName, session, response);
+                manager.NewService(name, session, response);
             } catch (std::out_of_range &) {
                 response.errorCode = constant::status::ServiceNotReg;
-                state.logger->Warn("Service has not been implemented: \"{}\"", serviceName);
+                std::string_view stringName(reinterpret_cast<char *>(&name), sizeof(u64));
+                state.logger->Warn("Service has not been implemented: \"{}\"", stringName);
             }
+        } else {
+            response.errorCode = constant::status::ServiceInvName;
         }
     }
 }

--- a/app/src/main/cpp/skyline/services/sm/IUserInterface.h
+++ b/app/src/main/cpp/skyline/services/sm/IUserInterface.h
@@ -7,6 +7,18 @@
 #include <services/serviceman.h>
 
 namespace skyline::service::sm {
+    namespace result {
+        constexpr Result OutOfProcesses(21, 1);
+        constexpr Result InvalidClient(21, 2);
+        constexpr Result OutOfSessions(21, 3);
+        constexpr Result AlreadyRegistered(21, 4);
+        constexpr Result OutOfServices(21, 5);
+        constexpr Result InvalidServiceName(21, 6);
+        constexpr Result NotRegistered(21, 7);
+        constexpr Result NotAllowed(21, 8);
+        constexpr Result TooLargeAccessControl(21, 9);
+    }
+
     /**
      * @brief IUserInterface or sm: is responsible for providing handles to services (https://switchbrew.org/wiki/Services_API)
      */
@@ -15,13 +27,13 @@ namespace skyline::service::sm {
         IUserInterface(const DeviceState &state, ServiceManager &manager);
 
         /**
-         * @brief This initializes the sm: service. It doesn't actually do anything. (https://switchbrew.org/wiki/Services_API#Initialize)
+         * @brief This initializes the sm: service. (https://switchbrew.org/wiki/Services_API#Initialize)
          */
-        void Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to a service with it's name passed in as an argument (https://switchbrew.org/wiki/Services_API#GetService)
          */
-        void GetService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
+++ b/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
@@ -9,9 +9,12 @@ namespace skyline::service::socket {
         {0x1, SFUNC(IClient::StartMonitoring)},
     }) {}
 
-    void IClient::RegisterClient(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IClient::RegisterClient(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u32>(0);
+        return {};
     }
 
-    void IClient::StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IClient::StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
+++ b/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
@@ -4,7 +4,7 @@
 #include "IClient.h"
 
 namespace skyline::service::socket {
-    IClient::IClient(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::socket_IClient, "socket:IClient", {
+    IClient::IClient(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IClient::RegisterClient)},
         {0x1, SFUNC(IClient::StartMonitoring)},
     }) {}

--- a/app/src/main/cpp/skyline/services/socket/bsd/IClient.h
+++ b/app/src/main/cpp/skyline/services/socket/bsd/IClient.h
@@ -17,11 +17,11 @@ namespace skyline::service::socket {
         /**
          * @brief This initializes a socket client with the given parameters (https://switchbrew.org/wiki/Sockets_services#Initialize)
          */
-        void RegisterClient(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result RegisterClient(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This starts the monitoring of the socket
          */
-        void StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/ssl/ISslContext.cpp
+++ b/app/src/main/cpp/skyline/services/ssl/ISslContext.cpp
@@ -4,6 +4,6 @@
 #include "ISslContext.h"
 
 namespace skyline::service::ssl {
-    ISslContext::ISslContext(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::ssl_ISslContext, "ssl:ISslContext", {
+    ISslContext::ISslContext(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
     }) {}
 }

--- a/app/src/main/cpp/skyline/services/ssl/ISslService.cpp
+++ b/app/src/main/cpp/skyline/services/ssl/ISslService.cpp
@@ -5,7 +5,7 @@
 #include "ISslService.h"
 
 namespace skyline::service::ssl {
-    ISslService::ISslService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::ssl_ISslService, "ssl:ISslService", {
+    ISslService::ISslService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ISslService::CreateContext)},
         {0x5, SFUNC(ISslService::SetInterfaceVersion)}
     }) {}

--- a/app/src/main/cpp/skyline/services/ssl/ISslService.cpp
+++ b/app/src/main/cpp/skyline/services/ssl/ISslService.cpp
@@ -10,9 +10,12 @@ namespace skyline::service::ssl {
         {0x5, SFUNC(ISslService::SetInterfaceVersion)}
     }) {}
 
-    void ISslService::CreateContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISslService::CreateContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ISslContext), session, response);
+        return {};
     }
 
-    void ISslService::SetInterfaceVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISslService::SetInterfaceVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/ssl/ISslService.h
+++ b/app/src/main/cpp/skyline/services/ssl/ISslService.h
@@ -17,11 +17,11 @@ namespace skyline::service::ssl {
         /**
          * @brief This creates an SSL context (https://switchbrew.org/wiki/SSL_services#CreateContext)
          */
-        void CreateContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This sets the SSL interface version (https://switchbrew.org/wiki/SSL_services#SetInterfaceVersion)
          */
-        void SetInterfaceVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetInterfaceVersion(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/timesrv/IStaticService.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/IStaticService.cpp
@@ -7,7 +7,7 @@
 #include "IStaticService.h"
 
 namespace skyline::service::timesrv {
-    IStaticService::IStaticService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::timesrv_IStaticService, "timesrv:IStaticService", {
+    IStaticService::IStaticService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(IStaticService::GetStandardUserSystemClock)},
         {0x1, SFUNC(IStaticService::GetStandardNetworkSystemClock)},
         {0x2, SFUNC(IStaticService::GetStandardSteadyClock)},

--- a/app/src/main/cpp/skyline/services/timesrv/IStaticService.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/IStaticService.cpp
@@ -15,23 +15,28 @@ namespace skyline::service::timesrv {
         {0x4, SFUNC(IStaticService::GetStandardLocalSystemClock)}
     }) {}
 
-    void IStaticService::GetStandardUserSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::GetStandardUserSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<ISystemClock>(SystemClockType::User, state, manager), session, response);
+        return {};
     }
 
-    void IStaticService::GetStandardNetworkSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::GetStandardNetworkSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<ISystemClock>(SystemClockType::Network, state, manager), session, response);
+        return {};
     }
 
-    void IStaticService::GetStandardSteadyClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::GetStandardSteadyClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<ISteadyClock>(state, manager), session, response);
+        return {};
     }
 
-    void IStaticService::GetTimeZoneService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::GetTimeZoneService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<ITimeZoneService>(state, manager), session, response);
+        return {};
     }
 
-    void IStaticService::GetStandardLocalSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IStaticService::GetStandardLocalSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(std::make_shared<ISystemClock>(SystemClockType::Local, state, manager), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/timesrv/IStaticService.h
+++ b/app/src/main/cpp/skyline/services/timesrv/IStaticService.h
@@ -17,26 +17,26 @@ namespace skyline::service::timesrv {
         /**
          * @brief This returns a handle to a ISystemClock for user time
          */
-        void GetStandardUserSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetStandardUserSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to a ISystemClock for network time
          */
-        void GetStandardNetworkSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetStandardNetworkSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to a ISteadyClock for a steady timepoint
          */
-        void GetStandardSteadyClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetStandardSteadyClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to a ITimeZoneService for reading time zone information
          */
-        void GetTimeZoneService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetTimeZoneService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns a handle to a ISystemClock for local time
          */
-        void GetStandardLocalSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetStandardLocalSystemClock(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.cpp
@@ -8,7 +8,8 @@ namespace skyline::service::timesrv {
         {0x0, SFUNC(ISteadyClock::GetCurrentTimePoint)}
     }) {}
 
-    void ISteadyClock::GetCurrentTimePoint(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISteadyClock::GetCurrentTimePoint(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(SteadyClockTimePoint{static_cast<u64>(std::time(nullptr))});
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.cpp
@@ -4,7 +4,7 @@
 #include "ISteadyClock.h"
 
 namespace skyline::service::timesrv {
-    ISteadyClock::ISteadyClock(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::timesrv_ISteadyClock, "timesrv:ISteadyClock", {
+    ISteadyClock::ISteadyClock(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x0, SFUNC(ISteadyClock::GetCurrentTimePoint)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.h
+++ b/app/src/main/cpp/skyline/services/timesrv/ISteadyClock.h
@@ -25,6 +25,6 @@ namespace skyline::service::timesrv {
         /**
          * @brief This returns the current value of the steady clock
          */
-        void GetCurrentTimePoint(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetCurrentTimePoint(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
@@ -10,12 +10,14 @@ namespace skyline::service::timesrv {
         {0x2, SFUNC(ISystemClock::GetSystemClockContext)}
     }) {}
 
-    void ISystemClock::GetCurrentTime(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISystemClock::GetCurrentTime(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u64>(static_cast<u64>(std::time(nullptr)));
+        return {};
     }
 
-    void ISystemClock::GetSystemClockContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result ISystemClock::GetSystemClockContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u64>(static_cast<u64>(std::time(nullptr)));
         response.Push(SteadyClockTimePoint{static_cast<u64>(std::time(nullptr))});
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
@@ -5,7 +5,7 @@
 #include "ISystemClock.h"
 
 namespace skyline::service::timesrv {
-    ISystemClock::ISystemClock(const SystemClockType clockType, const DeviceState &state, ServiceManager &manager) : type(clockType), BaseService(state, manager, Service::timesrv_ISystemClock, "timesrv:ISystemClock", {
+    ISystemClock::ISystemClock(const SystemClockType clockType, const DeviceState &state, ServiceManager &manager) : type(clockType), BaseService(state, manager, {
         {0x0, SFUNC(ISystemClock::GetCurrentTime)},
         {0x2, SFUNC(ISystemClock::GetSystemClockContext)}
     }) {}

--- a/app/src/main/cpp/skyline/services/timesrv/ISystemClock.h
+++ b/app/src/main/cpp/skyline/services/timesrv/ISystemClock.h
@@ -28,11 +28,11 @@ namespace skyline::service::timesrv {
         /**
          * @brief This returns the amount of seconds since epoch
          */
-        void GetCurrentTime(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetCurrentTime(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This returns the system clock context
          */
-        void GetSystemClockContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSystemClockContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.cpp
@@ -8,9 +8,9 @@ namespace skyline::service::timesrv {
         {0x65, SFUNC(ITimeZoneService::ToCalendarTimeWithMyRule)}
     }) {}
 
-    void ITimeZoneService::ToCalendarTimeWithMyRule(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        time_t curTime = std::time(nullptr);
-        tm calender = *std::gmtime(&curTime);
+    Result ITimeZoneService::ToCalendarTimeWithMyRule(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto curTime = std::time(nullptr);
+        auto calender = *std::gmtime(&curTime);
 
         CalendarTime calendarTime{
             .year = static_cast<u16>(calender.tm_year),
@@ -29,5 +29,6 @@ namespace skyline::service::timesrv {
             .utcRel = static_cast<u32>(calender.tm_gmtoff),
         };
         response.Push(calendarInfo);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.cpp
@@ -4,7 +4,7 @@
 #include "ITimeZoneService.h"
 
 namespace skyline::service::timesrv {
-    ITimeZoneService::ITimeZoneService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::timesrv_ITimeZoneService, "timesrv:ITimeZoneService", {
+    ITimeZoneService::ITimeZoneService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x65, SFUNC(ITimeZoneService::ToCalendarTimeWithMyRule)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.h
+++ b/app/src/main/cpp/skyline/services/timesrv/ITimeZoneService.h
@@ -44,6 +44,6 @@ namespace skyline::service::timesrv {
         /**
          * @brief This receives a u64 #PosixTime (https://switchbrew.org/wiki/PSC_services#PosixTime), and returns a #CalendarTime (https://switchbrew.org/wiki/PSC_services#CalendarTime), #CalendarAdditionalInfo (https://switchbrew.org/wiki/PSC_services#CalendarAdditionalInfo)
          */
-        void ToCalendarTimeWithMyRule(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result ToCalendarTimeWithMyRule(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
@@ -9,7 +9,7 @@
 #include "IManagerDisplayService.h"
 
 namespace skyline::service::visrv {
-    IApplicationDisplayService::IApplicationDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager, Service::visrv_IApplicationDisplayService, "visrv:IApplicationDisplayService", {
+    IApplicationDisplayService::IApplicationDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager,  {
         {0x64, SFUNC(IApplicationDisplayService::GetRelayService)},
         {0x65, SFUNC(IApplicationDisplayService::GetSystemDisplayService)},
         {0x66, SFUNC(IApplicationDisplayService::GetManagerDisplayService)},
@@ -25,11 +25,11 @@ namespace skyline::service::visrv {
     }) {}
 
     void IApplicationDisplayService::GetRelayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false);
+        manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false, util::MakeMagic<ServiceName>("dispdrv"));
     }
 
     void IApplicationDisplayService::GetIndirectDisplayTransactionService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false);
+        manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false, util::MakeMagic<ServiceName>("dispdrv"));
     }
 
     void IApplicationDisplayService::GetSystemDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
@@ -43,14 +43,14 @@ namespace skyline::service::visrv {
     void IApplicationDisplayService::OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         std::string displayName(request.PopString());
         state.logger->Debug("Setting display as: {}", displayName);
-        state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver)->SetDisplay(displayName);
+        state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv")->SetDisplay(displayName);
 
         response.Push<u64>(0); // There's only one display
     }
 
     void IApplicationDisplayService::CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.logger->Debug("Closing the display");
-        state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver)->CloseDisplay();
+        state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv")->CloseDisplay();
     }
 
     void IApplicationDisplayService::OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
@@ -80,7 +80,7 @@ namespace skyline::service::visrv {
         u64 layerId = request.Pop<u64>();
         state.logger->Debug("Closing Layer: {}", layerId);
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Uninitialized)
             state.logger->Warn("The application is destroying an uninitialized layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Uninitialized;

--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
@@ -24,36 +24,42 @@ namespace skyline::service::visrv {
         {0x1452, SFUNC(IApplicationDisplayService::GetDisplayVsyncEvent)},
     }) {}
 
-    void IApplicationDisplayService::GetRelayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::GetRelayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false, util::MakeMagic<ServiceName>("dispdrv"));
+        return {};
     }
 
-    void IApplicationDisplayService::GetIndirectDisplayTransactionService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::GetIndirectDisplayTransactionService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(hosbinder::IHOSBinderDriver), session, response, false, util::MakeMagic<ServiceName>("dispdrv"));
+        return {};
     }
 
-    void IApplicationDisplayService::GetSystemDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::GetSystemDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(ISystemDisplayService), session, response);
+        return {};
     }
 
-    void IApplicationDisplayService::GetManagerDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::GetManagerDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IManagerDisplayService), session, response);
+        return {};
     }
 
-    void IApplicationDisplayService::OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         std::string displayName(request.PopString());
         state.logger->Debug("Setting display as: {}", displayName);
         state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv")->SetDisplay(displayName);
 
         response.Push<u64>(0); // There's only one display
+        return {};
     }
 
-    void IApplicationDisplayService::CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         state.logger->Debug("Closing the display");
         state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv")->CloseDisplay();
+        return {};
     }
 
-    void IApplicationDisplayService::OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         struct InputStruct {
             char displayName[0x40];
             u64 layerId;
@@ -74,9 +80,10 @@ namespace skyline::service::visrv {
         parcel.objects.resize(4);
 
         response.Push<u64>(parcel.WriteParcel(request.outputBuf.at(0)));
+        return {};
     }
 
-    void IApplicationDisplayService::CloseLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::CloseLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         u64 layerId = request.Pop<u64>();
         state.logger->Debug("Closing Layer: {}", layerId);
 
@@ -84,21 +91,22 @@ namespace skyline::service::visrv {
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Uninitialized)
             state.logger->Warn("The application is destroying an uninitialized layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Uninitialized;
-
-        response.Push<u32>(constant::status::Success);
+        return {};
     }
 
-    void IApplicationDisplayService::SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto scalingMode = request.Pop<u64>();
         auto layerId = request.Pop<u64>();
 
         state.logger->Debug("Setting Layer Scaling mode to '{}' for layer {}", scalingMode, layerId);
+        return {};
     }
 
-    void IApplicationDisplayService::GetDisplayVsyncEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IApplicationDisplayService::GetDisplayVsyncEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         KHandle handle = state.process->InsertItem(state.gpu->vsyncEvent);
         state.logger->Debug("VSync Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
@@ -16,51 +16,51 @@ namespace skyline::service::visrv {
         /**
          * @brief Returns an handle to the 'nvnflinger' service (https://switchbrew.org/wiki/Display_services#GetRelayService)
          */
-        void GetRelayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetRelayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns an handle to the 'nvnflinger' service (https://switchbrew.org/wiki/Display_services#GetIndirectDisplayTransactionService)
          */
-        void GetIndirectDisplayTransactionService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetIndirectDisplayTransactionService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns an handle to #ISystemDisplayService (https://switchbrew.org/wiki/Display_services#GetSystemDisplayService)
          */
-        void GetSystemDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetSystemDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns an handle to #IManagerDisplayService (https://switchbrew.org/wiki/Display_services#GetManagerDisplayService)
          */
-        void GetManagerDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetManagerDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Opens up a display using it's name as the input (https://switchbrew.org/wiki/Display_services#OpenDisplay)
          */
-        void OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Closes an open display using it's ID (https://switchbrew.org/wiki/Display_services#CloseDisplay)
          */
-        void CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Opens a specific layer on a display (https://switchbrew.org/wiki/Display_services#OpenLayer)
          */
-        void OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Closes a specific layer on a display (https://switchbrew.org/wiki/Display_services#CloseLayer)
          */
-        void CloseLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CloseLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Sets the scaling mode for a window, this is not required by emulators (https://switchbrew.org/wiki/Display_services#SetLayerScalingMode)
          */
-        void SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Returns a handle to a KEvent which is triggered every time a frame is drawn (https://switchbrew.org/wiki/Display_services#GetDisplayVsyncEvent)
          */
-        void GetDisplayVsyncEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDisplayVsyncEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
@@ -7,7 +7,7 @@
 #include "IDisplayService.h"
 
 namespace skyline::service::visrv {
-    IDisplayService::IDisplayService(const DeviceState &state, ServiceManager &manager, const Service serviceType, const std::string &serviceName, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, serviceType, serviceName, vTable) {}
+    IDisplayService::IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
 
     void IDisplayService::CreateStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.Skip<u64>();
@@ -15,7 +15,7 @@ namespace skyline::service::visrv {
 
         state.logger->Debug("Creating Stray Layer on Display: {}", displayId);
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Stray)
             throw exception("The application is creating more than one stray layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Stray;
@@ -37,7 +37,7 @@ namespace skyline::service::visrv {
         auto layerId = request.Pop<u64>();
         state.logger->Debug("Destroying Stray Layer: {}", layerId);
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Uninitialized)
             state.logger->Warn("The application is destroying an uninitialized layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Uninitialized;

--- a/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
@@ -7,9 +7,9 @@
 #include "IDisplayService.h"
 
 namespace skyline::service::visrv {
-    IDisplayService::IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
+    IDisplayService::IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<Result(type::KSession &, ipc::IpcRequest &, ipc::IpcResponse &)>> &vTable) : BaseService(state, manager, vTable) {}
 
-    void IDisplayService::CreateStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IDisplayService::CreateStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.Skip<u64>();
         auto displayId = request.Pop<u64>();
 
@@ -31,9 +31,10 @@ namespace skyline::service::visrv {
         parcel.WriteData(data);
 
         response.Push<u64>(parcel.WriteParcel(request.outputBuf.at(0)));
+        return {};
     }
 
-    void IDisplayService::DestroyStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IDisplayService::DestroyStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId = request.Pop<u64>();
         state.logger->Debug("Destroying Stray Layer: {}", layerId);
 
@@ -41,5 +42,6 @@ namespace skyline::service::visrv {
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Uninitialized)
             state.logger->Warn("The application is destroying an uninitialized layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Uninitialized;
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/visrv/IDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IDisplayService.h
@@ -8,9 +8,9 @@
 #include <services/common/parcel.h>
 
 namespace skyline::service::visrv {
-/**
- * @brief This is the base class for all IDisplayService variants with common functions
- */
+    /**
+     * @brief This is the base class for all IDisplayService variants with common functions
+     */
     class IDisplayService : public BaseService {
       protected:
         /**
@@ -27,7 +27,7 @@ namespace skyline::service::visrv {
         static_assert(sizeof(LayerParcel) == 0x28);
 
       public:
-        IDisplayService(const DeviceState &state, ServiceManager &manager, const Service serviceType, const std::string &serviceName, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
+        IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
 
         /**
          * @brief This creates a stray layer using a display's ID and returns a layer ID and the corresponding buffer ID

--- a/app/src/main/cpp/skyline/services/visrv/IDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IDisplayService.h
@@ -27,16 +27,16 @@ namespace skyline::service::visrv {
         static_assert(sizeof(LayerParcel) == 0x28);
 
       public:
-        IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<void(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
+        IDisplayService(const DeviceState &state, ServiceManager &manager, const std::unordered_map<u32, std::function<Result(type::KSession & , ipc::IpcRequest & , ipc::IpcResponse & )>> &vTable);
 
         /**
          * @brief This creates a stray layer using a display's ID and returns a layer ID and the corresponding buffer ID
          */
-        void CreateStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This takes a layer ID and destroys the corresponding stray layer
          */
-        void DestroyStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result DestroyStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
@@ -7,7 +7,7 @@
 #include "IManagerDisplayService.h"
 
 namespace skyline::service::visrv {
-    IManagerDisplayService::IManagerDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager, Service::visrv_IManagerDisplayService, "visrv:IManagerDisplayService", {
+    IManagerDisplayService::IManagerDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager, {
         {0x7DA, SFUNC(IManagerDisplayService::CreateManagedLayer)},
         {0x7DB, SFUNC(IManagerDisplayService::DestroyManagedLayer)},
         {0x7DC, SFUNC(IDisplayService::CreateStrayLayer)},
@@ -19,7 +19,7 @@ namespace skyline::service::visrv {
         auto displayId = request.Pop<u64>();
         state.logger->Debug("Creating Managed Layer on Display: {}", displayId);
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus != hosbinder::LayerStatus::Uninitialized)
             throw exception("The application is creating more than one layer");
         hosBinder->layerStatus = hosbinder::LayerStatus::Managed;
@@ -31,7 +31,7 @@ namespace skyline::service::visrv {
         auto layerId = request.Pop<u64>();
         state.logger->Debug("Destroying Managed Layer: {}", layerId);
 
-        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>(Service::hosbinder_IHOSBinderDriver);
+        auto hosBinder = state.os->serviceManager.GetService<hosbinder::IHOSBinderDriver>("dispdrv");
         if (hosBinder->layerStatus == hosbinder::LayerStatus::Uninitialized)
             state.logger->Warn("The application is destroying an uninitialized layer");
 

--- a/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
@@ -14,7 +14,7 @@ namespace skyline::service::visrv {
         {0x1770, SFUNC(IManagerDisplayService::AddToLayerStack)}
     }) {}
 
-    void IManagerDisplayService::CreateManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IManagerDisplayService::CreateManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.Skip<u32>();
         auto displayId = request.Pop<u64>();
         state.logger->Debug("Creating Managed Layer on Display: {}", displayId);
@@ -25,9 +25,10 @@ namespace skyline::service::visrv {
         hosBinder->layerStatus = hosbinder::LayerStatus::Managed;
 
         response.Push<u64>(0); // There's only one layer
+        return {};
     }
 
-    void IManagerDisplayService::DestroyManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IManagerDisplayService::DestroyManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId = request.Pop<u64>();
         state.logger->Debug("Destroying Managed Layer: {}", layerId);
 
@@ -36,7 +37,11 @@ namespace skyline::service::visrv {
             state.logger->Warn("The application is destroying an uninitialized layer");
 
         hosBinder->layerStatus = hosbinder::LayerStatus::Uninitialized;
+
+        return {};
     }
 
-    void IManagerDisplayService::AddToLayerStack(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result IManagerDisplayService::AddToLayerStack(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.h
@@ -16,16 +16,16 @@ namespace skyline::service::visrv {
         /**
          * @brief Creates a managed layer on a specific display
          */
-        void CreateManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result CreateManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief Destroys a managed layer created on a specific display
          */
-        void DestroyManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result DestroyManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
          * @brief This takes a layer's ID and adds it to the layer stack
          */
-        void AddToLayerStack(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result AddToLayerStack(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/visrv/IManagerRootService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerRootService.cpp
@@ -10,7 +10,8 @@ namespace skyline::service::visrv {
         {0x2, SFUNC(IManagerRootService::GetDisplayService)}
     }) {}
 
-    void IManagerRootService::GetDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+    Result IManagerRootService::GetDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         manager.RegisterService(SRVREG(IApplicationDisplayService), session, response);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/visrv/IManagerRootService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerRootService.cpp
@@ -6,7 +6,7 @@
 #include "IApplicationDisplayService.h"
 
 namespace skyline::service::visrv {
-    IManagerRootService::IManagerRootService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::visrv_IManagerRootService, "visrv:IManagerRootService", {
+    IManagerRootService::IManagerRootService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, {
         {0x2, SFUNC(IManagerRootService::GetDisplayService)}
     }) {}
 

--- a/app/src/main/cpp/skyline/services/visrv/IManagerRootService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerRootService.h
@@ -18,6 +18,6 @@ namespace skyline::service::visrv {
         /**
          * @brief This returns an handle to #IApplicationDisplayService (https://switchbrew.org/wiki/Display_services#GetDisplayService)
          */
-        void GetDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result GetDisplayService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.cpp
@@ -9,5 +9,7 @@ namespace skyline::service::visrv {
         {0x908, SFUNC(IDisplayService::CreateStrayLayer)}
     }) {}
 
-    void ISystemDisplayService::SetLayerZ(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {}
+    Result ISystemDisplayService::SetLayerZ(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.cpp
@@ -4,7 +4,7 @@
 #include "ISystemDisplayService.h"
 
 namespace skyline::service::visrv {
-    ISystemDisplayService::ISystemDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager, Service::visrv_ISystemDisplayService, "visrv:ISystemDisplayService", {
+    ISystemDisplayService::ISystemDisplayService(const DeviceState &state, ServiceManager &manager) : IDisplayService(state, manager, {
         {0x89D, SFUNC(ISystemDisplayService::SetLayerZ)},
         {0x908, SFUNC(IDisplayService::CreateStrayLayer)}
     }) {}

--- a/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/ISystemDisplayService.h
@@ -16,6 +16,6 @@ namespace skyline::service::visrv {
         /**
          * @brief Sets the Z index of a layer
          */
-        void SetLayerZ(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        Result SetLayerZ(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }


### PR DESCRIPTION
This patch reduces the burden of adding services significantly, rather than having to create an enum entry and add strings in the constructor it will all be determined at runtime through RTTI. A macro is also used in the service creation case to reduce clutter and further cut down on boilerplate.