### PR TITLE
Fix backing read size check

### DIFF
--- a/app/src/main/cpp/skyline/vfs/backing.h
+++ b/app/src/main/cpp/skyline/vfs/backing.h
@@ -73,7 +73,7 @@ namespace skyline::vfs {
             if ((size - offset) < output.size())
                 throw exception("Trying to read past the end of a backing: 0x{:X}/0x{:X} (Offset: 0x{:X})", output.size(), size, offset);
 
-            if (ReadUnchecked(output, offset) != size)
+            if (ReadUnchecked(output, offset) != output.size())
                 throw exception("Failed to read the requested size from backing");
 
             return size;


### PR DESCRIPTION
An incorrect check introduced in #135 has broken all VFS backing reads, this PR corrects that check.