### PR TITLE
Implement languages support

### DIFF
--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -8,7 +8,7 @@
 #include <android/asset_manager_jni.h>
 #include <sys/system_properties.h>
 #include "skyline/common.h"
-#include "skyline/common/languages.h"
+#include "skyline/common/language.h"
 #include "skyline/common/signal.h"
 #include "skyline/common/settings.h"
 #include "skyline/common/trace.h"
@@ -91,7 +91,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
                 settings,
                 std::string(appFilesPath),
                 GetTimeZoneName(),
-                static_cast<skyline::languages::SystemLanguage>(systemLanguage),
+                static_cast<skyline::language::SystemLanguage>(systemLanguage),
                 std::make_shared<skyline::vfs::AndroidAssetFileSystem>(AAssetManager_fromJava(env, assetManager))
             )};
         OsWeak = os;

--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -54,7 +54,8 @@ static std::string GetTimeZoneName() {
 }
 
 extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
-    JNIEnv *env, jobject instance,
+    JNIEnv *env,
+    jobject instance,
     jstring romUriJstring,
     jint romType,
     jint romFd,
@@ -84,8 +85,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
     perfetto::TrackEvent::Register();
 
     try {
-        auto os{
-            std::make_shared<skyline::kernel::OS>(
+        auto os{std::make_shared<skyline::kernel::OS>(
                 jvmManager,
                 logger,
                 settings,

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -60,7 +60,7 @@ extern "C" JNIEXPORT jint JNICALL Java_emu_skyline_loader_RomFile_populate(JNIEn
         env->SetObjectField(thiz, applicationNameField, env->NewStringUTF(loader->nacp->GetApplicationName(language).c_str()));
         env->SetObjectField(thiz, applicationAuthorField, env->NewStringUTF(loader->nacp->GetApplicationPublisher(language).c_str()));
 
-        auto icon{loader->GetIcon()};
+        auto icon{loader->GetIcon(language)};
         jbyteArray iconByteArray{env->NewByteArray(icon.size())};
         env->SetByteArrayRegion(iconByteArray, 0, icon.size(), reinterpret_cast<const jbyte *>(icon.data()));
         env->SetObjectField(thiz, rawIconField, iconByteArray);

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -54,7 +54,7 @@ extern "C" JNIEXPORT jint JNICALL Java_emu_skyline_loader_RomFile_populate(JNIEn
 
     if (loader->nacp) {
         auto language{skyline::languages::GetApplicationLanguage(static_cast<skyline::languages::SystemLanguage>(systemLanguage))};
-        if ((1 << static_cast<skyline::u32>(language) & loader->nacp->supportedTitleLanguages) == 0)
+        if (((1 << static_cast<skyline::u32>(language)) & loader->nacp->supportedTitleLanguages) == 0)
             language = loader->nacp->GetFirstSupportedTitleLanguage();
 
         env->SetObjectField(thiz, applicationNameField, env->NewStringUTF(loader->nacp->GetApplicationName(language).c_str()));

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -53,7 +53,7 @@ extern "C" JNIEXPORT jint JNICALL Java_emu_skyline_loader_RomFile_populate(JNIEn
     jfieldID rawIconField{env->GetFieldID(clazz, "rawIcon", "[B")};
 
     if (loader->nacp) {
-        auto language{skyline::languages::GetApplicationLanguage(static_cast<skyline::languages::SystemLanguage>(systemLanguage))};
+        auto language{skyline::language::GetApplicationLanguage(static_cast<skyline::language::SystemLanguage>(systemLanguage))};
         if (((1 << static_cast<skyline::u32>(language)) & loader->nacp->supportedTitleLanguages) == 0)
             language = loader->nacp->GetFirstSupportedTitleLanguage();
 

--- a/app/src/main/cpp/skyline/common/language.h
+++ b/app/src/main/cpp/skyline/common/language.h
@@ -13,7 +13,7 @@ namespace skyline {
         constexpr size_t NewLanguageCodeListSize{18}; //!< The size of the post 10.1.0 language code list (was 17 between 4.0.0 - 10.1.0)
     }
 
-    namespace languages {
+    namespace language {
         /**
          * @brief The list of all languages. Entries parameters are language, language code, system language index, application language index and map which holds a macro used for filtering some application languages that don't have a direct corresponding system language
          * @example #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) func(lang, code, sysIndex, appIndex, map) <br> LANGUAGES <br> #undef LANG_ENTRY

--- a/app/src/main/cpp/skyline/common/language.h
+++ b/app/src/main/cpp/skyline/common/language.h
@@ -8,6 +8,8 @@
 #include <common/macros.h>
 
 namespace skyline {
+    using LanguageCode = u64;
+
     namespace constant {
         constexpr size_t OldLanguageCodeListSize{15}; //!< The size of the pre 4.0.0 language code list
         constexpr size_t NewLanguageCodeListSize{18}; //!< The size of the post 10.1.0 language code list (was 17 between 4.0.0 - 10.1.0)
@@ -70,13 +72,13 @@ namespace skyline {
         #undef MAP
         #undef DONT_MAP
 
-        constexpr std::array<u64, constant::NewLanguageCodeListSize> LanguageCodeList{
-            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) util::MakeMagic<u64>(#code),
+        constexpr std::array<LanguageCode, constant::NewLanguageCodeListSize> LanguageCodeList{
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) util::MakeMagic<LanguageCode>(#code),
             LANGUAGES
             #undef LANG_ENTRY
         };
 
-        constexpr u64 GetLanguageCode(SystemLanguage language) {
+        constexpr LanguageCode GetLanguageCode(SystemLanguage language) {
             return LanguageCodeList.at(static_cast<size_t>(language));
         }
 

--- a/app/src/main/cpp/skyline/common/languages.h
+++ b/app/src/main/cpp/skyline/common/languages.h
@@ -5,6 +5,7 @@
 
 #include <frozen/unordered_map.h>
 #include <common.h>
+#include <common/macros.h>
 
 namespace skyline {
     namespace constant {
@@ -13,121 +14,94 @@ namespace skyline {
     }
 
     namespace languages {
+        /**
+         * @brief The list of all languages. Entries parameters are language, language code, system language index, application language index and map which holds a macro used for filtering some application languages that don't have a direct corresponding system language
+         * @example #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) func(lang, code, sysIndex, appIndex, map) <br> LANGUAGES <br> #undef LANG_ENTRY
+         */
+        #define LANGUAGES                                                       \
+            LANG_ENTRY(Japanese, ja, 0, 2, MAP)                                 \
+            LANG_ENTRY(AmericanEnglish, en-us, 1, 0, MAP)                       \
+            LANG_ENTRY(French, fr, 2, 3, MAP)                                   \
+            LANG_ENTRY(German, de, 3, 4, MAP)                                   \
+            LANG_ENTRY(Italian, it, 4, 7, MAP)                                  \
+            LANG_ENTRY(Spanish, es, 5, 6, MAP)                                  \
+            LANG_ENTRY(Chinese, zh-CN, 6, 14, DONT_MAP)                         \
+            LANG_ENTRY(Korean, ko, 7, 12, MAP)                                  \
+            LANG_ENTRY(Dutch, nl, 8, 8, MAP)                                    \
+            LANG_ENTRY(Portuguese, pt, 9, 10, MAP)                              \
+            LANG_ENTRY(Russian, ru, 10, 11, MAP)                                \
+            LANG_ENTRY(Taiwanese, zh-TW, 11, 13, DONT_MAP)                      \
+            LANG_ENTRY(BritishEnglish, en-GB, 12, 1, MAP)                       \
+            LANG_ENTRY(CanadianFrench, fr-CA, 13, 9, MAP)                       \
+            LANG_ENTRY(LatinAmericanSpanish, es-419, 14, 5, MAP)                \
+            LANG_ENTRY(SimplifiedChinese, zh-Hans, 15, 14, MAP)                 \
+            LANG_ENTRY(TraditionalChinese, zh-Hant, 16, 13, MAP)                \
+            LANG_ENTRY(BrazilianPortuguese, pt-BR, 17, 10, DONT_MAP)
+
+        /**
+         * @brief Enumeration of system languages
+         * @url https://switchbrew.org/wiki/Settings_services#Language
+         */
         enum class SystemLanguage : u32 {
-            Japanese = 0,
-            AmericanEnglish,
-            French,
-            German,
-            Italian,
-            Spanish,
-            Chinese,
-            Korean,
-            Dutch,
-            Portuguese,
-            Russian,
-            Taiwanese,
-            BritishEnglish,
-            CanadianFrench,
-            LatinAmericanSpanish,
-            SimplifiedChinese,
-            TraditionalChinese,
-            BrazilianPortuguese,
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) lang = sysIndex,
+            LANGUAGES
+            #undef LANG_ENTRY
         };
 
+        #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) ENUM_CASE(lang);
+        ENUM_STRING(SystemLanguage, LANGUAGES)
+        #undef LANG_ENTRY
+
+        /**
+         * @brief Enumeration of application languages
+         * @url https://switchbrew.org/wiki/NACP#ApplicationTitle
+         */
         enum class ApplicationLanguage : u32 {
-            AmericanEnglish = 0,
-            BritishEnglish,
-            Japanese,
-            French,
-            German,
-            LatinAmericanSpanish,
-            Spanish,
-            Italian,
-            Dutch,
-            CanadianFrench,
-            Portuguese,
-            Russian,
-            Korean,
-            TraditionalChinese,
-            SimplifiedChinese,
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) lang = appIndex,
+            LANGUAGES
+            #undef LANG_ENTRY
         };
+
+        #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) map(lang);
+        #define MAP(key) ENUM_CASE(key)
+        #define DONT_MAP(key)
+        ENUM_STRING(ApplicationLanguage, LANGUAGES)
+        #undef LANG_ENTRY
+        #undef MAP
+        #undef DONT_MAP
 
         constexpr std::array<u64, constant::NewLanguageCodeListSize> LanguageCodeList{
-            util::MakeMagic<u64>("ja"),
-            util::MakeMagic<u64>("en-US"),
-            util::MakeMagic<u64>("fr"),
-            util::MakeMagic<u64>("de"),
-            util::MakeMagic<u64>("it"),
-            util::MakeMagic<u64>("es"),
-            util::MakeMagic<u64>("zh-CN"),
-            util::MakeMagic<u64>("ko"),
-            util::MakeMagic<u64>("nl"),
-            util::MakeMagic<u64>("pt"),
-            util::MakeMagic<u64>("ru"),
-            util::MakeMagic<u64>("zh-TW"),
-            util::MakeMagic<u64>("en-GB"),
-            util::MakeMagic<u64>("fr-CA"),
-            util::MakeMagic<u64>("es-419"),
-            util::MakeMagic<u64>("zh-Hans"),
-            util::MakeMagic<u64>("zh-Hant"),
-            util::MakeMagic<u64>("pt-BR"),
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) util::MakeMagic<u64>(#code),
+            LANGUAGES
+            #undef LANG_ENTRY
         };
 
         constexpr u64 GetLanguageCode(SystemLanguage language) {
             return LanguageCodeList.at(static_cast<size_t>(language));
         }
 
-        #define LANG_MAP_ENTRY(lang) {SystemLanguage::lang, ApplicationLanguage::lang}
-        #define LANG_MAP_ENTRY_CST(sysLang, appLang) {SystemLanguage::sysLang, ApplicationLanguage::appLang}
-        constexpr frz::unordered_map<SystemLanguage, ApplicationLanguage, constant::NewLanguageCodeListSize> SystemToAppMap{
-            LANG_MAP_ENTRY(Japanese),
-            LANG_MAP_ENTRY(AmericanEnglish),
-            LANG_MAP_ENTRY(French),
-            LANG_MAP_ENTRY(German),
-            LANG_MAP_ENTRY(Italian),
-            LANG_MAP_ENTRY(Spanish),
-            LANG_MAP_ENTRY_CST(Chinese, SimplifiedChinese),
-            LANG_MAP_ENTRY(Korean),
-            LANG_MAP_ENTRY(Dutch),
-            LANG_MAP_ENTRY(Portuguese),
-            LANG_MAP_ENTRY(Russian),
-            LANG_MAP_ENTRY_CST(Taiwanese, TraditionalChinese),
-            LANG_MAP_ENTRY(BritishEnglish),
-            LANG_MAP_ENTRY(CanadianFrench),
-            LANG_MAP_ENTRY(LatinAmericanSpanish),
-            LANG_MAP_ENTRY(SimplifiedChinese),
-            LANG_MAP_ENTRY(TraditionalChinese),
-            LANG_MAP_ENTRY_CST(BrazilianPortuguese, Portuguese),
-        };
-        #undef LANG_MAP_ENTRY
-        #undef LANG_MAP_ENTRY_CST
-
+        /**
+         * @brief Maps a system language to its corresponding application language
+         */
         constexpr ApplicationLanguage GetApplicationLanguage(SystemLanguage systemLanguage) {
-            return SystemToAppMap.at(systemLanguage);
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) ENUM_CASE_PAIR(lang, ApplicationLanguage::lang);
+            ENUM_SWITCH(SystemLanguage, systemLanguage, LANGUAGES, ApplicationLanguage::AmericanEnglish)
+            #undef LANG_ENTRY
         }
 
-        #define LANG_MAP_ENTRY_REVERSE(lang) {ApplicationLanguage::lang, SystemLanguage::lang}
-        constexpr frz::unordered_map<ApplicationLanguage, SystemLanguage, constant::OldLanguageCodeListSize> AppToSystemMap{
-            LANG_MAP_ENTRY_REVERSE(Japanese),
-            LANG_MAP_ENTRY_REVERSE(AmericanEnglish),
-            LANG_MAP_ENTRY_REVERSE(French),
-            LANG_MAP_ENTRY_REVERSE(German),
-            LANG_MAP_ENTRY_REVERSE(Italian),
-            LANG_MAP_ENTRY_REVERSE(Spanish),
-            LANG_MAP_ENTRY_REVERSE(Korean),
-            LANG_MAP_ENTRY_REVERSE(Dutch),
-            LANG_MAP_ENTRY_REVERSE(Portuguese),
-            LANG_MAP_ENTRY_REVERSE(Russian),
-            LANG_MAP_ENTRY_REVERSE(BritishEnglish),
-            LANG_MAP_ENTRY_REVERSE(CanadianFrench),
-            LANG_MAP_ENTRY_REVERSE(LatinAmericanSpanish),
-            LANG_MAP_ENTRY_REVERSE(SimplifiedChinese),
-            LANG_MAP_ENTRY_REVERSE(TraditionalChinese),
-        };
-        #undef LANG_MAP_ENTRY_REVERSE
-
+        /**
+         * @brief Maps an application language to its corresponding system language
+         */
         constexpr SystemLanguage GetSystemLanguage(ApplicationLanguage applicationLanguage) {
-            return AppToSystemMap.at(applicationLanguage);
+            #define LANG_ENTRY(lang, code, sysIndex, appIndex, map) map(lang, SystemLanguage::lang);
+            #define MAP(key, value) ENUM_CASE_PAIR(key, value)
+            #define DONT_MAP(key, value)
+            ENUM_SWITCH(ApplicationLanguage, applicationLanguage, LANGUAGES, SystemLanguage::AmericanEnglish)
+            #undef LANG_ENTRY
+            #undef MAP
+            #undef DONT_MAP
         }
+
+        #undef LANGUAGES
     }
 }

--- a/app/src/main/cpp/skyline/common/languages.h
+++ b/app/src/main/cpp/skyline/common/languages.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <frozen/unordered_map.h>
 #include <common.h>
 
 namespace skyline {
@@ -14,6 +15,45 @@ namespace skyline {
     }
 
     namespace languages {
+        enum class SystemLanguage : u32 {
+            Japanese = 0,
+            AmericanEnglish,
+            French,
+            German,
+            Italian,
+            Spanish,
+            Chinese,
+            Korean,
+            Dutch,
+            Portuguese,
+            Russian,
+            Taiwanese,
+            BritishEnglish,
+            CanadianFrench,
+            LatinAmericanSpanish,
+            SimplifiedChinese,
+            TraditionalChinese,
+            BrazilianPortuguese,
+        };
+
+        enum class ApplicationLanguage : u32 {
+            AmericanEnglish = 0,
+            BritishEnglish,
+            Japanese,
+            French,
+            German,
+            LatinAmericanSpanish,
+            Spanish,
+            Italian,
+            Dutch,
+            CanadianFrench,
+            Portuguese,
+            Russian,
+            Korean,
+            TraditionalChinese,
+            SimplifiedChinese,
+        };
+
         constexpr std::array<LanguageCode, constant::NewLanguageCodeListSize> LanguageCodeList{
             util::MakeMagic<LanguageCode>("ja"),
             util::MakeMagic<LanguageCode>("en-US"),
@@ -37,6 +77,59 @@ namespace skyline {
 
         constexpr LanguageCode GetLanguageCode(SystemLanguage language) {
             return LanguageCodeList.at(static_cast<size_t>(language));
+        }
+
+        #define LANG_MAP_ENTRY(lang) {SystemLanguage::lang, ApplicationLanguage::lang}
+        #define LANG_MAP_ENTRY_CST(sysLang, appLang) {SystemLanguage::sysLang, ApplicationLanguage::appLang}
+        constexpr frz::unordered_map<SystemLanguage, ApplicationLanguage, constant::NewLanguageCodeListSize> SystemToAppMap{
+            LANG_MAP_ENTRY(Japanese),
+            LANG_MAP_ENTRY(AmericanEnglish),
+            LANG_MAP_ENTRY(French),
+            LANG_MAP_ENTRY(German),
+            LANG_MAP_ENTRY(Italian),
+            LANG_MAP_ENTRY(Spanish),
+            LANG_MAP_ENTRY_CST(Chinese, SimplifiedChinese),
+            LANG_MAP_ENTRY(Korean),
+            LANG_MAP_ENTRY(Dutch),
+            LANG_MAP_ENTRY(Portuguese),
+            LANG_MAP_ENTRY(Russian),
+            LANG_MAP_ENTRY_CST(Taiwanese, TraditionalChinese),
+            LANG_MAP_ENTRY(BritishEnglish),
+            LANG_MAP_ENTRY(CanadianFrench),
+            LANG_MAP_ENTRY(LatinAmericanSpanish),
+            LANG_MAP_ENTRY(SimplifiedChinese),
+            LANG_MAP_ENTRY(TraditionalChinese),
+            LANG_MAP_ENTRY_CST(BrazilianPortuguese, Portuguese),
+        };
+        #undef LANG_MAP_ENTRY
+        #undef LANG_MAP_ENTRY_CST
+
+        constexpr ApplicationLanguage GetApplicationLanguage(SystemLanguage systemLanguage) {
+            return SystemToAppMap.at(systemLanguage);
+        }
+
+        #define LANG_MAP_ENTRY_REVERSE(lang) {ApplicationLanguage::lang, SystemLanguage::lang}
+        constexpr frz::unordered_map<ApplicationLanguage, SystemLanguage, constant::OldLanguageCodeListSize> AppToSystemMap{
+            LANG_MAP_ENTRY_REVERSE(Japanese),
+            LANG_MAP_ENTRY_REVERSE(AmericanEnglish),
+            LANG_MAP_ENTRY_REVERSE(French),
+            LANG_MAP_ENTRY_REVERSE(German),
+            LANG_MAP_ENTRY_REVERSE(Italian),
+            LANG_MAP_ENTRY_REVERSE(Spanish),
+            LANG_MAP_ENTRY_REVERSE(Korean),
+            LANG_MAP_ENTRY_REVERSE(Dutch),
+            LANG_MAP_ENTRY_REVERSE(Portuguese),
+            LANG_MAP_ENTRY_REVERSE(Russian),
+            LANG_MAP_ENTRY_REVERSE(BritishEnglish),
+            LANG_MAP_ENTRY_REVERSE(CanadianFrench),
+            LANG_MAP_ENTRY_REVERSE(LatinAmericanSpanish),
+            LANG_MAP_ENTRY_REVERSE(SimplifiedChinese),
+            LANG_MAP_ENTRY_REVERSE(TraditionalChinese),
+        };
+        #undef LANG_MAP_ENTRY_REVERSE
+
+        constexpr SystemLanguage GetSystemLanguage(ApplicationLanguage applicationLanguage) {
+            return AppToSystemMap.at(applicationLanguage);
         }
     }
 }

--- a/app/src/main/cpp/skyline/common/languages.h
+++ b/app/src/main/cpp/skyline/common/languages.h
@@ -10,7 +10,7 @@ namespace skyline {
 
     namespace constant {
         constexpr size_t OldLanguageCodeListSize{15}; //!< The size of the pre 4.0.0 language code list
-        constexpr size_t NewLanguageCodeListSize{17}; //!< The size of the post 4.0.0 language code list
+        constexpr size_t NewLanguageCodeListSize{18}; //!< The size of the post 10.1.0 language code list (was 17 between 4.0.0 - 10.1.0)
     }
 
     namespace languages {
@@ -32,6 +32,7 @@ namespace skyline {
             util::MakeMagic<LanguageCode>("es-419"),
             util::MakeMagic<LanguageCode>("zh-Hans"),
             util::MakeMagic<LanguageCode>("zh-Hant"),
+            util::MakeMagic<LanguageCode>("pt-BR"),
         };
 
         constexpr LanguageCode GetLanguageCode(SystemLanguage language) {

--- a/app/src/main/cpp/skyline/common/languages.h
+++ b/app/src/main/cpp/skyline/common/languages.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common.h>
+
+namespace skyline {
+    using LanguageCode = u64;
+
+    namespace constant {
+        constexpr size_t OldLanguageCodeListSize{15}; //!< The size of the pre 4.0.0 language code list
+        constexpr size_t NewLanguageCodeListSize{17}; //!< The size of the post 4.0.0 language code list
+    }
+
+    namespace languages {
+        constexpr std::array<LanguageCode, constant::NewLanguageCodeListSize> LanguageCodeList{
+            util::MakeMagic<LanguageCode>("ja"),
+            util::MakeMagic<LanguageCode>("en-US"),
+            util::MakeMagic<LanguageCode>("fr"),
+            util::MakeMagic<LanguageCode>("de"),
+            util::MakeMagic<LanguageCode>("it"),
+            util::MakeMagic<LanguageCode>("es"),
+            util::MakeMagic<LanguageCode>("zh-CN"),
+            util::MakeMagic<LanguageCode>("ko"),
+            util::MakeMagic<LanguageCode>("nl"),
+            util::MakeMagic<LanguageCode>("pt"),
+            util::MakeMagic<LanguageCode>("ru"),
+            util::MakeMagic<LanguageCode>("zh-TW"),
+            util::MakeMagic<LanguageCode>("en-GB"),
+            util::MakeMagic<LanguageCode>("fr-CA"),
+            util::MakeMagic<LanguageCode>("es-419"),
+            util::MakeMagic<LanguageCode>("zh-Hans"),
+            util::MakeMagic<LanguageCode>("zh-Hant"),
+        };
+
+        constexpr LanguageCode GetLanguageCode(SystemLanguage language) {
+            return LanguageCodeList.at(static_cast<size_t>(language));
+        }
+    }
+}

--- a/app/src/main/cpp/skyline/common/languages.h
+++ b/app/src/main/cpp/skyline/common/languages.h
@@ -7,8 +7,6 @@
 #include <common.h>
 
 namespace skyline {
-    using LanguageCode = u64;
-
     namespace constant {
         constexpr size_t OldLanguageCodeListSize{15}; //!< The size of the pre 4.0.0 language code list
         constexpr size_t NewLanguageCodeListSize{18}; //!< The size of the post 10.1.0 language code list (was 17 between 4.0.0 - 10.1.0)
@@ -54,28 +52,28 @@ namespace skyline {
             SimplifiedChinese,
         };
 
-        constexpr std::array<LanguageCode, constant::NewLanguageCodeListSize> LanguageCodeList{
-            util::MakeMagic<LanguageCode>("ja"),
-            util::MakeMagic<LanguageCode>("en-US"),
-            util::MakeMagic<LanguageCode>("fr"),
-            util::MakeMagic<LanguageCode>("de"),
-            util::MakeMagic<LanguageCode>("it"),
-            util::MakeMagic<LanguageCode>("es"),
-            util::MakeMagic<LanguageCode>("zh-CN"),
-            util::MakeMagic<LanguageCode>("ko"),
-            util::MakeMagic<LanguageCode>("nl"),
-            util::MakeMagic<LanguageCode>("pt"),
-            util::MakeMagic<LanguageCode>("ru"),
-            util::MakeMagic<LanguageCode>("zh-TW"),
-            util::MakeMagic<LanguageCode>("en-GB"),
-            util::MakeMagic<LanguageCode>("fr-CA"),
-            util::MakeMagic<LanguageCode>("es-419"),
-            util::MakeMagic<LanguageCode>("zh-Hans"),
-            util::MakeMagic<LanguageCode>("zh-Hant"),
-            util::MakeMagic<LanguageCode>("pt-BR"),
+        constexpr std::array<u64, constant::NewLanguageCodeListSize> LanguageCodeList{
+            util::MakeMagic<u64>("ja"),
+            util::MakeMagic<u64>("en-US"),
+            util::MakeMagic<u64>("fr"),
+            util::MakeMagic<u64>("de"),
+            util::MakeMagic<u64>("it"),
+            util::MakeMagic<u64>("es"),
+            util::MakeMagic<u64>("zh-CN"),
+            util::MakeMagic<u64>("ko"),
+            util::MakeMagic<u64>("nl"),
+            util::MakeMagic<u64>("pt"),
+            util::MakeMagic<u64>("ru"),
+            util::MakeMagic<u64>("zh-TW"),
+            util::MakeMagic<u64>("en-GB"),
+            util::MakeMagic<u64>("fr-CA"),
+            util::MakeMagic<u64>("es-419"),
+            util::MakeMagic<u64>("zh-Hans"),
+            util::MakeMagic<u64>("zh-Hant"),
+            util::MakeMagic<u64>("pt-BR"),
         };
 
-        constexpr LanguageCode GetLanguageCode(SystemLanguage language) {
+        constexpr u64 GetLanguageCode(SystemLanguage language) {
             return LanguageCodeList.at(static_cast<size_t>(language));
         }
 

--- a/app/src/main/cpp/skyline/common/macros.h
+++ b/app/src/main/cpp/skyline/common/macros.h
@@ -21,5 +21,24 @@
             cases                                       \
             default:                                    \
                 return "Unknown";                       \
-        };                                              \
-    };
+        }                                               \
+    }
+
+/**
+ * @brief A case statement for an enumerant value to use alongside ENUM_SWITCH
+ */
+#define ENUM_CASE_PAIR(key, value)      \
+    case ENUM_TYPE::key:                \
+    return value
+
+/**
+ * @brief Creates a switch case statement to convert an enumerant to the given values
+ * @example ENUM_SWITCH(Example, value, { ENUM_CASE_PAIR(keyA, valueA); ENUM_CASE_PAIR(keyB, valueB); }, defaultValue)
+ */
+#define ENUM_SWITCH(name, value, cases, defaultValue)       \
+    using ENUM_TYPE = name;                                 \
+    switch (value) {                                        \
+        cases                                               \
+        default:                                            \
+            return defaultValue;                            \
+    }

--- a/app/src/main/cpp/skyline/loader/loader.h
+++ b/app/src/main/cpp/skyline/loader/loader.h
@@ -87,7 +87,7 @@ namespace skyline::loader {
 
         virtual ~Loader() = default;
 
-        virtual std::vector<u8> GetIcon() {
+        virtual std::vector<u8> GetIcon(languages::ApplicationLanguage language) {
             return std::vector<u8>();
         }
 

--- a/app/src/main/cpp/skyline/loader/loader.h
+++ b/app/src/main/cpp/skyline/loader/loader.h
@@ -87,7 +87,7 @@ namespace skyline::loader {
 
         virtual ~Loader() = default;
 
-        virtual std::vector<u8> GetIcon(languages::ApplicationLanguage language) {
+        virtual std::vector<u8> GetIcon(language::ApplicationLanguage language) {
             return std::vector<u8>();
         }
 

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -29,7 +29,7 @@ namespace skyline::loader {
         }
     }
 
-    std::vector<u8> NroLoader::GetIcon() {
+    std::vector<u8> NroLoader::GetIcon(languages::ApplicationLanguage language) {
         NroAssetSection &segmentHeader{assetHeader.icon};
         std::vector<u8> buffer(segmentHeader.size);
 

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -29,7 +29,7 @@ namespace skyline::loader {
         }
     }
 
-    std::vector<u8> NroLoader::GetIcon(languages::ApplicationLanguage language) {
+    std::vector<u8> NroLoader::GetIcon(language::ApplicationLanguage language) {
         NroAssetSection &segmentHeader{assetHeader.icon};
         std::vector<u8> buffer(segmentHeader.size);
 

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -64,7 +64,8 @@ namespace skyline::loader {
         }
 
         state.process->memory.InitializeVmm(memory::AddressSpaceType::AddressSpace39Bit);
-        auto loadInfo{LoadExecutable(process, state, executable, 0, nacp->applicationName.empty() ? "main.nro" : nacp->applicationName + ".nro")};
+        auto applicationName{nacp->GetApplicationName(nacp->GetFirstSupportedTitleLanguage())};
+        auto loadInfo{LoadExecutable(process, state, executable, 0, applicationName.empty() ? "main.nro" : applicationName + ".nro")};
         state.process->memory.InitializeRegions(loadInfo.base, loadInfo.size);
 
         return loadInfo.entry;

--- a/app/src/main/cpp/skyline/loader/nro.h
+++ b/app/src/main/cpp/skyline/loader/nro.h
@@ -70,7 +70,7 @@ namespace skyline::loader {
       public:
         NroLoader(std::shared_ptr<vfs::Backing> backing);
 
-        std::vector<u8> GetIcon() override;
+        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/loader/nro.h
+++ b/app/src/main/cpp/skyline/loader/nro.h
@@ -70,7 +70,7 @@ namespace skyline::loader {
       public:
         NroLoader(std::shared_ptr<vfs::Backing> backing);
 
-        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
+        std::vector<u8> GetIcon(language::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/loader/nsp.cpp
+++ b/app/src/main/cpp/skyline/loader/nsp.cpp
@@ -57,15 +57,15 @@ namespace skyline::loader {
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 
-    std::vector<u8> NspLoader::GetIcon(languages::ApplicationLanguage language) {
+    std::vector<u8> NspLoader::GetIcon(language::ApplicationLanguage language) {
         if (controlRomFs == nullptr)
             return std::vector<u8>();
 
         std::shared_ptr<vfs::Backing> icon{};
 
-        auto iconName{fmt::format("icon_{}.dat", languages::ToString(language))};
+        auto iconName{fmt::format("icon_{}.dat", language::ToString(language))};
         if (!(icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false}))) {
-            iconName = fmt::format("icon_{}.dat", languages::ToString(nacp->GetFirstSupportedTitleLanguage()));
+            iconName = fmt::format("icon_{}.dat", language::ToString(nacp->GetFirstSupportedTitleLanguage()));
             icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false});
         }
 

--- a/app/src/main/cpp/skyline/loader/nsp.cpp
+++ b/app/src/main/cpp/skyline/loader/nsp.cpp
@@ -57,19 +57,16 @@ namespace skyline::loader {
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 
-    std::vector<u8> NspLoader::GetIcon() {
-        if (romFs == nullptr)
+    std::vector<u8> NspLoader::GetIcon(languages::ApplicationLanguage language) {
+        if (controlRomFs == nullptr)
             return std::vector<u8>();
 
-        auto root{controlRomFs->OpenDirectory("", {false, true})};
         std::shared_ptr<vfs::Backing> icon{};
 
-        // Use the first icon file available
-        for (const auto &entry : root->Read()) {
-            if (entry.name.rfind("icon") == 0) {
-                icon = controlRomFs->OpenFileUnchecked(entry.name);
-                break;
-            }
+        auto iconName{fmt::format("icon_{}.dat", languages::ToString(language))};
+        if (!(icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false}))) {
+            iconName = fmt::format("icon_{}.dat", languages::ToString(nacp->GetFirstSupportedTitleLanguage()));
+            icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false});
         }
 
         if (icon == nullptr)

--- a/app/src/main/cpp/skyline/loader/nsp.h
+++ b/app/src/main/cpp/skyline/loader/nsp.h
@@ -24,7 +24,7 @@ namespace skyline::loader {
       public:
         NspLoader(const std::shared_ptr<vfs::Backing> &backing, const std::shared_ptr<crypto::KeyStore> &keyStore);
 
-        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
+        std::vector<u8> GetIcon(language::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/loader/nsp.h
+++ b/app/src/main/cpp/skyline/loader/nsp.h
@@ -24,7 +24,7 @@ namespace skyline::loader {
       public:
         NspLoader(const std::shared_ptr<vfs::Backing> &backing, const std::shared_ptr<crypto::KeyStore> &keyStore);
 
-        std::vector<u8> GetIcon() override;
+        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/loader/xci.cpp
+++ b/app/src/main/cpp/skyline/loader/xci.cpp
@@ -65,15 +65,15 @@ namespace skyline::loader {
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 
-    std::vector<u8> XciLoader::GetIcon(languages::ApplicationLanguage language) {
+    std::vector<u8> XciLoader::GetIcon(language::ApplicationLanguage language) {
         if (controlRomFs == nullptr)
             return std::vector<u8>();
 
         std::shared_ptr<vfs::Backing> icon{};
 
-        auto iconName{fmt::format("icon_{}.dat", languages::ToString(language))};
+        auto iconName{fmt::format("icon_{}.dat", language::ToString(language))};
         if (!(icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false}))) {
-            iconName = fmt::format("icon_{}.dat", languages::ToString(nacp->GetFirstSupportedTitleLanguage()));
+            iconName = fmt::format("icon_{}.dat", language::ToString(nacp->GetFirstSupportedTitleLanguage()));
             icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false});
         }
 

--- a/app/src/main/cpp/skyline/loader/xci.cpp
+++ b/app/src/main/cpp/skyline/loader/xci.cpp
@@ -65,19 +65,16 @@ namespace skyline::loader {
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 
-    std::vector<u8> XciLoader::GetIcon() {
-        if (romFs == nullptr)
+    std::vector<u8> XciLoader::GetIcon(languages::ApplicationLanguage language) {
+        if (controlRomFs == nullptr)
             return std::vector<u8>();
 
-        auto root{controlRomFs->OpenDirectory("", {false, true})};
         std::shared_ptr<vfs::Backing> icon{};
 
-        // Use the first icon file available
-        for (const auto &entry : root->Read()) {
-            if (entry.name.rfind("icon") == 0) {
-                icon = controlRomFs->OpenFile(entry.name);
-                break;
-            }
+        auto iconName{fmt::format("icon_{}.dat", languages::ToString(language))};
+        if (!(icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false}))) {
+            iconName = fmt::format("icon_{}.dat", languages::ToString(nacp->GetFirstSupportedTitleLanguage()));
+            icon = controlRomFs->OpenFileUnchecked(iconName, {true, false, false});
         }
 
         if (icon == nullptr)

--- a/app/src/main/cpp/skyline/loader/xci.h
+++ b/app/src/main/cpp/skyline/loader/xci.h
@@ -117,7 +117,7 @@ namespace skyline::loader {
       public:
         XciLoader(const std::shared_ptr<vfs::Backing> &backing, const std::shared_ptr<crypto::KeyStore> &keyStore);
 
-        std::vector<u8> GetIcon() override;
+        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/loader/xci.h
+++ b/app/src/main/cpp/skyline/loader/xci.h
@@ -117,7 +117,7 @@ namespace skyline::loader {
       public:
         XciLoader(const std::shared_ptr<vfs::Backing> &backing, const std::shared_ptr<crypto::KeyStore> &keyStore);
 
-        std::vector<u8> GetIcon(languages::ApplicationLanguage language) override;
+        std::vector<u8> GetIcon(language::ApplicationLanguage language) override;
 
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -19,7 +19,7 @@ namespace skyline::kernel {
         std::shared_ptr<Settings> &settings,
         std::string appFilesPath,
         std::string deviceTimeZone,
-        languages::SystemLanguage systemLanguage,
+        language::SystemLanguage systemLanguage,
         std::shared_ptr<vfs::FileSystem> assetFileSystem
     ) : state(this, jvmManager, settings, logger),
         appFilesPath(std::move(appFilesPath)),

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -21,13 +21,12 @@ namespace skyline::kernel {
         std::string deviceTimeZone,
         languages::SystemLanguage systemLanguage,
         std::shared_ptr<vfs::FileSystem> assetFileSystem
-    )
-        : state(this, jvmManager, settings, logger),
-          appFilesPath(std::move(appFilesPath)),
-          deviceTimeZone(std::move(deviceTimeZone)),
-          assetFileSystem(std::move(assetFileSystem)),
-          serviceManager(state),
-          systemLanguage(systemLanguage) {}
+    ) : state(this, jvmManager, settings, logger),
+        appFilesPath(std::move(appFilesPath)),
+        deviceTimeZone(std::move(deviceTimeZone)),
+        assetFileSystem(std::move(assetFileSystem)),
+        serviceManager(state),
+        systemLanguage(systemLanguage) {}
 
     void OS::Execute(int romFd, loader::RomFormat romType) {
         auto romFile{std::make_shared<vfs::OsBacking>(romFd)};

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -13,7 +13,21 @@
 #include "os.h"
 
 namespace skyline::kernel {
-    OS::OS(std::shared_ptr<JvmManager> &jvmManager, std::shared_ptr<Logger> &logger, std::shared_ptr<Settings> &settings, std::string appFilesPath, std::string deviceTimeZone, std::shared_ptr<vfs::FileSystem> assetFileSystem) : state(this, jvmManager, settings, logger), appFilesPath(std::move(appFilesPath)), deviceTimeZone(std::move(deviceTimeZone)), assetFileSystem(std::move(assetFileSystem)), serviceManager(state) {}
+    OS::OS(
+        std::shared_ptr<JvmManager> &jvmManager,
+        std::shared_ptr<Logger> &logger,
+        std::shared_ptr<Settings> &settings,
+        std::string appFilesPath,
+        std::string deviceTimeZone,
+        languages::SystemLanguage systemLanguage,
+        std::shared_ptr<vfs::FileSystem> assetFileSystem
+    )
+        : state(this, jvmManager, settings, logger),
+          appFilesPath(std::move(appFilesPath)),
+          deviceTimeZone(std::move(deviceTimeZone)),
+          assetFileSystem(std::move(assetFileSystem)),
+          serviceManager(state),
+          systemLanguage(systemLanguage) {}
 
     void OS::Execute(int romFd, loader::RomFormat romType) {
         auto romFile{std::make_shared<vfs::OsBacking>(romFd)};

--- a/app/src/main/cpp/skyline/os.h
+++ b/app/src/main/cpp/skyline/os.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <common/languages.h>
+#include <common/language.h>
 #include "vfs/filesystem.h"
 #include "loader/loader.h"
 #include "services/serviceman.h"
@@ -19,7 +19,7 @@ namespace skyline::kernel {
         std::string deviceTimeZone; //!< The timezone name (e.g. Europe/London)
         std::shared_ptr<vfs::FileSystem> assetFileSystem; //!< A filesystem to be used for accessing emulator assets (like tzdata)
         service::ServiceManager serviceManager;
-        languages::SystemLanguage systemLanguage;
+        language::SystemLanguage systemLanguage;
 
         /**
          * @param logger An instance of the Logger class
@@ -32,7 +32,7 @@ namespace skyline::kernel {
             std::shared_ptr<Settings> &settings,
             std::string appFilesPath,
             std::string deviceTimeZone,
-            languages::SystemLanguage systemLanguage,
+            language::SystemLanguage systemLanguage,
             std::shared_ptr<vfs::FileSystem> assetFileSystem
         );
 

--- a/app/src/main/cpp/skyline/os.h
+++ b/app/src/main/cpp/skyline/os.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <common/languages.h>
 #include "vfs/filesystem.h"
 #include "loader/loader.h"
 #include "services/serviceman.h"
@@ -18,13 +19,22 @@ namespace skyline::kernel {
         std::string deviceTimeZone; //!< The timezone name (e.g. Europe/London)
         std::shared_ptr<vfs::FileSystem> assetFileSystem; //!< A filesystem to be used for accessing emulator assets (like tzdata)
         service::ServiceManager serviceManager;
+        languages::SystemLanguage systemLanguage;
 
         /**
          * @param logger An instance of the Logger class
          * @param settings An instance of the Settings class
          * @param window The ANativeWindow object to draw the screen to
          */
-        OS(std::shared_ptr<JvmManager> &jvmManager, std::shared_ptr<Logger> &logger, std::shared_ptr<Settings> &settings, std::string appFilesPath, std::string deviceTimeZone, std::shared_ptr<vfs::FileSystem> assetFileSystem);
+        OS(
+            std::shared_ptr<JvmManager> &jvmManager,
+            std::shared_ptr<Logger> &logger,
+            std::shared_ptr<Settings> &settings,
+            std::string appFilesPath,
+            std::string deviceTimeZone,
+            languages::SystemLanguage systemLanguage,
+            std::shared_ptr<vfs::FileSystem> assetFileSystem
+        );
 
         /**
          * @brief Execute a particular ROM file

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -11,8 +11,7 @@
 #include "IApplicationFunctions.h"
 
 namespace skyline::service::am {
-    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager)
-        : gpuErrorEvent(std::make_shared<type::KEvent>(state, false)), BaseService(state, manager) {}
+    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager) : gpuErrorEvent(std::make_shared<type::KEvent>(state, false)), BaseService(state, manager) {}
 
     Result IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 LaunchParameterMagic{0xC79497CA}; //!< The magic of the application launch parameters
@@ -36,7 +35,8 @@ namespace skyline::service::am {
     Result IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto desiredLanguage{languages::GetApplicationLanguage(state.os->systemLanguage)};
 
-        if ((1 << static_cast<u32>(desiredLanguage) & state.loader->nacp->nacpContents.supportedLanguageFlag) == 0)
+        // In the future we might want to trigger an UI dialog if the user selected languages is not available, for now it will use the first available
+        if (((1 << static_cast<u32>(desiredLanguage)) & state.loader->nacp->nacpContents.supportedLanguageFlag) == 0)
             desiredLanguage = state.loader->nacp->GetFirstSupportedLanguage();
 
         response.Push(languages::GetLanguageCode(languages::GetSystemLanguage(desiredLanguage)));

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -33,13 +33,13 @@ namespace skyline::service::am {
     }
 
     Result IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        auto desiredLanguage{languages::GetApplicationLanguage(state.os->systemLanguage)};
+        auto desiredLanguage{language::GetApplicationLanguage(state.os->systemLanguage)};
 
         // In the future we might want to trigger an UI dialog if the user selected languages is not available, for now it will use the first available
         if (((1 << static_cast<u32>(desiredLanguage)) & state.loader->nacp->nacpContents.supportedLanguageFlag) == 0)
             desiredLanguage = state.loader->nacp->GetFirstSupportedLanguage();
 
-        response.Push(languages::GetLanguageCode(languages::GetSystemLanguage(desiredLanguage)));
+        response.Push(language::GetLanguageCode(language::GetSystemLanguage(desiredLanguage)));
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -34,7 +34,12 @@ namespace skyline::service::am {
     }
 
     Result IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        response.Push(languages::GetLanguageCode(state.os->systemLanguage));
+        auto desiredLanguage{languages::GetApplicationLanguage(state.os->systemLanguage)};
+
+        if ((1 << static_cast<u32>(desiredLanguage) & state.loader->nacp->nacpContents.supportedLanguageFlag) == 0)
+            desiredLanguage = state.loader->nacp->GetFirstSupportedLanguage();
+
+        response.Push(languages::GetLanguageCode(languages::GetSystemLanguage(desiredLanguage)));
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -4,13 +4,15 @@
 #include <common/uuid.h>
 #include <mbedtls/sha1.h>
 #include <loader/loader.h>
+#include <os.h>
 #include <kernel/types/KProcess.h>
 #include <services/account/IAccountServiceForApplication.h>
 #include <services/am/storage/IStorage.h>
 #include "IApplicationFunctions.h"
 
 namespace skyline::service::am {
-    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager) : gpuErrorEvent(std::make_shared<type::KEvent>(state, false)), BaseService(state, manager) {}
+    IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager)
+        : gpuErrorEvent(std::make_shared<type::KEvent>(state, false)), BaseService(state, manager) {}
 
     Result IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 LaunchParameterMagic{0xC79497CA}; //!< The magic of the application launch parameters
@@ -32,7 +34,7 @@ namespace skyline::service::am {
     }
 
     Result IApplicationFunctions::GetDesiredLanguage(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        response.Push(util::MakeMagic<u64>("en-US"));
+        response.Push(languages::GetLanguageCode(state.os->systemLanguage));
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
-#include <common/languages.h>
+#include <common/language.h>
 #include "ISettingsServer.h"
 
 namespace skyline::service::settings {
     ISettingsServer::ISettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
 
     Result ISettingsServer::GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        request.outputBuf.at(0).copy_from(span(languages::LanguageCodeList).first(constant::OldLanguageCodeListSize));
+        request.outputBuf.at(0).copy_from(span(language::LanguageCodeList).first(constant::OldLanguageCodeListSize));
         response.Push<i32>(constant::OldLanguageCodeListSize);
         return {};
     }
 
     Result ISettingsServer::MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        response.Push<u64>(languages::LanguageCodeList.at(request.Pop<i32>()));
+        response.Push<u64>(language::LanguageCodeList.at(request.Pop<i32>()));
         return {};
     }
 
     Result ISettingsServer::GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        request.outputBuf.at(0).copy_from(languages::LanguageCodeList);
+        request.outputBuf.at(0).copy_from(language::LanguageCodeList);
         response.Push<i32>(constant::NewLanguageCodeListSize);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -1,44 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include <common/languages.h>
 #include "ISettingsServer.h"
 
 namespace skyline::service::settings {
     ISettingsServer::ISettingsServer(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
 
-    constexpr std::array<u64, constant::NewLanguageCodeListSize> LanguageCodeList{
-        util::MakeMagic<u64>("ja"),
-        util::MakeMagic<u64>("en-US"),
-        util::MakeMagic<u64>("fr"),
-        util::MakeMagic<u64>("de"),
-        util::MakeMagic<u64>("it"),
-        util::MakeMagic<u64>("es"),
-        util::MakeMagic<u64>("zh-CN"),
-        util::MakeMagic<u64>("ko"),
-        util::MakeMagic<u64>("nl"),
-        util::MakeMagic<u64>("pt"),
-        util::MakeMagic<u64>("ru"),
-        util::MakeMagic<u64>("zh-TW"),
-        util::MakeMagic<u64>("en-GB"),
-        util::MakeMagic<u64>("fr-CA"),
-        util::MakeMagic<u64>("es-419"),
-        util::MakeMagic<u64>("zh-Hans"),
-        util::MakeMagic<u64>("zh-Hant"),
-    };
-
     Result ISettingsServer::GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        request.outputBuf.at(0).copy_from(span(LanguageCodeList).first(constant::OldLanguageCodeListSize));
+        request.outputBuf.at(0).copy_from(span(languages::LanguageCodeList).first(constant::OldLanguageCodeListSize));
         response.Push<i32>(constant::OldLanguageCodeListSize);
         return {};
     }
 
     Result ISettingsServer::MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        response.Push<u64>(LanguageCodeList.at(request.Pop<i32>()));
+        response.Push<u64>(languages::LanguageCodeList.at(request.Pop<i32>()));
         return {};
     }
 
     Result ISettingsServer::GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        request.outputBuf.at(0).copy_from(LanguageCodeList);
+        request.outputBuf.at(0).copy_from(languages::LanguageCodeList);
         response.Push<i32>(constant::NewLanguageCodeListSize);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
@@ -3,43 +3,36 @@
 
 #pragma once
 
-#include <services/serviceman.h>
+#include <services/base_service.h>
 
-namespace skyline::service {
-    namespace constant {
-        constexpr size_t OldLanguageCodeListSize{15}; //!< The size of the pre 4.0.0 language code list
-        constexpr size_t NewLanguageCodeListSize{17}; //!< The size of the post 4.0.0 language code list
-    }
+namespace skyline::service::settings {
+    /**
+     * @brief ISettingsServer or 'set' provides access to user settings
+     * @url https://switchbrew.org/wiki/Settings_services#set
+     */
+    class ISettingsServer : public BaseService {
+      public:
+        ISettingsServer(const DeviceState &state, ServiceManager &manager);
 
-    namespace settings {
         /**
-         * @brief ISettingsServer or 'set' provides access to user settings
-         * @url https://switchbrew.org/wiki/Settings_services#set
+         * @brief Reads the available language codes that an application can use (pre 4.0.0)
          */
-        class ISettingsServer : public BaseService {
-          public:
-            ISettingsServer(const DeviceState &state, ServiceManager &manager);
+        Result GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
-            /**
-             * @brief Reads the available language codes that an application can use (pre 4.0.0)
-             */
-            Result GetAvailableLanguageCodes(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        /**
+         * @brief Converts a language code list index to its corresponding language code
+         */
+        Result MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
-            /**
-             * @brief Converts a language code list index to its corresponding language code
-             */
-            Result MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+        /**
+         * @brief Reads the available language codes that an application can use (post 4.0.0)
+         */
+        Result GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
-            /**
-             * @brief Reads the available language codes that an application can use (post 4.0.0)
-             */
-            Result GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
-
-            SERVICE_DECL(
-                SFUNC(0x1, ISettingsServer, GetAvailableLanguageCodes),
-                SFUNC(0x2, ISettingsServer, MakeLanguageCode),
-                SFUNC(0x5, ISettingsServer, GetAvailableLanguageCodes2)
-            )
-        };
-    }
+        SERVICE_DECL(
+            SFUNC(0x1, ISettingsServer, GetAvailableLanguageCodes),
+            SFUNC(0x2, ISettingsServer, MakeLanguageCode),
+            SFUNC(0x5, ISettingsServer, GetAvailableLanguageCodes2)
+        )
+    };
 }

--- a/app/src/main/cpp/skyline/vfs/nacp.cpp
+++ b/app/src/main/cpp/skyline/vfs/nacp.cpp
@@ -21,6 +21,10 @@ namespace skyline::vfs {
         return static_cast<languages::ApplicationLanguage>(std::countr_zero(supportedTitleLanguages));
     }
 
+    languages::ApplicationLanguage NACP::GetFirstSupportedLanguage() {
+        return static_cast<languages::ApplicationLanguage>(std::countr_zero(nacpContents.supportedLanguageFlag));
+    }
+
     std::string NACP::GetApplicationName(languages::ApplicationLanguage language) {
         auto applicationName{span(nacpContents.titleEntries.at(static_cast<size_t>(language)).applicationName)};
         return std::string(applicationName.as_string(true));

--- a/app/src/main/cpp/skyline/vfs/nacp.cpp
+++ b/app/src/main/cpp/skyline/vfs/nacp.cpp
@@ -1,21 +1,33 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include <bit>
 #include "nacp.h"
 
 namespace skyline::vfs {
     NACP::NACP(const std::shared_ptr<vfs::Backing> &backing) {
         nacpContents = backing->Read<NacpData>();
 
-        // TODO: Select based on language settings, complete struct, yada yada
-
-        // Iterate till we get to the first populated entry
+        u32 counter{0};
         for (auto &entry : nacpContents.titleEntries) {
-            if (entry.applicationName.front() == '\0')
-                continue;
-
-            applicationName = span(entry.applicationName).as_string(true);
-            applicationPublisher = span(entry.applicationPublisher).as_string(true);
+            if (entry.applicationName.front() != '\0') {
+                supportedTitleLanguages |= (1 << counter);
+            }
+            counter++;
         }
+    }
+
+    languages::ApplicationLanguage NACP::GetFirstSupportedTitleLanguage() {
+        return static_cast<languages::ApplicationLanguage>(std::countr_zero(supportedTitleLanguages));
+    }
+
+    std::string NACP::GetApplicationName(languages::ApplicationLanguage language) {
+        auto applicationName{span(nacpContents.titleEntries.at(static_cast<size_t>(language)).applicationName)};
+        return std::string(applicationName.as_string(true));
+    }
+
+    std::string NACP::GetApplicationPublisher(languages::ApplicationLanguage language) {
+        auto applicationPublisher{span(nacpContents.titleEntries.at(static_cast<size_t>(language)).applicationPublisher)};
+        return std::string(applicationPublisher.as_string(true));
     }
 }

--- a/app/src/main/cpp/skyline/vfs/nacp.cpp
+++ b/app/src/main/cpp/skyline/vfs/nacp.cpp
@@ -8,7 +8,7 @@ namespace skyline::vfs {
     NACP::NACP(const std::shared_ptr<vfs::Backing> &backing) {
         nacpContents = backing->Read<NacpData>();
 
-        u32 counter{0};
+        u32 counter{};
         for (auto &entry : nacpContents.titleEntries) {
             if (entry.applicationName.front() != '\0') {
                 supportedTitleLanguages |= (1 << counter);
@@ -17,20 +17,20 @@ namespace skyline::vfs {
         }
     }
 
-    languages::ApplicationLanguage NACP::GetFirstSupportedTitleLanguage() {
-        return static_cast<languages::ApplicationLanguage>(std::countr_zero(supportedTitleLanguages));
+    language::ApplicationLanguage NACP::GetFirstSupportedTitleLanguage() {
+        return static_cast<language::ApplicationLanguage>(std::countr_zero(supportedTitleLanguages));
     }
 
-    languages::ApplicationLanguage NACP::GetFirstSupportedLanguage() {
-        return static_cast<languages::ApplicationLanguage>(std::countr_zero(nacpContents.supportedLanguageFlag));
+    language::ApplicationLanguage NACP::GetFirstSupportedLanguage() {
+        return static_cast<language::ApplicationLanguage>(std::countr_zero(nacpContents.supportedLanguageFlag));
     }
 
-    std::string NACP::GetApplicationName(languages::ApplicationLanguage language) {
+    std::string NACP::GetApplicationName(language::ApplicationLanguage language) {
         auto applicationName{span(nacpContents.titleEntries.at(static_cast<size_t>(language)).applicationName)};
         return std::string(applicationName.as_string(true));
     }
 
-    std::string NACP::GetApplicationPublisher(languages::ApplicationLanguage language) {
+    std::string NACP::GetApplicationPublisher(language::ApplicationLanguage language) {
         auto applicationPublisher{span(nacpContents.titleEntries.at(static_cast<size_t>(language)).applicationPublisher)};
         return std::string(applicationPublisher.as_string(true));
     }

--- a/app/src/main/cpp/skyline/vfs/nacp.h
+++ b/app/src/main/cpp/skyline/vfs/nacp.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <common/languages.h>
+#include <common/language.h>
 #include "backing.h"
 
 namespace skyline::vfs {
@@ -35,16 +35,16 @@ namespace skyline::vfs {
         } nacpContents{};
         static_assert(sizeof(NacpData) == 0x4000);
 
-        u32 supportedTitleLanguages{0}; //<! A bitmask containing the available title entry languages and game icons
+        u32 supportedTitleLanguages{}; //<! A bitmask containing the available title entry languages and game icons
 
         NACP(const std::shared_ptr<vfs::Backing> &backing);
 
-        languages::ApplicationLanguage GetFirstSupportedTitleLanguage();
+        language::ApplicationLanguage GetFirstSupportedTitleLanguage();
 
-        languages::ApplicationLanguage GetFirstSupportedLanguage();
+        language::ApplicationLanguage GetFirstSupportedLanguage();
 
-        std::string GetApplicationName(languages::ApplicationLanguage language);
+        std::string GetApplicationName(language::ApplicationLanguage language);
 
-        std::string GetApplicationPublisher(languages::ApplicationLanguage language);
+        std::string GetApplicationPublisher(language::ApplicationLanguage language);
     };
 }

--- a/app/src/main/cpp/skyline/vfs/nacp.h
+++ b/app/src/main/cpp/skyline/vfs/nacp.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <common/languages.h>
 #include "backing.h"
 
 namespace skyline::vfs {
@@ -24,17 +25,24 @@ namespace skyline::vfs {
       public:
         struct NacpData {
             std::array<ApplicationTitle, 0x10> titleEntries; //!< Title entries for each language
-            u8 _pad0_[0x78];
-            u64 saveDataOwnerId; //!< The ID that should be used for this application's savedata
+            u8 _pad0_[0x2C];
+            u32 supportedLanguageFlag; //!< A bitmask containing the game's supported languages
             u8 _pad1_[0x78];
+            u64 saveDataOwnerId; //!< The ID that should be used for this application's savedata
+            u8 _pad2_[0x48];
             std::array<u8, 8> seedForPseudoDeviceId; //!< Seed that is combined with the device seed for generating the pseudo-device ID
-            u8 _pad2_[0xF00];
+            u8 _pad3_[0xF00];
         } nacpContents{};
         static_assert(sizeof(NacpData) == 0x4000);
 
         NACP(const std::shared_ptr<vfs::Backing> &backing);
 
-        std::string applicationName; //!< The name of the application in the currently selected language
-        std::string applicationPublisher; //!< The publisher of the application in the currently selected language
+        languages::ApplicationLanguage GetFirstSupportedTitleLanguage();
+
+        std::string GetApplicationName(languages::ApplicationLanguage language);
+
+        std::string GetApplicationPublisher(languages::ApplicationLanguage language);
+
+        u32 supportedTitleLanguages{0};
     };
 }

--- a/app/src/main/cpp/skyline/vfs/nacp.h
+++ b/app/src/main/cpp/skyline/vfs/nacp.h
@@ -39,6 +39,8 @@ namespace skyline::vfs {
 
         languages::ApplicationLanguage GetFirstSupportedTitleLanguage();
 
+        languages::ApplicationLanguage GetFirstSupportedLanguage();
+
         std::string GetApplicationName(languages::ApplicationLanguage language);
 
         std::string GetApplicationPublisher(languages::ApplicationLanguage language);

--- a/app/src/main/cpp/skyline/vfs/nacp.h
+++ b/app/src/main/cpp/skyline/vfs/nacp.h
@@ -35,6 +35,8 @@ namespace skyline::vfs {
         } nacpContents{};
         static_assert(sizeof(NacpData) == 0x4000);
 
+        u32 supportedTitleLanguages{0}; //<! A bitmask containing the available title entry languages and game icons
+
         NACP(const std::shared_ptr<vfs::Backing> &backing);
 
         languages::ApplicationLanguage GetFirstSupportedTitleLanguage();
@@ -44,7 +46,5 @@ namespace skyline::vfs {
         std::string GetApplicationName(languages::ApplicationLanguage language);
 
         std::string GetApplicationPublisher(languages::ApplicationLanguage language);
-
-        u32 supportedTitleLanguages{0};
     };
 }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -173,7 +173,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         val preferenceFd = ParcelFileDescriptor.open(File("${applicationInfo.dataDir}/shared_prefs/${applicationInfo.packageName}_preferences.xml"), ParcelFileDescriptor.MODE_READ_WRITE)
 
         emulationThread = Thread {
-            executeApplication(rom.toString(), romType, romFd.detachFd(), preferenceFd.detachFd(), Integer.parseInt(settings.systemLanguage), applicationContext.filesDir.canonicalPath + "/", assets)
+            executeApplication(rom.toString(), romType, romFd.detachFd(), preferenceFd.detachFd(), settings.systemLanguage, applicationContext.filesDir.canonicalPath + "/", assets)
             if (shouldFinish)
                 runOnUiThread {
                     emulationThread.join()

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -70,7 +70,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
      * @param appFilesPath The full path to the app files directory
      * @param assetManager The asset manager used for accessing app assets
      */
-    private external fun executeApplication(romUri : String, romType : Int, romFd : Int, preferenceFd : Int, appFilesPath : String, assetManager : AssetManager)
+    private external fun executeApplication(romUri : String, romType : Int, romFd : Int, preferenceFd : Int, language : Int, appFilesPath : String, assetManager : AssetManager)
 
     /**
      * @return If it successfully caused the [emulationThread] to gracefully stop
@@ -173,7 +173,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         val preferenceFd = ParcelFileDescriptor.open(File("${applicationInfo.dataDir}/shared_prefs/${applicationInfo.packageName}_preferences.xml"), ParcelFileDescriptor.MODE_READ_WRITE)
 
         emulationThread = Thread {
-            executeApplication(rom.toString(), romType, romFd.detachFd(), preferenceFd.detachFd(), applicationContext.filesDir.canonicalPath + "/", assets)
+            executeApplication(rom.toString(), romType, romFd.detachFd(), preferenceFd.detachFd(), Integer.parseInt(settings.systemLanguage), applicationContext.filesDir.canonicalPath + "/", assets)
             if (shouldFinish)
                 runOnUiThread {
                     emulationThread.join()

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -292,7 +292,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadRoms(loadFromFile : Boolean) {
-        viewModel.loadRoms(loadFromFile, Uri.parse(settings.searchLocation))
+        viewModel.loadRoms(loadFromFile, Uri.parse(settings.searchLocation), Integer.parseInt(settings.systemLanguage))
         settings.refreshRequired = false
     }
 

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -292,7 +292,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadRoms(loadFromFile : Boolean) {
-        viewModel.loadRoms(loadFromFile, Uri.parse(settings.searchLocation), Integer.parseInt(settings.systemLanguage))
+        viewModel.loadRoms(loadFromFile, Uri.parse(settings.searchLocation), settings.systemLanguage)
         settings.refreshRequired = false
     }
 

--- a/app/src/main/java/emu/skyline/MainViewModel.kt
+++ b/app/src/main/java/emu/skyline/MainViewModel.kt
@@ -43,7 +43,7 @@ class MainViewModel @Inject constructor(@ApplicationContext context : Context, p
      *
      * @param loadFromFile If this is false then trying to load cached adapter data is skipped entirely
      */
-    fun loadRoms(loadFromFile : Boolean, searchLocation : Uri) {
+    fun loadRoms(loadFromFile : Boolean, searchLocation : Uri, systemLanguage : Int) {
         if (state == MainState.Loading) return
         state = MainState.Loading
 
@@ -64,7 +64,7 @@ class MainViewModel @Inject constructor(@ApplicationContext context : Context, p
                 MainState.Loaded(HashMap())
             } else {
                 try {
-                    val romElements = romProvider.loadRoms(searchLocation)
+                    val romElements = romProvider.loadRoms(searchLocation, systemLanguage)
                     romElements.toFile(romsFile)
                     MainState.Loaded(romElements)
                 } catch (e : Exception) {

--- a/app/src/main/java/emu/skyline/RomProvider.kt
+++ b/app/src/main/java/emu/skyline/RomProvider.kt
@@ -18,21 +18,21 @@ class RomProvider @Inject constructor(@ApplicationContext private val context : 
      * This adds all files in [directory] with [extension] as an entry using [RomFile] to load metadata
      */
     @SuppressLint("DefaultLocale")
-    private fun addEntries(fileFormats : Map<String, RomFormat>, directory : DocumentFile, entries : HashMap<RomFormat, ArrayList<AppEntry>>) {
+    private fun addEntries(fileFormats : Map<String, RomFormat>, directory : DocumentFile, entries : HashMap<RomFormat, ArrayList<AppEntry>>, systemLanguage : Int) {
         directory.listFiles().forEach { file ->
             if (file.isDirectory) {
-                addEntries(fileFormats, file, entries)
+                addEntries(fileFormats, file, entries, systemLanguage)
             } else {
                 fileFormats[file.name?.substringAfterLast(".")?.toLowerCase()]?.let { romFormat->
-                    entries.getOrPut(romFormat, { arrayListOf() }).add(RomFile(context, romFormat, file.uri).appEntry)
+                    entries.getOrPut(romFormat, { arrayListOf() }).add(RomFile(context, romFormat, file.uri, systemLanguage).appEntry)
                 }
             }
         }
     }
 
-    fun loadRoms(searchLocation : Uri) = DocumentFile.fromTreeUri(context, searchLocation)!!.let { documentFile ->
+    fun loadRoms(searchLocation : Uri, systemLanguage : Int) = DocumentFile.fromTreeUri(context, searchLocation)!!.let { documentFile ->
         hashMapOf<RomFormat, ArrayList<AppEntry>>().apply {
-            addEntries(mapOf("nro" to NRO, "nso" to NSO, "nca" to NCA, "nsp" to NSP, "xci" to XCI), documentFile, this)
+            addEntries(mapOf("nro" to NRO, "nso" to NSO, "nca" to NCA, "nsp" to NSP, "xci" to XCI), documentFile, this, systemLanguage)
         }
     }
 }

--- a/app/src/main/java/emu/skyline/SettingsActivity.kt
+++ b/app/src/main/java/emu/skyline/SettingsActivity.kt
@@ -9,8 +9,10 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import emu.skyline.databinding.SettingsActivityBinding
+import emu.skyline.preference.IntegerListPreference
 
 class SettingsActivity : AppCompatActivity() {
     val binding by lazy { SettingsActivityBinding.inflate(layoutInflater) }
@@ -45,12 +47,30 @@ class SettingsActivity : AppCompatActivity() {
      * This fragment is used to display all of the preferences
      */
     class PreferenceFragment : PreferenceFragmentCompat() {
+        companion object {
+            private const val DIALOG_FRAGMENT_TAG = "androidx.preference.PreferenceFragment.DIALOG"
+        }
 
         /**
          * This constructs the preferences from [R.xml.preferences]
          */
         override fun onCreatePreferences(savedInstanceState : Bundle?, rootKey : String?) {
             setPreferencesFromResource(R.xml.preferences, rootKey)
+        }
+
+        override fun onDisplayPreferenceDialog(preference : Preference?) {
+            if (preference is IntegerListPreference) {
+                // check if dialog is already showing
+                if (parentFragmentManager.findFragmentByTag(DIALOG_FRAGMENT_TAG) != null) {
+                    return
+                }
+
+                val f = IntegerListPreference.IntegerListPreferenceDialogFragmentCompat.newInstance(preference.getKey())
+                f.setTargetFragment(this, 0)
+                f.show(parentFragmentManager, DIALOG_FRAGMENT_TAG)
+            } else {
+                super.onDisplayPreferenceDialog(preference)
+            }
         }
     }
 

--- a/app/src/main/java/emu/skyline/SettingsActivity.kt
+++ b/app/src/main/java/emu/skyline/SettingsActivity.kt
@@ -60,10 +60,9 @@ class SettingsActivity : AppCompatActivity() {
 
         override fun onDisplayPreferenceDialog(preference : Preference?) {
             if (preference is IntegerListPreference) {
-                // check if dialog is already showing
-                if (parentFragmentManager.findFragmentByTag(DIALOG_FRAGMENT_TAG) != null) {
+                // Check if dialog is already showing
+                if (parentFragmentManager.findFragmentByTag(DIALOG_FRAGMENT_TAG) != null)
                     return
-                }
 
                 val f = IntegerListPreference.IntegerListPreferenceDialogFragmentCompat.newInstance(preference.getKey())
                 f.setTargetFragment(this, 0)

--- a/app/src/main/java/emu/skyline/loader/RomFile.kt
+++ b/app/src/main/java/emu/skyline/loader/RomFile.kt
@@ -103,7 +103,7 @@ data class AppEntry(var name : String, var author : String?, var icon : Bitmap?,
 /**
  * This class is used as interface between libskyline and Kotlin for loaders
  */
-internal class RomFile(context : Context, format : RomFormat, uri : Uri) {
+internal class RomFile(context : Context, format : RomFormat, uri : Uri, systemLanguage : Int) {
     /**
      * @note This field is filled in by native code
      */
@@ -130,7 +130,7 @@ internal class RomFile(context : Context, format : RomFormat, uri : Uri) {
         System.loadLibrary("skyline")
 
         context.contentResolver.openFileDescriptor(uri, "r")!!.use {
-            result = LoaderResult.get(populate(format.ordinal, it.fd, context.filesDir.canonicalPath + "/"))
+            result = LoaderResult.get(populate(format.ordinal, it.fd, context.filesDir.canonicalPath + "/", systemLanguage))
         }
 
         appEntry = applicationName?.let { name ->
@@ -149,5 +149,5 @@ internal class RomFile(context : Context, format : RomFormat, uri : Uri) {
      * @param appFilesPath Path to internal app data storage, needed to read imported keys
      * @return A pointer to the newly allocated object, or 0 if the ROM is invalid
      */
-    private external fun populate(format : Int, romFd : Int, appFilesPath : String) : Int
+    private external fun populate(format : Int, romFd : Int, appFilesPath : String, systemLanguage : Int) : Int
 }

--- a/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ */
+
+package emu.skyline.preference
+
+import java.lang.Exception
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import android.os.Parcelable.Creator
+import android.util.AttributeSet
+import android.content.Context
+import android.content.res.Resources
+import android.content.res.TypedArray
+import android.content.DialogInterface
+import android.annotation.SuppressLint
+import androidx.annotation.ArrayRes
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.res.TypedArrayUtils
+import androidx.preference.R
+import androidx.preference.DialogPreference
+import androidx.preference.PreferenceDialogFragmentCompat
+
+/**
+ * A Preference that displays a list of entries as a dialog.
+ * This preference saves an integer value instead of a string one.
+ * @see androidx.preference.ListPreference
+ */
+@SuppressLint("RestrictedApi", "ResourceType")
+class IntegerListPreference @JvmOverloads constructor(
+    context : Context,
+    attrs : AttributeSet? = null,
+    defStyleAttr : Int = TypedArrayUtils.getAttr(
+        context, R.attr.dialogPreferenceStyle,
+        R.attr.dialogPreferenceStyle
+    ),
+    defStyleRes : Int = 0
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
+    /**
+     * The list of entries to be shown in the list in subsequent dialogs.
+     */
+    var entries : Array<CharSequence>?
+
+    /**
+     * The array to find the value to save for a preference when an entry from entries is
+     * selected. If a user clicks on the second item in entries, the second item in this array
+     * will be saved to the preference.
+     */
+    var entryValues : IntArray?
+
+    private var value : Int? = null
+        set(value) {
+            // Always persist/notify the first time.
+            val changed = field != value
+            if (changed || !isValueSet) {
+                field = value
+                isValueSet = true
+                value?.let { persistInt(it) }
+                if (changed) {
+                    notifyChanged()
+                }
+            }
+        }
+
+    private var isValueSet = false
+
+    init {
+        val res : Resources = context.resources
+        val entryValuesId = attrs!!.getAttributeResourceValue("http://schemas.android.com/apk/res/android", "entryValues", 0)
+
+        var a = context.obtainStyledAttributes(
+            attrs, R.styleable.ListPreference, defStyleAttr, defStyleRes
+        )
+        entries = TypedArrayUtils.getTextArray(
+            a, R.styleable.ListPreference_entries,
+            R.styleable.ListPreference_android_entries
+        )
+        entryValues = try { res.getIntArray(entryValuesId) } catch (e : Exception) { null }
+        if (TypedArrayUtils.getBoolean(
+                a, R.styleable.ListPreference_useSimpleSummaryProvider,
+                R.styleable.ListPreference_useSimpleSummaryProvider, false
+            )
+        ) {
+            summaryProvider = SimpleSummaryProvider.instance
+        }
+        a.recycle()
+
+        //Retrieve the Preference summary attribute since it's private in the Preference class.
+        a = context.obtainStyledAttributes(
+            attrs,
+            R.styleable.Preference, defStyleAttr, defStyleRes
+        )
+        a.recycle()
+    }
+
+    /**
+     * @param entriesResId The entries array as a resource
+     */
+    fun setEntries(@ArrayRes entriesResId : Int) {
+        entries = context.resources.getTextArray(entriesResId)
+    }
+
+    /**
+     * @param entryValuesResId The entry values array as a resource
+     */
+    fun setEntryValues(@ArrayRes entryValuesResId : Int) {
+        entryValues = context.resources.getIntArray(entryValuesResId)
+    }
+
+    /**
+     * @return The entry corresponding to the current value, or `null`
+     */
+    fun getEntry() : CharSequence? {
+        return entries?.getOrNull(getValueIndex())
+    }
+
+    /**
+     * @param value The value whose index should be returned
+     * @return The index of the value, or -1 if not found
+     */
+    private fun findIndexOfValue(value : Int?) : Int {
+        entryValues?.let {
+            if (value != null) {
+                for (i in it.indices.reversed()) {
+                    if (it[i] == value) {
+                        return i
+                    }
+                }
+            }
+        }
+        return value ?: -1
+    }
+
+    /**
+     * Sets the value to the given index from the entry values.
+     * @param index The index of the value to set
+     */
+    fun setValueIndex(index : Int) {
+        value = entryValues?.get(index) ?: index
+    }
+
+    private fun getValueIndex() : Int {
+        return findIndexOfValue(value)
+    }
+
+    override fun onGetDefaultValue(a : TypedArray, index : Int) : Any? {
+        return a.getInt(index, 0)
+    }
+
+    override fun onSetInitialValue(defaultValue : Any?) {
+        // `Preference` superclass passes a null defaultValue if it is sure there
+        // is already a persisted value, se we have to account for that here by
+        // passing a random number as default value.
+        value = if (defaultValue != null) {
+            getPersistedInt(defaultValue as Int)
+        } else {
+            getPersistedInt(0)
+        }
+    }
+
+    override fun onSaveInstanceState() : Parcelable {
+        val superState = super.onSaveInstanceState()
+        if (isPersistent) {
+            // No need to save instance state since it's persistent
+            return superState
+        }
+        val myState = SavedState(superState)
+        myState.value = value
+        return myState
+    }
+
+    override fun onRestoreInstanceState(state : Parcelable?) {
+        if (state == null || state.javaClass != SavedState::class.java) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state)
+            return
+        }
+        val myState = state as SavedState
+        super.onRestoreInstanceState(myState.superState)
+        value = myState.value
+    }
+
+    private class SavedState : BaseSavedState {
+        var value : Int? = null
+
+        constructor(source : Parcel) : super(source) {
+            value = source.readSerializable() as Int?
+        }
+
+        constructor(superState : Parcelable?) : super(superState)
+
+        override fun writeToParcel(dest : Parcel, flags : Int) {
+            super.writeToParcel(dest, flags)
+            dest.writeSerializable(value)
+        }
+
+        companion object {
+            @JvmField
+            val CREATOR : Creator<SavedState> = object : Creator<SavedState> {
+                override fun createFromParcel(input : Parcel) : SavedState? {
+                    return SavedState(input)
+                }
+
+                override fun newArray(size : Int) : Array<SavedState?> {
+                    return arrayOfNulls(size)
+                }
+            }
+        }
+    }
+
+    /**
+     * A simple [androidx.preference.Preference.SummaryProvider] implementation for a
+     * [IntegerListPreference]. If no value has been set, the summary displayed will be 'Not set',
+     * otherwise the summary displayed will be the entry set for this preference.
+     */
+    class SimpleSummaryProvider private constructor() : SummaryProvider<IntegerListPreference> {
+        override fun provideSummary(preference : IntegerListPreference) : CharSequence {
+            return preference.getEntry() ?: preference.context.getString(R.string.not_set)
+        }
+
+        companion object {
+            private var simpleSummaryProvider : SimpleSummaryProvider? = null
+
+            /**
+             * Retrieve a singleton instance of this simple
+             * [androidx.preference.Preference.SummaryProvider] implementation.
+             *
+             * @return a singleton instance of this simple
+             * [androidx.preference.Preference.SummaryProvider] implementation
+             */
+            val instance : SimpleSummaryProvider?
+                get() {
+                    if (simpleSummaryProvider == null) {
+                        simpleSummaryProvider = SimpleSummaryProvider()
+                    }
+                    return simpleSummaryProvider
+                }
+        }
+    }
+
+    class IntegerListPreferenceDialogFragmentCompat : PreferenceDialogFragmentCompat() {
+        var clickedDialogEntryIndex = 0
+        private var entries : Array<CharSequence>? = null
+        private var entryValues : IntArray? = null
+
+        override fun onCreate(savedInstanceState : Bundle?) {
+            super.onCreate(savedInstanceState)
+            if (savedInstanceState == null) {
+                val preference = listPreference
+                check(preference.entries != null) { "IntegerListPreference requires at least the entries array." }
+                clickedDialogEntryIndex = preference.findIndexOfValue(preference.value)
+                entries = preference.entries
+                entryValues = preference.entryValues
+            } else {
+                clickedDialogEntryIndex = savedInstanceState.getInt(SAVE_STATE_INDEX, 0)
+                entries = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRIES)
+                entryValues = savedInstanceState.getIntArray(SAVE_STATE_ENTRY_VALUES)
+            }
+        }
+
+        override fun onSaveInstanceState(outState : Bundle) {
+            super.onSaveInstanceState(outState)
+            outState.putInt(SAVE_STATE_INDEX, clickedDialogEntryIndex)
+            outState.putCharSequenceArray(SAVE_STATE_ENTRIES, entries)
+            outState.putIntArray(SAVE_STATE_ENTRY_VALUES, entryValues)
+        }
+
+        private val listPreference : IntegerListPreference
+            get() = preference as IntegerListPreference
+
+        override fun onPrepareDialogBuilder(builder : AlertDialog.Builder) {
+            super.onPrepareDialogBuilder(builder)
+            builder.setSingleChoiceItems(
+                entries, clickedDialogEntryIndex
+            ) { dialog, which ->
+                clickedDialogEntryIndex = which
+
+                // Clicking on an item simulates the positive button click, and dismisses
+                // the dialog.
+                onClick(
+                    dialog,
+                    DialogInterface.BUTTON_POSITIVE
+                )
+                dialog.dismiss()
+            }
+
+            // The typical interaction for list-based dialogs is to have click-on-an-item dismiss the
+            // dialog instead of the user having to press 'Ok'.
+            builder.setPositiveButton(null, null)
+        }
+
+        override fun onDialogClosed(positiveResult : Boolean) {
+            if (positiveResult && clickedDialogEntryIndex >= 0) {
+                val value = entryValues?.get(clickedDialogEntryIndex) ?: clickedDialogEntryIndex
+                val preference = listPreference
+                if (preference.callChangeListener(value)) {
+                    preference.value = value
+                }
+            }
+        }
+
+        companion object {
+            private const val SAVE_STATE_INDEX = "ListPreferenceDialogFragment.index"
+            private const val SAVE_STATE_ENTRIES = "ListPreferenceDialogFragment.entries"
+            private const val SAVE_STATE_ENTRY_VALUES = "ListPreferenceDialogFragment.entryValues"
+
+            fun newInstance(key : String?) : IntegerListPreferenceDialogFragmentCompat {
+                val fragment = IntegerListPreferenceDialogFragmentCompat()
+                val b = Bundle(1)
+                b.putString(ARG_KEY, key)
+                fragment.arguments = b
+                return fragment
+            }
+        }
+    }
+}

--- a/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
@@ -25,11 +25,10 @@ import emu.skyline.R as sR
 import emu.skyline.di.getSettings
 
 /**
- * A Preference that displays a list of entries as a dialog.
- * This preference saves an integer value instead of a string one.
+ * A Preference that displays a list of strings in a dialog and saves an integer that corresponds to the selected entry (as specified by entryValues or the index of the selected entry)
  * @see androidx.preference.ListPreference
  */
-@SuppressLint("RestrictedApi", "ResourceType")
+@SuppressLint("RestrictedApi")
 class IntegerListPreference @JvmOverloads constructor(
     context : Context,
     attrs : AttributeSet? = null,
@@ -40,28 +39,27 @@ class IntegerListPreference @JvmOverloads constructor(
     defStyleRes : Int = 0
 ) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
     /**
-     * The list of entries to be shown in the list in subsequent dialogs.
+     * The list of entries to be shown in the list in subsequent dialogs
      */
     var entries : Array<CharSequence>?
 
     /**
      * The array to find the value to save for a preference when an entry from entries is
      * selected. If a user clicks on the second item in entries, the second item in this array
-     * will be saved to the preference.
+     * will be saved to the preference
      */
     var entryValues : IntArray?
 
     private var value : Int? = null
         set(value) {
-            // Always persist/notify the first time.
+            // Always persist/notify the first time
             val changed = field != value
             if (changed || !isValueSet) {
                 field = value
                 isValueSet = true
                 value?.let { persistInt(it) }
-                if (changed) {
+                if (changed)
                     notifyChanged()
-                }
             }
         }
 
@@ -70,36 +68,19 @@ class IntegerListPreference @JvmOverloads constructor(
 
     init {
         val res : Resources = context.resources
+        val styledAttrs = context.obtainStyledAttributes(attrs, sR.styleable.IntegerListPreference, defStyleAttr, defStyleRes)
 
-        val a = context.obtainStyledAttributes(
-            attrs, sR.styleable.IntegerListPreference, defStyleAttr, defStyleRes
-        )
+        entries = TypedArrayUtils.getTextArray(styledAttrs, sR.styleable.IntegerListPreference_entries, sR.styleable.IntegerListPreference_android_entries)
 
-        entries = TypedArrayUtils.getTextArray(
-            a, sR.styleable.IntegerListPreference_entries,
-            sR.styleable.IntegerListPreference_android_entries
-        )
-
-        val entryValuesId = TypedArrayUtils.getResourceId(
-            a, sR.styleable.IntegerListPreference_android_entryValues,
-            sR.styleable.IntegerListPreference_android_entryValues, 0
-        )
+        val entryValuesId = TypedArrayUtils.getResourceId(styledAttrs, sR.styleable.IntegerListPreference_android_entryValues, sR.styleable.IntegerListPreference_android_entryValues, 0)
         entryValues = if (entryValuesId != 0) res.getIntArray(entryValuesId) else null
 
-        if (TypedArrayUtils.getBoolean(
-                a, sR.styleable.IntegerListPreference_useSimpleSummaryProvider,
-                sR.styleable.IntegerListPreference_useSimpleSummaryProvider, false
-            )
-        ) {
+        if (TypedArrayUtils.getBoolean(styledAttrs, sR.styleable.IntegerListPreference_useSimpleSummaryProvider, sR.styleable.IntegerListPreference_useSimpleSummaryProvider, false))
             summaryProvider = SimpleSummaryProvider.instance
-        }
 
-        refreshRequired = TypedArrayUtils.getBoolean(
-            a, sR.styleable.IntegerListPreference_refreshRequired,
-            sR.styleable.IntegerListPreference_refreshRequired, false
-        )
+        refreshRequired = TypedArrayUtils.getBoolean(styledAttrs, sR.styleable.IntegerListPreference_refreshRequired, sR.styleable.IntegerListPreference_refreshRequired, false)
 
-        a.recycle()
+        styledAttrs.recycle()
     }
 
     /**
@@ -124,16 +105,14 @@ class IntegerListPreference @JvmOverloads constructor(
     }
 
     /**
-     * @param value The value whose index should be returned
      * @return The index of the value, or -1 if not found
      */
     private fun findIndexOfValue(value : Int?) : Int {
         entryValues?.let {
             if (value != null) {
                 for (i in it.indices.reversed()) {
-                    if (it[i] == value) {
+                    if (it[i] == value)
                         return i
-                    }
                 }
             }
         }
@@ -141,8 +120,7 @@ class IntegerListPreference @JvmOverloads constructor(
     }
 
     /**
-     * Sets the value to the given index from the entry values.
-     * @param index The index of the value to set
+     * Sets the value to the given index from the entry values
      */
     fun setValueIndex(index : Int) {
         value = entryValues?.get(index) ?: index
@@ -157,22 +135,19 @@ class IntegerListPreference @JvmOverloads constructor(
     }
 
     override fun onSetInitialValue(defaultValue : Any?) {
-        // `Preference` superclass passes a null defaultValue if it is sure there
-        // is already a persisted value, se we have to account for that here by
-        // passing a random number as default value.
-        value = if (defaultValue != null) {
+        // `Preference` superclass passes a null defaultValue if it is sure there is already a persisted value
+        // We have to account for that here by passing a random number as default value
+        value = if (defaultValue != null)
             getPersistedInt(defaultValue as Int)
-        } else {
+        else
             getPersistedInt(0)
-        }
     }
 
     override fun onSaveInstanceState() : Parcelable {
         val superState = super.onSaveInstanceState()
-        if (isPersistent) {
+        if (isPersistent)
             // No need to save instance state since it's persistent
             return superState
-        }
         val myState = SavedState(superState)
         myState.value = value
         return myState
@@ -218,9 +193,8 @@ class IntegerListPreference @JvmOverloads constructor(
     }
 
     /**
-     * A simple [androidx.preference.Preference.SummaryProvider] implementation for a
-     * [IntegerListPreference]. If no value has been set, the summary displayed will be 'Not set',
-     * otherwise the summary displayed will be the entry set for this preference.
+     * A simple [androidx.preference.Preference.SummaryProvider] implementation
+     * If no value has been set, the summary displayed will be 'Not set', otherwise the summary displayed will be the entry set for this preference
      */
     class SimpleSummaryProvider private constructor() : SummaryProvider<IntegerListPreference> {
         override fun provideSummary(preference : IntegerListPreference) : CharSequence {
@@ -230,18 +204,10 @@ class IntegerListPreference @JvmOverloads constructor(
         companion object {
             private var simpleSummaryProvider : SimpleSummaryProvider? = null
 
-            /**
-             * Retrieve a singleton instance of this simple
-             * [androidx.preference.Preference.SummaryProvider] implementation.
-             *
-             * @return a singleton instance of this simple
-             * [androidx.preference.Preference.SummaryProvider] implementation
-             */
             val instance : SimpleSummaryProvider?
                 get() {
-                    if (simpleSummaryProvider == null) {
+                    if (simpleSummaryProvider == null)
                         simpleSummaryProvider = SimpleSummaryProvider()
-                    }
                     return simpleSummaryProvider
                 }
         }
@@ -288,17 +254,12 @@ class IntegerListPreference @JvmOverloads constructor(
                         context?.getSettings()?.refreshRequired = true
                 }
 
-                // Clicking on an item simulates the positive button click, and dismisses
-                // the dialog.
-                onClick(
-                    dialog,
-                    DialogInterface.BUTTON_POSITIVE
-                )
+                // Clicking on an item simulates the positive button click, and dismisses the dialog
+                onClick(dialog, DialogInterface.BUTTON_POSITIVE)
                 dialog.dismiss()
             }
 
-            // The typical interaction for list-based dialogs is to have click-on-an-item dismiss the
-            // dialog instead of the user having to press 'Ok'.
+            // The typical interaction for list-based dialogs is to have click-on-an-item dismiss the dialog instead of the user having to press 'Ok'
             builder.setPositiveButton(null, null)
         }
 
@@ -306,9 +267,8 @@ class IntegerListPreference @JvmOverloads constructor(
             if (positiveResult && clickedDialogEntryIndex >= 0) {
                 val value = entryValues?.get(clickedDialogEntryIndex) ?: clickedDialogEntryIndex
                 val preference = listPreference
-                if (preference.callChangeListener(value)) {
+                if (preference.callChangeListener(value))
                     preference.value = value
-                }
             }
         }
 
@@ -319,9 +279,9 @@ class IntegerListPreference @JvmOverloads constructor(
 
             fun newInstance(key : String?) : IntegerListPreferenceDialogFragmentCompat {
                 val fragment = IntegerListPreferenceDialogFragmentCompat()
-                val b = Bundle(1)
-                b.putString(ARG_KEY, key)
-                fragment.arguments = b
+                val bundle = Bundle(1)
+                bundle.putString(ARG_KEY, key)
+                fragment.arguments = bundle
                 return fragment
             }
         }

--- a/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
@@ -22,6 +22,7 @@ import androidx.preference.R
 import androidx.preference.DialogPreference
 import androidx.preference.PreferenceDialogFragmentCompat
 import emu.skyline.R as sR
+import emu.skyline.di.getSettings
 
 /**
  * A Preference that displays a list of entries as a dialog.
@@ -65,6 +66,7 @@ class IntegerListPreference @JvmOverloads constructor(
         }
 
     private var isValueSet = false
+    val refreshRequired : Boolean
 
     init {
         val res : Resources = context.resources
@@ -91,6 +93,12 @@ class IntegerListPreference @JvmOverloads constructor(
         ) {
             summaryProvider = SimpleSummaryProvider.instance
         }
+
+        refreshRequired = TypedArrayUtils.getBoolean(
+            a, sR.styleable.IntegerListPreference_refreshRequired,
+            sR.styleable.IntegerListPreference_refreshRequired, false
+        )
+
         a.recycle()
     }
 
@@ -274,7 +282,11 @@ class IntegerListPreference @JvmOverloads constructor(
             builder.setSingleChoiceItems(
                 entries, clickedDialogEntryIndex
             ) { dialog, which ->
-                clickedDialogEntryIndex = which
+                if (clickedDialogEntryIndex != which) {
+                    clickedDialogEntryIndex = which
+                    if (listPreference.refreshRequired)
+                        context?.getSettings()?.refreshRequired = true
+                }
 
                 // Clicking on an item simulates the positive button click, and dismisses
                 // the dialog.

--- a/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/IntegerListPreference.kt
@@ -5,7 +5,6 @@
 
 package emu.skyline.preference
 
-import java.lang.Exception
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
@@ -22,6 +21,7 @@ import androidx.core.content.res.TypedArrayUtils
 import androidx.preference.R
 import androidx.preference.DialogPreference
 import androidx.preference.PreferenceDialogFragmentCompat
+import emu.skyline.R as sR
 
 /**
  * A Preference that displays a list of entries as a dialog.
@@ -68,30 +68,29 @@ class IntegerListPreference @JvmOverloads constructor(
 
     init {
         val res : Resources = context.resources
-        val entryValuesId = attrs!!.getAttributeResourceValue("http://schemas.android.com/apk/res/android", "entryValues", 0)
 
-        var a = context.obtainStyledAttributes(
-            attrs, R.styleable.ListPreference, defStyleAttr, defStyleRes
+        val a = context.obtainStyledAttributes(
+            attrs, sR.styleable.IntegerListPreference, defStyleAttr, defStyleRes
         )
+
         entries = TypedArrayUtils.getTextArray(
-            a, R.styleable.ListPreference_entries,
-            R.styleable.ListPreference_android_entries
+            a, sR.styleable.IntegerListPreference_entries,
+            sR.styleable.IntegerListPreference_android_entries
         )
-        entryValues = try { res.getIntArray(entryValuesId) } catch (e : Exception) { null }
+
+        val entryValuesId = TypedArrayUtils.getResourceId(
+            a, sR.styleable.IntegerListPreference_android_entryValues,
+            sR.styleable.IntegerListPreference_android_entryValues, 0
+        )
+        entryValues = if (entryValuesId != 0) res.getIntArray(entryValuesId) else null
+
         if (TypedArrayUtils.getBoolean(
-                a, R.styleable.ListPreference_useSimpleSummaryProvider,
-                R.styleable.ListPreference_useSimpleSummaryProvider, false
+                a, sR.styleable.IntegerListPreference_useSimpleSummaryProvider,
+                sR.styleable.IntegerListPreference_useSimpleSummaryProvider, false
             )
         ) {
             summaryProvider = SimpleSummaryProvider.instance
         }
-        a.recycle()
-
-        //Retrieve the Preference summary attribute since it's private in the Preference class.
-        a = context.obtainStyledAttributes(
-            attrs,
-            R.styleable.Preference, defStyleAttr, defStyleRes
-        )
         a.recycle()
     }
 

--- a/app/src/main/java/emu/skyline/utils/Settings.kt
+++ b/app/src/main/java/emu/skyline/utils/Settings.kt
@@ -38,5 +38,5 @@ class Settings @Inject constructor(@ApplicationContext private val context : Con
 
     var maxRefreshRate by sharedPreferences(context, false)
 
-    var systemLanguage by sharedPreferences(context, "1")
+    var systemLanguage by sharedPreferences(context, 1)
 }

--- a/app/src/main/java/emu/skyline/utils/Settings.kt
+++ b/app/src/main/java/emu/skyline/utils/Settings.kt
@@ -37,4 +37,6 @@ class Settings @Inject constructor(@ApplicationContext private val context : Con
     var filter by sharedPreferences(context, 0)
 
     var maxRefreshRate by sharedPreferences(context, false)
+
+    var systemLanguage by sharedPreferences(context, "1")
 }

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -54,24 +54,4 @@
         <item>Traditional Chinese (正體中文)</item>
         <item>Brazilian Portuguese (português do Brasil)</item>
     </string-array>
-    <string-array name="system_lang_values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-        <item>6</item>
-        <item>7</item>
-        <item>8</item>
-        <item>9</item>
-        <item>10</item>
-        <item>11</item>
-        <item>12</item>
-        <item>13</item>
-        <item>14</item>
-        <item>15</item>
-        <item>16</item>
-        <item>17</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -34,4 +34,44 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+    <string-array name="system_languages">
+        <item>Japanese (日本語)</item>
+        <item>English</item>
+        <item>French (français)</item>
+        <item>German (Deutsch)</item>
+        <item>Italian (italiano)</item>
+        <item>Spanish (español)</item>
+        <item>Chinese</item>
+        <item>Korean (한국어)</item>
+        <item>Dutch (Nederlands)</item>
+        <item>Portuguese (português)</item>
+        <item>Russian (Русский)</item>
+        <item>Taiwanese</item>
+        <item>British English</item>
+        <item>Canadian English</item>
+        <item>Latin American Spanish</item>
+        <item>Simplified Chinese</item>
+        <item>Traditional Chinese (正體中文)</item>
+        <item>Brazilian Portuguese (português do Brasil)</item>
+    </string-array>
+    <string-array name="system_lang_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
+        <item>17</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -17,5 +17,7 @@
         <!-- Whether the preference should automatically set its summary to the value saved for the
              preference, and update the summary when the value is changed. Defaults to false. -->
         <attr format="boolean" name="useSimpleSummaryProvider"/>
+        <!-- Whether the preference should request a game list refresh or not. Defaults to false. -->
+        <attr format="boolean" name="refreshRequired"/>
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -4,4 +4,18 @@
         <attr name="limit" format="integer" />
     </declare-styleable>
     <attr name="chipChoiceStyle" format="reference" />
+    <declare-styleable name="IntegerListPreference">
+        <!-- The human-readable array to present as a list. Each entry must have a corresponding
+             index in entryValues. -->
+        <attr format="reference" name="entries"/>
+        <attr name="android:entries"/>
+        <!-- The array to find the value to save for a preference when an entry from
+             entries is selected. If a user clicks on the second item in entries, the
+             second item in this array will be saved to the preference. -->
+        <attr format="reference" name="entryValues"/>
+        <attr name="android:entryValues"/>
+        <!-- Whether the preference should automatically set its summary to the value saved for the
+             preference, and update the summary when the value is changed. Defaults to false. -->
+        <attr format="boolean" name="useSimpleSummaryProvider"/>
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="docked_enabled">The system will emulate being in docked mode</string>
     <string name="username">Username</string>
     <string name="username_default">@string/app_name</string>
+    <string name="system_language">System language</string>
     <!-- Settings - Keys -->
     <string name="keys">Keys</string>
     <string name="prod_keys">Production Keys</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -75,7 +75,6 @@
         <emu.skyline.preference.IntegerListPreference
             android:defaultValue="1"
             android:entries="@array/system_languages"
-            android:entryValues="@array/system_lang_values"
             app:key="system_language"
             app:title="@string/system_language"
             app:useSimpleSummaryProvider="true" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -77,6 +77,7 @@
             android:entries="@array/system_languages"
             app:key="system_language"
             app:title="@string/system_language"
+            app:refreshRequired="true"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,7 +72,7 @@
             app:key="username_value"
             app:limit="31"
             app:title="@string/username" />
-        <ListPreference
+        <emu.skyline.preference.IntegerListPreference
             android:defaultValue="1"
             android:entries="@array/system_languages"
             android:entryValues="@array/system_lang_values"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,6 +72,13 @@
             app:key="username_value"
             app:limit="31"
             app:title="@string/username" />
+        <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/system_languages"
+            android:entryValues="@array/system_lang_values"
+            app:key="system_language"
+            app:title="@string/system_language"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="category_presentation"


### PR DESCRIPTION
Support for switch system languages has been implemented:
- Rom loaders correctly display game title and game icon in the selected language
- `OS` class has now access to the user selected language and it will be used when a game requests the current language

<img height="80%" width="80%" alt="Zelda in different languages" src="https://user-images.githubusercontent.com/37104290/134492601-66c99c16-41e3-48a9-8592-94f69b6405ec.jpg">

A new `System language` setting has been added:

<img height="50%" width="50%" alt="System language setting" src="https://user-images.githubusercontent.com/37104290/134492753-b61b8a23-82f3-4008-a7fe-13d553910786.jpg">

With this PR also comes `IntegerListPreference`, an integer-based implementation of AndroidX `ListPreference`, see commits for a full description.