### PR TITLE
Implement Vibration Emulation for Host Vibrators

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/am/applet/ILibraryAppletAccessor.cpp
         ${source_DIR}/skyline/services/hid/IHidServer.cpp
         ${source_DIR}/skyline/services/hid/IAppletResource.cpp
+        ${source_DIR}/skyline/services/hid/IActiveVibrationDeviceList.cpp
         ${source_DIR}/skyline/services/timesrv/IStaticService.cpp
         ${source_DIR}/skyline/services/timesrv/ISystemClock.cpp
         ${source_DIR}/skyline/services/timesrv/ISteadyClock.cpp

--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -116,7 +116,7 @@ extern "C" JNIEXPORT void JNICALL Java_emu_skyline_EmulationActivity_setButtonSt
         auto device = input->npad.controllers[index].device;
         if (device)
             device->SetButtonState(skyline::input::NpadButton{.raw = static_cast<skyline::u64>(mask)}, pressed);
-    } catch (const std::bad_weak_ptr&) {
+    } catch (const std::bad_weak_ptr &) {
         // We don't mind if we miss button updates while input hasn't been initialized
     }
 }
@@ -127,7 +127,7 @@ extern "C" JNIEXPORT void JNICALL Java_emu_skyline_EmulationActivity_setAxisValu
         auto device = input->npad.controllers[index].device;
         if (device)
             device->SetAxisValue(static_cast<skyline::input::NpadAxisId>(axis), value);
-    } catch (const std::bad_weak_ptr&) {
+    } catch (const std::bad_weak_ptr &) {
         // We don't mind if we miss axis updates while input hasn't been initialized
     }
 }

--- a/app/src/main/cpp/skyline/common.h
+++ b/app/src/main/cpp/skyline/common.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <unordered_map>
+#include <span>
 #include <vector>
 #include <fstream>
 #include <syslog.h>

--- a/app/src/main/cpp/skyline/gpu/gpfifo.h
+++ b/app/src/main/cpp/skyline/gpu/gpfifo.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <common.h>
-#include <span>
 #include <queue>
 #include "engines/engine.h"
 #include "engines/gpfifo.h"

--- a/app/src/main/cpp/skyline/gpu/memory_manager.h
+++ b/app/src/main/cpp/skyline/gpu/memory_manager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <span>
 #include <common.h>
 
 namespace skyline {

--- a/app/src/main/cpp/skyline/input/npad.cpp
+++ b/app/src/main/cpp/skyline/input/npad.cpp
@@ -50,9 +50,13 @@ namespace skyline::input {
                 if (style.raw) {
                     if (style.proController || style.joyconHandheld || style.joyconLeft || style.joyconRight) {
                         device.Connect(controller.type);
+                        device.index = static_cast<size_t>(&controller - controllers.data());
+                        device.partnerIndex = -1;
                         controller.device = &device;
                     } else if (style.joyconDual && orientation == NpadJoyOrientation::Vertical && device.GetAssignment() == NpadJoyAssignment::Dual) {
                         device.Connect(NpadControllerType::JoyconDual);
+                        device.index = static_cast<size_t>(&controller - controllers.data());
+                        device.partnerIndex = controller.partnerIndex;
                         controller.device = &device;
                         controllers.at(controller.partnerIndex).device = &device;
                     } else {

--- a/app/src/main/cpp/skyline/input/npad.h
+++ b/app/src/main/cpp/skyline/input/npad.h
@@ -11,7 +11,7 @@ namespace skyline::input {
      */
     struct GuestController {
         NpadControllerType type{};
-        i8 partnerIndex{-1}; //!< The index of a Joy-Con partner, if this has one
+        i8 partnerIndex{constant::NullIndex}; //!< The index of a Joy-Con partner, if this has one
         NpadDevice *device{nullptr}; //!< A pointer to the NpadDevice that all events from this are redirected to
     };
 

--- a/app/src/main/cpp/skyline/input/npad_device.h
+++ b/app/src/main/cpp/skyline/input/npad_device.h
@@ -6,6 +6,12 @@
 #include <kernel/types/KEvent.h>
 #include "shared_mem.h"
 
+namespace skyline::constant {
+    constexpr jlong MsInSecond = 1000; //!< The amount of milliseconds in a single second of time
+    constexpr jint AmplitudeMax = std::numeric_limits<u8>::max(); //!< The maximum amplitude for Android Vibration APIs
+    constexpr i8 NullIndex = -1; //!< The placeholder index value when there is no device present
+}
+
 namespace skyline::input {
     /**
      * @brief This enumerates the orientations the Joy-Con(s) can be held in
@@ -74,7 +80,7 @@ namespace skyline::input {
             bool isSixAxisSingle    : 1; //!< If the Six-Axis device is a single unit, either Handheld or Pro-Controller
         };
 
-        constexpr NpadControllerType GetType() {
+        constexpr NpadControllerType GetType() const {
             switch (type) {
                 case 3:
                     return NpadControllerType::ProController;
@@ -129,12 +135,10 @@ namespace skyline::input {
         */
         NpadControllerInfo &GetControllerInfo();
 
-        void VibrateDevice(i8 index, const NpadVibrationValue &value);
-
       public:
         NpadId id;
-        i8 index{-1}; //!< The index of the device assigned to this player
-        i8 partnerIndex{-1}; //!< The index of a partner device, if present
+        i8 index{constant::NullIndex}; //!< The index of the device assigned to this player
+        i8 partnerIndex{constant::NullIndex}; //!< The index of a partner device, if present
         NpadVibrationValue vibrationLeft; //!< Vibration for the left Joy-Con (Handheld/Pair), left LRA in a Pro-Controller or individual Joy-Cons
         std::optional<NpadVibrationValue> vibrationRight; //!< Vibration for the right Joy-Con (Handheld/Pair) or right LRA in a Pro-Controller
         NpadControllerType type{};

--- a/app/src/main/cpp/skyline/input/sections/Npad.h
+++ b/app/src/main/cpp/skyline/input/sections/Npad.h
@@ -147,38 +147,38 @@ namespace skyline::input {
     /**
      * @brief This structure is used to hold a single sample of 3D data from the IMU
      */
-    struct SixaxisVector {
+    struct SixAxisVector {
         float x; //!< The data in the X-axis
         float y; //!< The data in the Y-axis
         float z; //!< The data in the Z-axis
     };
-    static_assert(sizeof(SixaxisVector) == 0xC);
+    static_assert(sizeof(SixAxisVector) == 0xC);
 
     /**
-    * @brief This structure contains data about the state of the controller's IMU (Sixaxis) (https://switchbrew.org/wiki/HID_Shared_Memory#NpadSixAxisSensorHandheldState)
+    * @brief This structure contains data about the state of the controller's IMU (Six-Axis) (https://switchbrew.org/wiki/HID_Shared_Memory#NpadSixAxisSensorHandheldState)
     */
-    struct NpadSixaxisState {
+    struct NpadSixAxisState {
         u64 globalTimestamp; //!< The global timestamp in samples
         u64 _unk0_;
         u64 localTimestamp; //!< The local timestamp in samples
 
-        SixaxisVector accelerometer;
-        SixaxisVector gyroscope;
-        SixaxisVector rotation;
-        std::array<SixaxisVector, 3> orientation; //!< The orientation basis data as a matrix
+        SixAxisVector accelerometer;
+        SixAxisVector gyroscope;
+        SixAxisVector rotation;
+        std::array<SixAxisVector, 3> orientation; //!< The orientation basis data as a matrix
 
         u64 _unk2_; //!< This is always 1
     };
-    static_assert(sizeof(NpadSixaxisState) == 0x68);
+    static_assert(sizeof(NpadSixAxisState) == 0x68);
 
     /**
-    * @brief This structure contains header and entries for the IMU (Sixaxis) data
+    * @brief This structure contains header and entries for the IMU (Six-Axis) data
     */
-    struct NpadSixaxisInfo {
+    struct NpadSixAxisInfo {
         CommonHeader header;
-        std::array<NpadSixaxisState, constant::HidEntryCount> state;
+        std::array<NpadSixAxisState, constant::HidEntryCount> state;
     };
-    static_assert(sizeof(NpadSixaxisInfo) == 0x708);
+    static_assert(sizeof(NpadSixAxisInfo) == 0x708);
 
     /**
     * @brief This is a bit-field of all the device types (https://switchbrew.org/wiki/HID_services#DeviceType)
@@ -268,12 +268,12 @@ namespace skyline::input {
         NpadControllerInfo palmaController; //!< The Poké Ball Plus controller data
         NpadControllerInfo defaultController; //!< The Default controller data (Inputs are rotated based on orientation and SL/SR are mapped to L/R incase it is a single JC)
 
-        NpadSixaxisInfo fullKeySixaxis; //!< The Pro/GC IMU data
-        NpadSixaxisInfo handheldSixaxis; //!< The Handheld IMU data
-        NpadSixaxisInfo dualLeftSixaxis; //!< The Left Joy-Con in dual mode's IMU data
-        NpadSixaxisInfo dualRightSixaxis; //!< The Left Joy-Con in dual mode's IMU data
-        NpadSixaxisInfo leftSixaxis; //!< The Left Joy-Con IMU data
-        NpadSixaxisInfo rightSixaxis; //!< The Right Joy-Con IMU data
+        NpadSixAxisInfo fullKeySixAxis; //!< The Pro/GC IMU data
+        NpadSixAxisInfo handheldSixAxis; //!< The Handheld IMU data
+        NpadSixAxisInfo dualLeftSixAxis; //!< The Left Joy-Con in dual mode's IMU data
+        NpadSixAxisInfo dualRightSixAxis; //!< The Left Joy-Con in dual mode's IMU data
+        NpadSixAxisInfo leftSixAxis; //!< The Left Joy-Con IMU data
+        NpadSixAxisInfo rightSixAxis; //!< The Right Joy-Con IMU data
 
         NpadDeviceType deviceType;
 

--- a/app/src/main/cpp/skyline/jvm.cpp
+++ b/app/src/main/cpp/skyline/jvm.cpp
@@ -6,10 +6,15 @@
 thread_local JNIEnv *env;
 
 namespace skyline {
-    JvmManager::JvmManager(JNIEnv *environ, jobject instance) : instance(instance), instanceClass(reinterpret_cast<jclass>(environ->NewGlobalRef(environ->GetObjectClass(instance)))), initializeControllersId(environ->GetMethodID(instanceClass, "initializeControllers", "()V")) {
+    JvmManager::JvmManager(JNIEnv *environ, jobject instance) : instance(environ->NewGlobalRef(instance)), instanceClass(reinterpret_cast<jclass>(environ->NewGlobalRef(environ->GetObjectClass(instance)))), initializeControllersId(environ->GetMethodID(instanceClass, "initializeControllers", "()V")), vibrateDeviceId(environ->GetMethodID(instanceClass, "vibrateDevice", "(I[J[I)V")), clearVibrationDeviceId(environ->GetMethodID(instanceClass, "clearVibrationDevice", "(I)V")) {
         env = environ;
         if (env->GetJavaVM(&vm) < 0)
             throw exception("Cannot get JavaVM from environment");
+    }
+
+    JvmManager::~JvmManager() {
+        env->DeleteGlobalRef(instanceClass);
+        env->DeleteGlobalRef(instance);
     }
 
     void JvmManager::AttachThread() {
@@ -40,5 +45,21 @@ namespace skyline {
 
     void JvmManager::InitializeControllers() {
         env->CallVoidMethod(instance, initializeControllersId);
+    }
+
+    void JvmManager::VibrateDevice(jint index, const std::span<jlong> &timings, const std::span<jint> &amplitudes) {
+        auto jTimings = env->NewLongArray(timings.size());
+        env->SetLongArrayRegion(jTimings, 0, timings.size(), timings.data());
+        auto jAmplitudes = env->NewIntArray(amplitudes.size());
+        env->SetIntArrayRegion(jAmplitudes, 0, amplitudes.size(), amplitudes.data());
+
+        env->CallVoidMethod(instance, vibrateDeviceId, index, jTimings, jAmplitudes);
+
+        env->DeleteLocalRef(jTimings);
+        env->DeleteLocalRef(jAmplitudes);
+    }
+
+    void JvmManager::ClearVibrationDevice(jint index) {
+        env->CallVoidMethod(instance, clearVibrationDeviceId, index);
     }
 }

--- a/app/src/main/cpp/skyline/jvm.h
+++ b/app/src/main/cpp/skyline/jvm.h
@@ -22,6 +22,8 @@ namespace skyline {
          */
         JvmManager(JNIEnv *env, jobject instance);
 
+        ~JvmManager();
+
         /**
          * @brief Attach the current thread to the Java VM
          */
@@ -92,7 +94,19 @@ namespace skyline {
          */
         void InitializeControllers();
 
+        /**
+         * @brief A call to EmulationActivity.vibrateDevice in Kotlin
+         */
+        void VibrateDevice(jint index, const std::span<jlong> &timings, const std::span<jint> &amplitudes);
+
+        /**
+         * @brief A call to EmulationActivity.clearVibrationDevice in Kotlin
+         */
+        void ClearVibrationDevice(jint index);
+
       private:
         jmethodID initializeControllersId;
+        jmethodID vibrateDeviceId;
+        jmethodID clearVibrationDeviceId;
     };
 }

--- a/app/src/main/cpp/skyline/nce.cpp
+++ b/app/src/main/cpp/skyline/nce.cpp
@@ -16,6 +16,7 @@ extern skyline::GroupMutex JniMtx;
 
 namespace skyline {
     void NCE::KernelThread(pid_t thread) {
+        state.jvm->AttachThread();
         try {
             state.thread = state.process->threads.at(thread);
             state.ctx = reinterpret_cast<ThreadContext *>(state.thread->ctxMemory->kernel.address);
@@ -76,6 +77,8 @@ namespace skyline {
                 state.os->KillThread(thread);
             }
         }
+
+        state.jvm->DetachThread();
     }
 
     NCE::NCE(DeviceState &state) : state(state) {}

--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
-#include <span>
 #include <kernel/types/KProcess.h>
 #include "IManagerForApplication.h"
 #include "IProfile.h"

--- a/app/src/main/cpp/skyline/services/base_service.h
+++ b/app/src/main/cpp/skyline/services/base_service.h
@@ -52,6 +52,7 @@ namespace skyline::service {
         audio_IAudioDevice,
         hid_IHidServer,
         hid_IAppletResource,
+        hid_IActiveVibrationDeviceList,
         timesrv_IStaticService,
         timesrv_ISystemClock,
         timesrv_ITimeZoneService,

--- a/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <input.h>
+#include "IActiveVibrationDeviceList.h"
+
+using namespace skyline::input;
+
+namespace skyline::service::hid {
+    IActiveVibrationDeviceList::IActiveVibrationDeviceList(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager, Service::hid_IActiveVibrationDeviceList, "hid:IActiveVibrationDeviceList", {
+        {0x0, SFUNC(IActiveVibrationDeviceList::ActivateVibrationDevice)}
+    }) {}
+
+    void IActiveVibrationDeviceList::ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto handle = request.Pop<NpadDeviceHandle>();
+
+        if (!handle.isRight)
+            state.input->npad.at(handle.id).vibrationRight = NpadVibrationValue{};
+    }
+}

--- a/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.h
+++ b/app/src/main/cpp/skyline/services/hid/IActiveVibrationDeviceList.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <kernel/types/KProcess.h>
+#include <services/base_service.h>
+#include <services/serviceman.h>
+
+namespace skyline::service::hid {
+    /**
+     * @brief IActiveVibrationDeviceList is used to activate vibration on certain HID devices (https://switchbrew.org/wiki/HID_services#IActiveVibrationDeviceList)
+     */
+    class IActiveVibrationDeviceList : public BaseService {
+      public:
+        IActiveVibrationDeviceList(const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief Activates a vibration device with the specified #VibrationDeviceHandle (https://switchbrew.org/wiki/HID_services#ActivateVibrationDevice)
+         */
+        void ActivateVibrationDevice(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+    };
+}

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -121,18 +121,17 @@ namespace skyline::service::hid {
         auto &valueBuf = request.inputBuf.at(1);
         std::span values(reinterpret_cast<NpadVibrationValue *>(valueBuf.address), valueBuf.size / sizeof(NpadVibrationValue));
 
-        for (int i = 0; i < handles.size(); ++i) {
-            auto &handle = handles[i];
-
+        for (size_t i{}; i < handles.size(); ++i) {
+            const auto &handle = handles[i];
             auto &device = state.input->npad.at(handle.id);
             if (device.type == handle.GetType()) {
                 if (i + 1 != handles.size() && handles[i + 1].id == handle.id && handles[i + 1].isRight && !handle.isRight) {
-                    state.logger->Info("Vibration #{}&{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz - {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, i + 1, u8(handle.id), u8(handle.type), values[i].amplitudeLow, values[i].frequencyLow, values[i].amplitudeHigh, values[i].frequencyHigh, values[i + 1].amplitudeLow, values[i + 1].frequencyLow, values[i + 1].amplitudeHigh, values[i + 1].frequencyHigh);
+                    state.logger->Debug("Vibration #{}&{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz - {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, i + 1, u8(handle.id), u8(handle.type), values[i].amplitudeLow, values[i].frequencyLow, values[i].amplitudeHigh, values[i].frequencyHigh, values[i + 1].amplitudeLow, values[i + 1].frequencyLow, values[i + 1].amplitudeHigh, values[i + 1].frequencyHigh);
                     device.Vibrate(values[i], values[i + 1]);
                     i++;
                 } else {
-                    auto &value = values[i];
-                    state.logger->Info("Vibration #{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, u8(handle.id), u8(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
+                    const auto &value = values[i];
+                    state.logger->Debug("Vibration #{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, u8(handle.id), u8(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
                     device.Vibrate(handle.isRight, value);
                 }
             }

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.h
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.h
@@ -79,5 +79,15 @@ namespace skyline::service::hid {
          * @brief Sets the Joy-Con assignment mode to Dual (https://switchbrew.org/wiki/HID_services#SetNpadJoyAssignmentModeDual)
          */
         void SetNpadJoyAssignmentModeDual(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Returns an instance of #IActiveVibrationDeviceList (https://switchbrew.org/wiki/HID_services#CreateActiveVibrationDeviceList)
+         */
+        void CreateActiveVibrationDeviceList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Send vibration values to an NPad (https://switchbrew.org/wiki/HID_services#SendVibrationValues)
+         */
+        void SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
     };
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost_channel.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
-#include <span>
 #include <os.h>
 #include <gpu/gpfifo.h>
 #include <kernel/types/KProcess.h>

--- a/app/src/main/java/emu/skyline/adapter/ControllerAdapter.kt
+++ b/app/src/main/java/emu/skyline/adapter/ControllerAdapter.kt
@@ -83,7 +83,8 @@ class ControllerGeneralItem(val context : ControllerActivity, val type : General
                     else
                         context.getString(R.string.none)
                 }
-                GeneralType.RumbleDevice -> controller.rumbleDevice?.second ?: context.getString(R.string.none)
+
+                GeneralType.RumbleDevice -> controller.rumbleDeviceName ?: context.getString(R.string.none)
             }
         }
     }

--- a/app/src/main/java/emu/skyline/input/Controller.kt
+++ b/app/src/main/java/emu/skyline/input/Controller.kt
@@ -15,7 +15,7 @@ import java.io.Serializable
  * @param firstController If the type only applies to the first controller
  */
 enum class ControllerType(val stringRes : Int, val firstController : Boolean, val sticks : Array<StickId> = arrayOf(), val buttons : Array<ButtonId> = arrayOf(), val id : Int) {
-    None(R.string.none, false, id=0b0),
+    None(R.string.none, false, id = 0b0),
     ProController(R.string.procon, false, arrayOf(StickId.Left, StickId.Right), arrayOf(ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y, ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus), 0b1),
     HandheldProController(R.string.handheld_procon, true, arrayOf(StickId.Left, StickId.Right), arrayOf(ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y, ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus), 0b10),
     JoyConLeft(R.string.ljoycon, false, arrayOf(StickId.Left), arrayOf(ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.ZL, ButtonId.Minus, ButtonId.LeftSL, ButtonId.LeftSR), 0b1000),
@@ -38,9 +38,10 @@ enum class GeneralType(val stringRes : Int, val compatibleControllers : Array<Co
  *
  * @param id The ID of the controller
  * @param type The type of the controller
- * @param rumbleDevice The device descriptor and the name of the device rumble/force-feedback will be passed onto
+ * @param rumbleDeviceDescriptor The device descriptor of the device rumble/force-feedback will be passed onto
+ * @param rumbleDeviceName The name of the device rumble/force-feedback will be passed onto
  */
-open class Controller(val id : Int, var type : ControllerType, var rumbleDevice : Pair<String, String>? = null) : Serializable {
+open class Controller(val id : Int, var type : ControllerType, var rumbleDeviceDescriptor : String? = null, var rumbleDeviceName : String? = null) : Serializable {
     /**
      * The current version of this class so that different versions won't be deserialized mistakenly
      */

--- a/app/src/main/res/layout/rumble_dialog.xml
+++ b/app/src/main/res/layout/rumble_dialog.xml
@@ -63,13 +63,29 @@
 
     </RelativeLayout>
 
-    <Button
-            android:id="@+id/rumble_reset"
-            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-            android:layout_width="wrap_content"
+    <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginEnd="10dp"
-            android:text="@string/reset" />
+            android:gravity="end"
+            android:orientation="horizontal">
+
+        <Button
+                android:id="@+id/rumble_builtin"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:text="@string/builtin"
+                android:visibility="gone" />
+
+        <Button
+                android:id="@+id/rumble_reset"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:text="@string/reset" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
     <string name="not_supported">Not Supported</string>
     <string name="press_any_button">Press any button on a controller</string>
     <string name="confirm_button_again">Confirm choice by pressing a button again</string>
+    <string name="builtin">Built-in</string>
+    <string name="builtin_vibrator">Built-in Vibrator</string>
     <string name="reset">Reset</string>
     <string name="buttons">Buttons</string>
     <string name="use_button_axis">Use any button or axis on a controller</string>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
This PR adds in a translation layer for all guest vibration to be converted into corresponding host vibration data and ran on host vibrators using Android Vibration APIs. There's support for using vibrators present in the controllers and those which are present in the device itself.