### PR TITLE
Make Logger class static and introduce `LoggerContext`

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(skyline SHARED
         ${source_DIR}/emu_jni.cpp
         ${source_DIR}/loader_jni.cpp
         ${source_DIR}/skyline/common.cpp
+        ${source_DIR}/skyline/common/logger.cpp
         ${source_DIR}/skyline/common/settings.cpp
         ${source_DIR}/skyline/common/signal.cpp
         ${source_DIR}/skyline/common/uuid.cpp

--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -7,7 +7,6 @@
 #include <android/asset_manager_jni.h>
 #include <sys/system_properties.h>
 #include "skyline/common.h"
-#include "skyline/common/logger.h"
 #include "skyline/common/language.h"
 #include "skyline/common/signal.h"
 #include "skyline/common/settings.h"
@@ -113,15 +112,15 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
         InputWeak = os->state.input;
         jvmManager->InitializeControllers();
 
-        logger->InfoNoPrefix("Launching ROM {}", skyline::JniString(env, romUriJstring));
+        skyline::Logger::InfoNoPrefix("Launching ROM {}", skyline::JniString(env, romUriJstring));
 
         os->Execute(romFd, static_cast<skyline::loader::RomFormat>(romType));
     } catch (std::exception &e) {
-        logger->ErrorNoPrefix("An uncaught exception has occurred: {}", e.what());
+        skyline::Logger::ErrorNoPrefix("An uncaught exception has occurred: {}", e.what());
     } catch (const skyline::signal::SignalException &e) {
-        logger->ErrorNoPrefix("An uncaught exception has occurred: {}", e.what());
+        skyline::Logger::ErrorNoPrefix("An uncaught exception has occurred: {}", e.what());
     } catch (...) {
-        logger->ErrorNoPrefix("An unknown uncaught exception has occurred");
+        skyline::Logger::ErrorNoPrefix("An unknown uncaught exception has occurred");
     }
 
     perfetto::TrackEvent::Flush();
@@ -129,7 +128,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
     InputWeak.reset();
 
     auto end{std::chrono::steady_clock::now()};
-    logger->Write(skyline::Logger::LogLevel::Info, fmt::format("Emulation has ended in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()));
+    skyline::Logger::Write(skyline::Logger::LogLevel::Info, fmt::format("Emulation has ended in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()));
 
     skyline::Logger::EmulationContext.Finalize();
     close(romFd);

--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -62,7 +62,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_SkylineApplication_initializeLog(
 ) {
     std::string appFilesPath{env->GetStringUTFChars(appFilesPathJstring, nullptr)};
     skyline::Logger::configLevel = static_cast<skyline::Logger::LogLevel>(logLevel);
-    skyline::Logger::LoaderContext.Initialize(appFilesPath + "loader.log");
+    skyline::Logger::LoaderContext.Initialize(appFilesPath + "loader.sklog");
 }
 
 extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
@@ -87,7 +87,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
     close(preferenceFd);
 
     skyline::JniString appFilesPath(env, appFilesPathJstring);
-    skyline::Logger::EmulationContext.Initialize(appFilesPath + "emulation.log");
+    skyline::Logger::EmulationContext.Initialize(appFilesPath + "emulation.sklog");
 
     auto start{std::chrono::steady_clock::now()};
 

--- a/app/src/main/cpp/loader_jni.cpp
+++ b/app/src/main/cpp/loader_jni.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include "skyline/common/logger.h"
 #include "skyline/crypto/key_store.h"
 #include "skyline/vfs/nca.h"
 #include "skyline/vfs/os_backing.h"
@@ -13,6 +14,8 @@
 
 extern "C" JNIEXPORT jint JNICALL Java_emu_skyline_loader_RomFile_populate(JNIEnv *env, jobject thiz, jint jformat, jint fd, jstring appFilesPathJstring, jint systemLanguage) {
     skyline::loader::RomFormat format{static_cast<skyline::loader::RomFormat>(jformat)};
+
+    skyline::Logger::SetContext(&skyline::Logger::LoaderContext);
 
     auto keyStore{std::make_shared<skyline::crypto::KeyStore>(skyline::JniString(env, appFilesPathJstring))};
     std::unique_ptr<skyline::loader::Loader> loader;

--- a/app/src/main/cpp/skyline/common.cpp
+++ b/app/src/main/cpp/skyline/common.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
-#include <android/log.h>
 #include "common.h"
 #include "nce.h"
 #include "soc.h"
@@ -11,45 +10,8 @@
 #include "kernel/types/KProcess.h"
 
 namespace skyline {
-    Logger::Logger(const std::string &path, LogLevel configLevel)
-        : configLevel(configLevel),
-          start(util::GetTimeNs() / constant::NsInMillisecond) {
-        logFile.open(path, std::ios::trunc);
-        UpdateTag();
-        Write(LogLevel::Info, "Logging started");
-    }
-
-    Logger::~Logger() {
-        Write(LogLevel::Info, "Logging ended");
-        logFile.flush();
-    }
-
-    thread_local static std::string logTag, threadName;
-
-    void Logger::UpdateTag() {
-        std::array<char, 16> name;
-        if (!pthread_getname_np(pthread_self(), name.data(), name.size()))
-            threadName = name.data();
-        else
-            threadName = "unk";
-        logTag = std::string("emu-cpp-") + threadName;
-    }
-
-    void Logger::Write(LogLevel level, const std::string &str) {
-        constexpr std::array<char, 5> levelCharacter{'E', 'W', 'I', 'D', 'V'}; // The LogLevel as written out to a file
-        constexpr std::array<int, 5> levelAlog{ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_INFO, ANDROID_LOG_DEBUG, ANDROID_LOG_VERBOSE}; // This corresponds to LogLevel and provides its equivalent for NDK Logging
-
-        if (logTag.empty())
-            UpdateTag();
-
-        __android_log_write(levelAlog[static_cast<u8>(level)], logTag.c_str(), str.c_str());
-
-        std::lock_guard guard(mutex);
-        logFile << '\036' << levelCharacter[static_cast<u8>(level)] << '\035' << std::dec << (util::GetTimeNs() / constant::NsInMillisecond) - start << '\035' << threadName << '\035' << str << '\n'; // We use RS (\036) and GS (\035) as our delimiters
-    }
-
-    DeviceState::DeviceState(kernel::OS *os, std::shared_ptr<JvmManager> jvmManager, std::shared_ptr<Settings> settings, std::shared_ptr<Logger> logger)
-        : os(os), jvm(std::move(jvmManager)), settings(std::move(settings)), logger(std::move(logger)) {
+    DeviceState::DeviceState(kernel::OS *os, std::shared_ptr<JvmManager> jvmManager, std::shared_ptr<Settings> settings)
+        : os(os), jvm(std::move(jvmManager)), settings(std::move(settings)) {
         // We assign these later as they use the state in their constructor and we don't want null pointers
         gpu = std::make_shared<gpu::GPU>(*this);
         soc = std::make_shared<soc::SOC>(*this);

--- a/app/src/main/cpp/skyline/common.h
+++ b/app/src/main/cpp/skyline/common.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <list>
 #include <vector>
-#include <fstream>
 #include <mutex>
 #include <shared_mutex>
 #include <functional>
@@ -21,152 +20,6 @@
 #include <common/result.h>
 
 namespace skyline {
-    /**
-     * @brief A wrapper around writing logs into a log file and logcat using Android Log APIs
-     */
-    class Logger {
-      private:
-        std::mutex mutex; //!< Synchronizes all output I/O to ensure there are no races
-        std::ofstream logFile; //!< An output stream to the log file
-        i64 start; //!< A timestamp in milliseconds for when the logger was started, this is used as the base for all log timestamps
-
-      public:
-        enum class LogLevel {
-            Error,
-            Warn,
-            Info,
-            Debug,
-            Verbose,
-        };
-
-        LogLevel configLevel; //!< The minimum level of logs to write
-
-        /**
-         * @param path The path of the log file
-         * @param configLevel The minimum level of logs to write
-         */
-        Logger(const std::string &path, LogLevel configLevel);
-
-        /**
-         * @brief Writes the termination message to the log file
-         */
-        ~Logger();
-
-        /**
-         * @brief Update the tag in log messages with a new thread name
-         */
-        static void UpdateTag();
-
-        void Write(LogLevel level, const std::string &str);
-
-        /**
-         * @brief A wrapper around a string which captures the calling function using Clang source location builtins
-         * @note A function needs to be declared for every argument template specialization as CTAD cannot work with implicit casting
-         * @url https://clang.llvm.org/docs/LanguageExtensions.html#source-location-builtins
-         */
-        template<typename S>
-        struct FunctionString {
-            S string;
-            const char *function;
-
-            constexpr FunctionString(S string, const char *function = __builtin_FUNCTION()) : string(std::move(string)), function(function) {}
-
-            std::string operator*() {
-                return std::string(function) + ": " + std::string(string);
-            }
-        };
-
-        template<typename... Args>
-        void Error(FunctionString<const char*> formatString, Args &&... args) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(*formatString, args...));
-        }
-
-        template<typename... Args>
-        void Error(FunctionString<std::string> formatString, Args &&... args) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        void ErrorNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(formatString, args...));
-        }
-
-        template<typename... Args>
-        void Warn(FunctionString<const char*> formatString, Args &&... args) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(*formatString, args...));
-        }
-
-        template<typename... Args>
-        void Warn(FunctionString<std::string> formatString, Args &&... args) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        void WarnNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(formatString, args...));
-        }
-
-        template<typename... Args>
-        void Info(FunctionString<const char*> formatString, Args &&... args) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(*formatString, args...));
-        }
-
-        template<typename... Args>
-        void Info(FunctionString<std::string> formatString, Args &&... args) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        void InfoNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(formatString, args...));
-        }
-
-        template<typename... Args>
-        void Debug(FunctionString<const char*> formatString, Args &&... args) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(*formatString, args...));
-        }
-
-        template<typename... Args>
-        void Debug(FunctionString<std::string> formatString, Args &&... args) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        void DebugNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(formatString, args...));
-        }
-
-        template<typename... Args>
-        void Verbose(FunctionString<const char*> formatString, Args &&... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(*formatString, args...));
-        }
-
-        template<typename... Args>
-        void Verbose(FunctionString<std::string> formatString, Args &&... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        void VerboseNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(formatString, args...));
-        }
-    };
-
     class Settings;
     namespace nce {
         class NCE;
@@ -201,14 +54,13 @@ namespace skyline {
      * @brief The state of the entire emulator is contained within this class, all objects related to emulation are tied into it
      */
     struct DeviceState {
-        DeviceState(kernel::OS *os, std::shared_ptr<JvmManager> jvmManager, std::shared_ptr<Settings> settings, std::shared_ptr<Logger> logger);
+        DeviceState(kernel::OS *os, std::shared_ptr<JvmManager> jvmManager, std::shared_ptr<Settings> settings);
 
         ~DeviceState();
 
         kernel::OS *os;
         std::shared_ptr<JvmManager> jvm;
         std::shared_ptr<Settings> settings;
-        std::shared_ptr<Logger> logger;
         std::shared_ptr<loader::Loader> loader;
         std::shared_ptr<kernel::type::KProcess> process{};
         static thread_local inline std::shared_ptr<kernel::type::KThread> thread{}; //!< The KThread of the thread which accesses this object

--- a/app/src/main/cpp/skyline/common.h
+++ b/app/src/main/cpp/skyline/common.h
@@ -18,6 +18,7 @@
 #include <boost/container/small_vector.hpp>
 #include <common/span.h>
 #include <common/result.h>
+#include <common/logger.h>
 
 namespace skyline {
     class Settings;

--- a/app/src/main/cpp/skyline/common/base.h
+++ b/app/src/main/cpp/skyline/common/base.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <variant>
+#include <bitset>
 #include <fmt/format.h>
 
 namespace fmt {

--- a/app/src/main/cpp/skyline/common/logger.cpp
+++ b/app/src/main/cpp/skyline/common/logger.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <android/log.h>
+#include "logger.h"
+
+namespace skyline {
+    void Logger::LoggerContext::Initialize(const std::string &path) {
+        start = util::GetTimeNs() / constant::NsInMillisecond;
+        logFile.open(path, std::ios::trunc);
+    }
+
+    void Logger::LoggerContext::Finalize() {
+        logFile.close();
+    }
+
+    void Logger::LoggerContext::Flush() {
+        logFile.flush();
+    }
+
+    thread_local static std::string logTag, threadName;
+    thread_local static Logger::LoggerContext *context{&Logger::EmulationContext};
+
+    void Logger::UpdateTag() {
+        std::array<char, 16> name;
+        if (!pthread_getname_np(pthread_self(), name.data(), name.size()))
+            threadName = name.data();
+        else
+            threadName = "unk";
+        logTag = std::string("emu-cpp-") + threadName;
+    }
+
+    Logger::LoggerContext *Logger::GetContext() {
+        return context;
+    }
+
+    void Logger::SetContext(LoggerContext *pContext) {
+        context = pContext;
+    }
+
+    void Logger::WriteAndroid(LogLevel level, const std::string &str) {
+        constexpr std::array<int, 5> levelAlog{ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_INFO, ANDROID_LOG_DEBUG, ANDROID_LOG_VERBOSE}; // This corresponds to LogLevel and provides its equivalent for NDK Logging
+        if (logTag.empty())
+            UpdateTag();
+
+        __android_log_write(levelAlog[static_cast<u8>(level)], logTag.c_str(), str.c_str());
+    }
+
+    void Logger::Write(LogLevel level, const std::string &str) {
+        constexpr std::array<char, 5> levelCharacter{'E', 'W', 'I', 'D', 'V'}; // The LogLevel as written out to a file
+        WriteAndroid(level, str);
+
+        if (context)
+            // We use RS (\036) and GS (\035) as our delimiters
+            context->Write(fmt::format("\036{}\035{}\035{}\035{}\n", levelCharacter[static_cast<u8>(level)], (util::GetTimeNs() / constant::NsInMillisecond) - context->start, threadName, str));
+    }
+
+    void Logger::LoggerContext::Write(const std::string &str) {
+        std::lock_guard guard(mutex);
+        logFile << str;
+    }
+}

--- a/app/src/main/cpp/skyline/common/logger.cpp
+++ b/app/src/main/cpp/skyline/common/logger.cpp
@@ -2,6 +2,7 @@
 // Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
 #include <android/log.h>
+#include "utils.h"
 #include "logger.h"
 
 namespace skyline {

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <fstream>
+#include <mutex>
+#include "common.h"
+
+namespace skyline {
+    /**
+     * @brief A wrapper around writing logs into a log file and logcat using Android Log APIs
+     */
+    class Logger {
+      private:
+        Logger() {}
+
+      public:
+        enum class LogLevel {
+            Error,
+            Warn,
+            Info,
+            Debug,
+            Verbose,
+        };
+
+        static inline LogLevel configLevel{LogLevel::Verbose}; //!< The minimum level of logs to write
+
+        /**
+         * @brief Holds logger variables that cannot be static
+         */
+        struct LoggerContext {
+            std::mutex mutex; //!< Synchronizes all output I/O to ensure there are no races
+            std::ofstream logFile; //!< An output stream to the log file
+            i64 start; //!< A timestamp in milliseconds for when the logger was started, this is used as the base for all log timestamps
+
+            LoggerContext() {}
+
+            void Initialize(const std::string &path);
+
+            void Finalize();
+
+            void Flush();
+
+            void Write(const std::string &str);
+        };
+        static inline LoggerContext EmulationContext, LoaderContext;
+
+        /**
+         * @brief Update the tag in log messages with a new thread name
+         */
+        static void UpdateTag();
+
+        static LoggerContext *GetContext();
+
+        static void SetContext(LoggerContext *context);
+
+        static void WriteAndroid(LogLevel level, const std::string &str);
+
+        static void Write(LogLevel level, const std::string &str);
+
+        /**
+         * @brief A wrapper around a string which captures the calling function using Clang source location builtins
+         * @note A function needs to be declared for every argument template specialization as CTAD cannot work with implicit casting
+         * @url https://clang.llvm.org/docs/LanguageExtensions.html#source-location-builtins
+         */
+        template<typename S>
+        struct FunctionString {
+            S string;
+            const char *function;
+
+            FunctionString(S string, const char *function = __builtin_FUNCTION()) : string(std::move(string)), function(function) {}
+
+            std::string operator*() {
+                return std::string(function) + ": " + std::string(string);
+            }
+        };
+
+        template<typename... Args>
+        static void Error(FunctionString<const char *> formatString, Args &&... args) {
+            if (LogLevel::Error <= configLevel)
+                Write(LogLevel::Error, util::Format(*formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Error(FunctionString<std::string> formatString, Args &&... args) {
+            if (LogLevel::Error <= configLevel)
+                Write(LogLevel::Error, util::Format(*formatString, args...));
+        }
+
+        template<typename S, typename... Args>
+        static void ErrorNoPrefix(S formatString, Args &&... args) {
+            if (LogLevel::Error <= configLevel)
+                Write(LogLevel::Error, util::Format(formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Warn(FunctionString<const char *> formatString, Args &&... args) {
+            if (LogLevel::Warn <= configLevel)
+                Write(LogLevel::Warn, util::Format(*formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Warn(FunctionString<std::string> formatString, Args &&... args) {
+            if (LogLevel::Warn <= configLevel)
+                Write(LogLevel::Warn, util::Format(*formatString, args...));
+        }
+
+        template<typename S, typename... Args>
+        static void WarnNoPrefix(S formatString, Args &&... args) {
+            if (LogLevel::Warn <= configLevel)
+                Write(LogLevel::Warn, util::Format(formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Info(FunctionString<const char *> formatString, Args &&... args) {
+            if (LogLevel::Info <= configLevel)
+                Write(LogLevel::Info, util::Format(*formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Info(FunctionString<std::string> formatString, Args &&... args) {
+            if (LogLevel::Info <= configLevel)
+                Write(LogLevel::Info, util::Format(*formatString, args...));
+        }
+
+        template<typename S, typename... Args>
+        static void InfoNoPrefix(S formatString, Args &&... args) {
+            if (LogLevel::Info <= configLevel)
+                Write(LogLevel::Info, util::Format(formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Debug(FunctionString<const char *> formatString, Args &&... args) {
+            if (LogLevel::Debug <= configLevel)
+                Write(LogLevel::Debug, util::Format(*formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Debug(FunctionString<std::string> formatString, Args &&... args) {
+            if (LogLevel::Debug <= configLevel)
+                Write(LogLevel::Debug, util::Format(*formatString, args...));
+        }
+
+        template<typename S, typename... Args>
+        static void DebugNoPrefix(S formatString, Args &&... args) {
+            if (LogLevel::Debug <= configLevel)
+                Write(LogLevel::Debug, util::Format(formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Verbose(FunctionString<const char *> formatString, Args &&... args) {
+            if (LogLevel::Verbose <= configLevel)
+                Write(LogLevel::Verbose, util::Format(*formatString, args...));
+        }
+
+        template<typename... Args>
+        static void Verbose(FunctionString<std::string> formatString, Args &&... args) {
+            if (LogLevel::Verbose <= configLevel)
+                Write(LogLevel::Verbose, util::Format(*formatString, args...));
+        }
+
+        template<typename S, typename... Args>
+        static void VerboseNoPrefix(S formatString, Args &&... args) {
+            if (LogLevel::Verbose <= configLevel)
+                Write(LogLevel::Verbose, util::Format(formatString, args...));
+        }
+    };
+}

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -5,7 +5,7 @@
 
 #include <fstream>
 #include <mutex>
-#include "common.h"
+#include "base.h"
 
 namespace skyline {
     /**

--- a/app/src/main/cpp/skyline/common/utils.h
+++ b/app/src/main/cpp/skyline/common/utils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <random>
+#include <span>
 #include <frozen/unordered_map.h>
 #include <frozen/string.h>
 #include "base.h"

--- a/app/src/main/cpp/skyline/gpu.h
+++ b/app/src/main/cpp/skyline/gpu.h
@@ -16,13 +16,13 @@ namespace skyline::gpu {
       private:
         static vk::raii::Instance CreateInstance(const DeviceState &state, const vk::raii::Context &context);
 
-        static vk::raii::DebugReportCallbackEXT CreateDebugReportCallback(const DeviceState &state, const vk::raii::Instance &instance);
+        static vk::raii::DebugReportCallbackEXT CreateDebugReportCallback(const vk::raii::Instance &instance);
 
-        static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location, int32_t messageCode, const char *layerPrefix, const char *message, Logger *logger);
+        static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location, int32_t messageCode, const char *layerPrefix, const char *message);
 
-        static vk::raii::PhysicalDevice CreatePhysicalDevice(const DeviceState &state, const vk::raii::Instance &instance);
+        static vk::raii::PhysicalDevice CreatePhysicalDevice(const vk::raii::Instance &instance);
 
-        static vk::raii::Device CreateDevice(const DeviceState &state, const vk::raii::PhysicalDevice &physicalDevice, typeof(vk::DeviceQueueCreateInfo::queueCount)& queueConfiguration);
+        static vk::raii::Device CreateDevice(const vk::raii::PhysicalDevice &physicalDevice, typeof(vk::DeviceQueueCreateInfo::queueCount)& queueConfiguration);
 
       public:
         static constexpr u32 VkApiVersion{VK_API_VERSION_1_1}; //!< The version of core Vulkan that we require

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -72,13 +72,13 @@ namespace skyline::gpu {
             AChoreographer_postFrameCallback64(AChoreographer_getInstance(), reinterpret_cast<AChoreographer_frameCallback64>(&ChoreographerCallback), this);
             while (ALooper_pollAll(-1, nullptr, nullptr, nullptr) == ALOOPER_POLL_WAKE && !choreographerStop); // Will block and process callbacks till ALooper_wake() is called with choreographerStop set
         } catch (const signal::SignalException &e) {
-            state.logger->Error("{}\nStack Trace:{}", e.what(), state.loader->GetStackTrace(e.frames));
+            Logger::Error("{}\nStack Trace:{}", e.what(), state.loader->GetStackTrace(e.frames));
             if (state.process)
                 state.process->Kill(false);
             else
                 std::rethrow_exception(std::current_exception());
         } catch (const std::exception &e) {
-            state.logger->Error(e.what());
+            Logger::Error(e.what());
             if (state.process)
                 state.process->Kill(false);
             else

--- a/app/src/main/cpp/skyline/kernel/ipc.cpp
+++ b/app/src/main/cpp/skyline/kernel/ipc.cpp
@@ -29,7 +29,7 @@ namespace skyline::kernel::ipc {
             auto bufX{reinterpret_cast<BufferDescriptorX *>(pointer)};
             if (bufX->Pointer()) {
                 inputBuf.emplace_back(bufX->Pointer(), static_cast<u16>(bufX->size));
-                state.logger->Verbose("Buf X #{}: 0x{:X}, 0x{:X}, #{}", index, bufX->Pointer(), static_cast<u16>(bufX->size), static_cast<u16>(bufX->Counter()));
+                Logger::Verbose("Buf X #{}: 0x{:X}, 0x{:X}, #{}", index, bufX->Pointer(), static_cast<u16>(bufX->size), static_cast<u16>(bufX->Counter()));
             }
             pointer += sizeof(BufferDescriptorX);
         }
@@ -38,7 +38,7 @@ namespace skyline::kernel::ipc {
             auto bufA{reinterpret_cast<BufferDescriptorABW *>(pointer)};
             if (bufA->Pointer()) {
                 inputBuf.emplace_back(bufA->Pointer(), bufA->Size());
-                state.logger->Verbose("Buf A #{}: 0x{:X}, 0x{:X}", index, bufA->Pointer(), static_cast<u64>(bufA->Size()));
+                Logger::Verbose("Buf A #{}: 0x{:X}, 0x{:X}", index, bufA->Pointer(), static_cast<u64>(bufA->Size()));
             }
             pointer += sizeof(BufferDescriptorABW);
         }
@@ -47,7 +47,7 @@ namespace skyline::kernel::ipc {
             auto bufB{reinterpret_cast<BufferDescriptorABW *>(pointer)};
             if (bufB->Pointer()) {
                 outputBuf.emplace_back(bufB->Pointer(), bufB->Size());
-                state.logger->Verbose("Buf B #{}: 0x{:X}, 0x{:X}", index, bufB->Pointer(), static_cast<u64>(bufB->Size()));
+                Logger::Verbose("Buf B #{}: 0x{:X}, 0x{:X}", index, bufB->Pointer(), static_cast<u64>(bufB->Size()));
             }
             pointer += sizeof(BufferDescriptorABW);
         }
@@ -57,7 +57,7 @@ namespace skyline::kernel::ipc {
             if (bufW->Pointer()) {
                 outputBuf.emplace_back(bufW->Pointer(), bufW->Size());
                 outputBuf.emplace_back(bufW->Pointer(), bufW->Size());
-                state.logger->Verbose("Buf W #{}: 0x{:X}, 0x{:X}", index, bufW->Pointer(), static_cast<u16>(bufW->Size()));
+                Logger::Verbose("Buf W #{}: 0x{:X}, 0x{:X}", index, bufW->Pointer(), static_cast<u16>(bufW->Size()));
             }
             pointer += sizeof(BufferDescriptorABW);
         }
@@ -94,33 +94,33 @@ namespace skyline::kernel::ipc {
         payloadOffset = cmdArg;
 
         if (payload->magic != util::MakeMagic<u32>("SFCI") && (header->type != CommandType::Control && header->type != CommandType::ControlWithContext && header->type != CommandType::Close) && (!domain || domain->command != DomainCommand::CloseVHandle)) // SFCI is the magic in received IPC messages
-            state.logger->Debug("Unexpected Magic in PayloadHeader: 0x{:X}", static_cast<u32>(payload->magic));
+            Logger::Debug("Unexpected Magic in PayloadHeader: 0x{:X}", static_cast<u32>(payload->magic));
 
 
         if (header->cFlag == BufferCFlag::SingleDescriptor) {
             auto bufC{reinterpret_cast<BufferDescriptorC *>(bufCPointer)};
             if (bufC->address) {
                 outputBuf.emplace_back(bufC->Pointer(), static_cast<u16>(bufC->size));
-                state.logger->Verbose("Buf C: 0x{:X}, 0x{:X}", bufC->Pointer(), static_cast<u16>(bufC->size));
+                Logger::Verbose("Buf C: 0x{:X}, 0x{:X}", bufC->Pointer(), static_cast<u16>(bufC->size));
             }
         } else if (header->cFlag > BufferCFlag::SingleDescriptor) {
             for (u8 index{}; (static_cast<u8>(header->cFlag) - 2) > index; index++) { // (cFlag - 2) C descriptors are present
                 auto bufC{reinterpret_cast<BufferDescriptorC *>(bufCPointer)};
                 if (bufC->address) {
                     outputBuf.emplace_back(bufC->Pointer(), static_cast<u16>(bufC->size));
-                    state.logger->Verbose("Buf C #{}: 0x{:X}, 0x{:X}", index, bufC->Pointer(), static_cast<u16>(bufC->size));
+                    Logger::Verbose("Buf C #{}: 0x{:X}, 0x{:X}", index, bufC->Pointer(), static_cast<u16>(bufC->size));
                 }
                 bufCPointer += sizeof(BufferDescriptorC);
             }
         }
 
         if (header->type == CommandType::Request || header->type == CommandType::RequestWithContext) {
-            state.logger->Verbose("Header: Input No: {}, Output No: {}, Raw Size: {}", inputBuf.size(), outputBuf.size(), static_cast<u64>(cmdArgSz));
+            Logger::Verbose("Header: Input No: {}, Output No: {}, Raw Size: {}", inputBuf.size(), outputBuf.size(), static_cast<u64>(cmdArgSz));
             if (header->handleDesc)
-                state.logger->Verbose("Handle Descriptor: Send PID: {}, Copy Count: {}, Move Count: {}", static_cast<bool>(handleDesc->sendPid), static_cast<u32>(handleDesc->copyCount), static_cast<u32>(handleDesc->moveCount));
+                Logger::Verbose("Handle Descriptor: Send PID: {}, Copy Count: {}, Move Count: {}", static_cast<bool>(handleDesc->sendPid), static_cast<u32>(handleDesc->copyCount), static_cast<u32>(handleDesc->moveCount));
             if (isDomain)
-                state.logger->Verbose("Domain Header: Command: {}, Input Object Count: {}, Object ID: 0x{:X}", domain->command, domain->inputCount, domain->objectId);
-            state.logger->Verbose("Command ID: 0x{:X}", static_cast<u32>(payload->value));
+                Logger::Verbose("Domain Header: Command: {}, Input Object Count: {}, Object ID: 0x{:X}", domain->command, domain->inputCount, domain->objectId);
+            Logger::Verbose("Command ID: 0x{:X}", static_cast<u32>(payload->value));
         }
     }
 
@@ -181,6 +181,6 @@ namespace skyline::kernel::ipc {
             }
         }
 
-        state.logger->Verbose("Output: Raw Size: {}, Result: 0x{:X}, Copy Handles: {}, Move Handles: {}", static_cast<u32>(header->rawSize), static_cast<u32>(payloadHeader->value), copyHandles.size(), moveHandles.size());
+        Logger::Verbose("Output: Raw Size: {}, Result: 0x{:X}, Copy Handles: {}, Move Handles: {}", static_cast<u32>(header->rawSize), static_cast<u32>(payloadHeader->value), copyHandles.size(), moveHandles.size());
     }
 }

--- a/app/src/main/cpp/skyline/kernel/memory.cpp
+++ b/app/src/main/cpp/skyline/kernel/memory.cpp
@@ -131,7 +131,7 @@ namespace skyline::kernel {
         if (size > code.size)
             throw exception("Code region ({}) is smaller than mapped code size ({})", code.size, size);
 
-        state.logger->Debug("Region Map:\nVMM Base: 0x{:X}\nCode Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nAlias Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nHeap Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nStack Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nTLS/IO Region: 0x{:X} - 0x{:X} (Size: 0x{:X})", base.address, code.address, code.address + code.size, code.size, alias.address, alias.address + alias.size, alias.size, heap.address, heap
+        Logger::Debug("Region Map:\nVMM Base: 0x{:X}\nCode Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nAlias Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nHeap Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nStack Region: 0x{:X} - 0x{:X} (Size: 0x{:X})\nTLS/IO Region: 0x{:X} - 0x{:X} (Size: 0x{:X})", base.address, code.address, code.address + code.size, code.size, alias.address, alias.address + alias.size, alias.size, heap.address, heap
             .address + heap.size, heap.size, stack.address, stack.address + stack.size, stack.size, tlsIo.address, tlsIo.address + tlsIo.size, tlsIo.size);
     }
 

--- a/app/src/main/cpp/skyline/kernel/scheduler.cpp
+++ b/app/src/main/cpp/skyline/kernel/scheduler.cpp
@@ -70,14 +70,14 @@ namespace skyline::kernel {
             }
 
             if (optimalCore != currentCore)
-                state.logger->Debug("Load Balancing T{}: C{} -> C{}", thread->id, currentCore->id, optimalCore->id);
+                Logger::Debug("Load Balancing T{}: C{} -> C{}", thread->id, currentCore->id, optimalCore->id);
             else
-                state.logger->Debug("Load Balancing T{}: C{} (Late)", thread->id, currentCore->id);
+                Logger::Debug("Load Balancing T{}: C{} (Late)", thread->id, currentCore->id);
 
             return *optimalCore;
         }
 
-        state.logger->Debug("Load Balancing T{}: C{} (Early)", thread->id, currentCore->id);
+        Logger::Debug("Load Balancing T{}: C{} (Early)", thread->id, currentCore->id);
 
         return *currentCore;
     }

--- a/app/src/main/cpp/skyline/kernel/types/KSharedMemory.cpp
+++ b/app/src/main/cpp/skyline/kernel/types/KSharedMemory.cpp
@@ -102,9 +102,9 @@ namespace skyline::kernel::type {
                 constexpr memory::Permission UnborrowPermission{true, true, false};
 
                 if (mmap(guest.ptr, guest.size, UnborrowPermission.Get(), MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0) == MAP_FAILED)
-                    state.logger->Warn("An error occurred while remapping transfer memory as anonymous memory in guest: {}", strerror(errno));
+                    Logger::Warn("An error occurred while remapping transfer memory as anonymous memory in guest: {}", strerror(errno));
                 else if (!host.Valid())
-                    state.logger->Warn("Expected host mapping of transfer memory to be valid during KTransferMemory destruction");
+                    Logger::Warn("Expected host mapping of transfer memory to be valid during KTransferMemory destruction");
 
                 std::memcpy(guest.ptr, host.ptr, host.size);
 

--- a/app/src/main/cpp/skyline/kernel/types/KThread.cpp
+++ b/app/src/main/cpp/skyline/kernel/types/KThread.cpp
@@ -38,7 +38,7 @@ namespace skyline::kernel::type {
         std::array<char, 16> threadName;
         pthread_getname_np(pthread, threadName.data(), threadName.size());
         pthread_setname_np(pthread, fmt::format("HOS-{}", id).c_str());
-        state.logger->UpdateTag();
+        Logger::UpdateTag();
 
         if (!ctx.tpidrroEl0)
             ctx.tpidrroEl0 = parent->AllocateTlsSlot();
@@ -61,7 +61,7 @@ namespace skyline::kernel::type {
 
             if (threadName[0] != 'H' || threadName[1] != 'O' || threadName[2] != 'S' || threadName[3] != '-') {
                 pthread_setname_np(pthread, threadName.data());
-                state.logger->UpdateTag();
+                Logger::UpdateTag();
             }
 
             return;
@@ -176,7 +176,7 @@ namespace skyline::kernel::type {
 
             __builtin_unreachable();
         } catch (const std::exception &e) {
-            state.logger->Error(e.what());
+            Logger::Error(e.what());
             if (id) {
                 signal::BlockSignal({SIGINT});
                 state.process->Kill(false);
@@ -185,7 +185,7 @@ namespace skyline::kernel::type {
             std::longjmp(originalCtx, true);
         } catch (const signal::SignalException &e) {
             if (e.signal != SIGINT) {
-                state.logger->Error(e.what());
+                Logger::Error(e.what());
                 if (id) {
                     signal::BlockSignal({SIGINT});
                     state.process->Kill(false);

--- a/app/src/main/cpp/skyline/loader/loader.cpp
+++ b/app/src/main/cpp/skyline/loader/loader.cpp
@@ -27,16 +27,16 @@ namespace skyline::loader {
         auto size{patch.size + textSize + roSize + dataSize};
 
         process->NewHandle<kernel::type::KPrivateMemory>(base, patch.size, memory::Permission{false, false, false}, memory::states::Reserved); // ---
-        state.logger->Debug("Successfully mapped section .patch @ 0x{:X}, Size = 0x{:X}", base, patch.size);
+        Logger::Debug("Successfully mapped section .patch @ 0x{:X}, Size = 0x{:X}", base, patch.size);
 
         process->NewHandle<kernel::type::KPrivateMemory>(base + patch.size + executable.text.offset, textSize, memory::Permission{true, false, true}, memory::states::CodeStatic); // R-X
-        state.logger->Debug("Successfully mapped section .text @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.text.offset, textSize);
+        Logger::Debug("Successfully mapped section .text @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.text.offset, textSize);
 
         process->NewHandle<kernel::type::KPrivateMemory>(base + patch.size + executable.ro.offset, roSize, memory::Permission{true, false, false}, memory::states::CodeStatic); // R--
-        state.logger->Debug("Successfully mapped section .rodata @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.ro.offset, roSize);
+        Logger::Debug("Successfully mapped section .rodata @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.ro.offset, roSize);
 
         process->NewHandle<kernel::type::KPrivateMemory>(base + patch.size + executable.data.offset, dataSize, memory::Permission{true, true, false}, memory::states::CodeMutable); // RW-
-        state.logger->Debug("Successfully mapped section .data + .bss @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.data.offset, dataSize);
+        Logger::Debug("Successfully mapped section .data + .bss @ 0x{:X}, Size = 0x{:X}", base + patch.size + executable.data.offset, dataSize);
 
         state.nce->PatchCode(executable.text.contents, reinterpret_cast<u32 *>(base), patch.size, patch.offsets);
         std::memcpy(base + patch.size + executable.text.offset, executable.text.contents.data(), textSize);

--- a/app/src/main/cpp/skyline/loader/nca.cpp
+++ b/app/src/main/cpp/skyline/loader/nca.cpp
@@ -28,7 +28,7 @@ namespace skyline::loader {
         u8 *base{loadInfo.base};
         void *entry{loadInfo.entry};
 
-        state.logger->Info("Loaded 'rtld.nso' at 0x{:X} (.text @ 0x{:X})", base, entry);
+        Logger::Info("Loaded 'rtld.nso' at 0x{:X} (.text @ 0x{:X})", base, entry);
 
         for (const auto &nso : {"main", "subsdk0", "subsdk1", "subsdk2", "subsdk3", "subsdk4", "subsdk5", "subsdk6", "subsdk7", "sdk"}) {
             if (exeFs->FileExists(nso))
@@ -37,7 +37,7 @@ namespace skyline::loader {
                 continue;
 
             loadInfo = NsoLoader::LoadNso(loader, nsoFile, process, state, offset, nso + std::string(".nso"));
-            state.logger->Info("Loaded '{}.nso' at 0x{:X} (.text @ 0x{:X})", nso, base + offset, loadInfo.entry);
+            Logger::Info("Loaded '{}.nso' at 0x{:X} (.text @ 0x{:X})", nso, base + offset, loadInfo.entry);
             offset += loadInfo.size;
         }
 
@@ -47,7 +47,7 @@ namespace skyline::loader {
     }
 
     void *NcaLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) {
-        process->npdm = vfs::NPDM(nca.exeFs->OpenFile("main.npdm"), state);
+        process->npdm = vfs::NPDM(nca.exeFs->OpenFile("main.npdm"));
         return LoadExeFs(this, nca.exeFs, process, state);
     }
 }

--- a/app/src/main/cpp/skyline/loader/nsp.cpp
+++ b/app/src/main/cpp/skyline/loader/nsp.cpp
@@ -53,7 +53,7 @@ namespace skyline::loader {
     }
 
     void *NspLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) {
-        process->npdm = vfs::NPDM(programNca->exeFs->OpenFile("main.npdm"), state);
+        process->npdm = vfs::NPDM(programNca->exeFs->OpenFile("main.npdm"));
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 

--- a/app/src/main/cpp/skyline/loader/xci.cpp
+++ b/app/src/main/cpp/skyline/loader/xci.cpp
@@ -61,7 +61,7 @@ namespace skyline::loader {
     }
 
     void *XciLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) {
-        process->npdm = vfs::NPDM(programNca->exeFs->OpenFile("main.npdm"), state);
+        process->npdm = vfs::NPDM(programNca->exeFs->OpenFile("main.npdm"));
         return NcaLoader::LoadExeFs(this, programNca->exeFs, process, state);
     }
 

--- a/app/src/main/cpp/skyline/nce.cpp
+++ b/app/src/main/cpp/skyline/nce.cpp
@@ -40,7 +40,7 @@ namespace skyline::nce {
             }
         } catch (const signal::SignalException &e) {
             if (e.signal != SIGINT) {
-                state.logger->ErrorNoPrefix("{} (SVC: {})\nStack Trace:{}", e.what(), svc.name, state.loader->GetStackTrace(e.frames));
+                Logger::ErrorNoPrefix("{} (SVC: {})\nStack Trace:{}", e.what(), svc.name, state.loader->GetStackTrace(e.frames));
                 if (state.thread->id) {
                     signal::BlockSignal({SIGINT});
                     state.process->Kill(false);
@@ -56,9 +56,9 @@ namespace skyline::nce {
             std::longjmp(state.thread->originalCtx, true);
         } catch (const std::exception &e) {
             if (svc)
-                state.logger->ErrorNoPrefix("{} (SVC: {})\nStack Trace:{}", e.what(), svc.name, state.loader->GetStackTrace());
+                Logger::ErrorNoPrefix("{} (SVC: {})\nStack Trace:{}", e.what(), svc.name, state.loader->GetStackTrace());
             else
-                state.logger->ErrorNoPrefix("{} (SVC: 0x{:X})\nStack Trace:{}", e.what(), svcId, state.loader->GetStackTrace());
+                Logger::ErrorNoPrefix("{} (SVC: 0x{:X})\nStack Trace:{}", e.what(), svcId, state.loader->GetStackTrace());
 
             if (state.thread->id) {
                 signal::BlockSignal({SIGINT});
@@ -87,7 +87,7 @@ namespace skyline::nce {
                 for (u8 index{}; index < (sizeof(mcontext_t::regs) / sizeof(u64)); index += 2)
                     cpuContext += fmt::format("\n  X{:<2}: 0x{:<16X} X{:<2}: 0x{:X}", index, mctx.regs[index], index + 1, mctx.regs[index + 1]);
 
-                state.logger->Error("Thread #{} has crashed due to signal: {}\nStack Trace:{}\nCPU Context:{}", state.thread->id, strsignal(signal), trace, cpuContext);
+                Logger::Error("Thread #{} has crashed due to signal: {}\nStack Trace:{}\nCPU Context:{}", state.thread->id, strsignal(signal), trace, cpuContext);
 
                 if (state.thread->id) {
                     signal::BlockSignal({SIGINT});

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -15,13 +15,12 @@
 namespace skyline::kernel {
     OS::OS(
         std::shared_ptr<JvmManager> &jvmManager,
-        std::shared_ptr<Logger> &logger,
         std::shared_ptr<Settings> &settings,
         std::string appFilesPath,
         std::string deviceTimeZone,
         language::SystemLanguage systemLanguage,
         std::shared_ptr<vfs::FileSystem> assetFileSystem)
-        : state(this, jvmManager, settings, logger),
+        : state(this, jvmManager, settings),
           appFilesPath(std::move(appFilesPath)),
           deviceTimeZone(std::move(deviceTimeZone)),
           assetFileSystem(std::move(assetFileSystem)),

--- a/app/src/main/cpp/skyline/os.cpp
+++ b/app/src/main/cpp/skyline/os.cpp
@@ -54,7 +54,7 @@ namespace skyline::kernel {
         process->InitializeHeapTls();
         auto thread{process->CreateThread(entry)};
         if (thread) {
-            state.logger->Debug("Starting main HOS thread");
+            Logger::Debug("Starting main HOS thread");
             thread->Start(true);
             process->Kill(true, true, true);
         }

--- a/app/src/main/cpp/skyline/os.h
+++ b/app/src/main/cpp/skyline/os.h
@@ -22,13 +22,11 @@ namespace skyline::kernel {
         language::SystemLanguage systemLanguage;
 
         /**
-         * @param logger An instance of the Logger class
          * @param settings An instance of the Settings class
          * @param window The ANativeWindow object to draw the screen to
          */
         OS(
             std::shared_ptr<JvmManager> &jvmManager,
-            std::shared_ptr<Logger> &logger,
             std::shared_ptr<Settings> &settings,
             std::string appFilesPath,
             std::string deviceTimeZone,

--- a/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
+++ b/app/src/main/cpp/skyline/services/am/applet/ILibraryAppletAccessor.cpp
@@ -13,7 +13,7 @@ namespace skyline::service::am {
         stateChangeEvent->Signal();
 
         KHandle handle{state.process->InsertItem(stateChangeEvent)};
-        state.logger->Debug("Applet State Change Event Handle: 0x{:X}", handle);
+        Logger::Debug("Applet State Change Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
         return {};

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -103,7 +103,7 @@ namespace skyline::service::am {
         if (width > MaximumFbWidth || height > MaximumFbHeight || !util::IsAligned(transferMemorySize, RequiredFbAlignment))
             return result::InvalidParameters;
 
-        state.logger->Debug("Dimensions: ({}, {}) Transfer Memory Size: {}", width, height, transferMemorySize);
+        Logger::Debug("Dimensions: ({}, {}) Transfer Memory Size: {}", width, height, transferMemorySize);
 
         return {};
     }
@@ -122,19 +122,19 @@ namespace skyline::service::am {
         if (y < 0 || x < 0 || width < 1 || height < 1)
             return result::InvalidParameters;
 
-        state.logger->Debug("Position: ({}, {}) Dimensions: ({}, {}) Origin mode: {}", x, y, width, height, static_cast<i32>(originMode));
+        Logger::Debug("Position: ({}, {}) Dimensions: ({}, {}) Origin mode: {}", x, y, width, height, static_cast<i32>(originMode));
         return {};
     }
 
     Result IApplicationFunctions::SetApplicationCopyrightVisibility(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         u8 visiblity{request.Pop<u8>()};
-        state.logger->Debug("Visiblity: {}", visiblity);
+        Logger::Debug("Visiblity: {}", visiblity);
         return {};
     }
 
     Result IApplicationFunctions::GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(gpuErrorEvent)};
-        state.logger->Debug("GPU Error Event Handle: 0x{:X}", handle);
+        Logger::Debug("GPU Error Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
@@ -13,13 +13,13 @@ namespace skyline::service::am {
 
     ICommonStateGetter::ICommonStateGetter(const DeviceState &state, ServiceManager &manager) : messageEvent(std::make_shared<type::KEvent>(state, false)), BaseService(state, manager) {
         operationMode = static_cast<OperationMode>(state.settings->operationMode);
-        state.logger->Info("Switch to mode: {}", static_cast<bool>(operationMode) ? "Docked" : "Handheld");
+        Logger::Info("Switch to mode: {}", static_cast<bool>(operationMode) ? "Docked" : "Handheld");
         QueueMessage(Message::FocusStateChange);
     }
 
     Result ICommonStateGetter::GetEventHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(messageEvent)};
-        state.logger->Debug("Applet Event Handle: 0x{:X}", handle);
+        Logger::Debug("Applet Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
@@ -29,7 +29,7 @@ namespace skyline::service::am {
         libraryAppletLaunchableEvent->Signal();
 
         KHandle handle{state.process->InsertItem(libraryAppletLaunchableEvent)};
-        state.logger->Debug("Library Applet Launchable Event Handle: 0x{:X}", handle);
+        Logger::Debug("Library Applet Launchable Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
         return {};
@@ -57,7 +57,7 @@ namespace skyline::service::am {
 
     Result ISelfController::CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId{hosbinder->CreateLayer(hosbinder::DisplayId::Default)};
-        state.logger->Debug("Creating Managed Layer #{} on 'Default' Display", layerId);
+        Logger::Debug("Creating Managed Layer #{} on 'Default' Display", layerId);
         response.Push(layerId);
         return {};
     }
@@ -70,7 +70,7 @@ namespace skyline::service::am {
 
     Result ISelfController::GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(accumulatedSuspendedTickChangedEvent)};
-        state.logger->Debug("Accumulated Suspended Tick Event Handle: 0x{:X}", handle);
+        Logger::Debug("Accumulated Suspended Tick Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
         return {};

--- a/app/src/main/cpp/skyline/services/apm/ISession.cpp
+++ b/app/src/main/cpp/skyline/services/apm/ISession.cpp
@@ -10,7 +10,7 @@ namespace skyline::service::apm {
         auto mode{request.Pop<u32>()};
         auto config{request.Pop<u32>()};
         performanceConfig.at(mode) = config;
-        state.logger->Info("Performance configuration set to 0x{:X} ({})", config, mode ? "Docked" : "Handheld");
+        Logger::Info("Performance configuration set to 0x{:X} ({})", config, mode ? "Docked" : "Handheld");
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioDevice.cpp
@@ -35,7 +35,7 @@ namespace skyline::service::audio {
 
     Result IAudioDevice::QueryAudioDeviceSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(systemEvent)};
-        state.logger->Debug("Audio Device System Event Handle: 0x{:X}", handle);
+        Logger::Debug("Audio Device System Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOut.cpp
@@ -23,13 +23,13 @@ namespace skyline::service::audio {
     }
 
     Result IAudioOut::StartAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        state.logger->Debug("Start playback");
+        Logger::Debug("Start playback");
         track->Start();
         return {};
     }
 
     Result IAudioOut::StopAudioOut(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        state.logger->Debug("Stop playback");
+        Logger::Debug("Stop playback");
         track->Stop();
         return {};
     }
@@ -44,7 +44,7 @@ namespace skyline::service::audio {
         } &data{request.inputBuf.at(0).as<Data>()};
         auto tag{request.Pop<u64>()};
 
-        state.logger->Debug("Appending buffer at 0x{:X}, Size: 0x{:X}", data.sampleBuffer, data.sampleSize);
+        Logger::Debug("Appending buffer at 0x{:X}, Size: 0x{:X}", data.sampleBuffer, data.sampleSize);
 
         span samples(data.sampleBuffer, data.sampleSize / sizeof(i16));
         if (sampleRate != constant::SampleRate) {
@@ -59,7 +59,7 @@ namespace skyline::service::audio {
 
     Result IAudioOut::RegisterBufferEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(releaseEvent)};
-        state.logger->Debug("Buffer Release Event Handle: 0x{:X}", handle);
+        Logger::Debug("Buffer Release Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioOutManager.cpp
@@ -17,7 +17,7 @@ namespace skyline::service::audio {
         auto sampleRate{request.Pop<u32>()};
         auto channelCount{static_cast<u16>(request.Pop<u32>())};
 
-        state.logger->Debug("Opening an IAudioOut with sample rate: {}, channel count: {}", sampleRate, channelCount);
+        Logger::Debug("Opening an IAudioOut with sample rate: {}, channel count: {}", sampleRate, channelCount);
 
         sampleRate = sampleRate ? sampleRate : constant::SampleRate;
         channelCount = channelCount ? channelCount : constant::ChannelCount;

--- a/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRenderer/IAudioRenderer.cpp
@@ -173,7 +173,7 @@ namespace skyline::service::audio::IAudioRenderer {
 
     Result IAudioRenderer::QuerySystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(systemEvent)};
-        state.logger->Debug("System Event Handle: 0x{:X}", handle);
+        Logger::Debug("System Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -11,7 +11,7 @@ namespace skyline::service::audio {
     Result IAudioRendererManager::OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         IAudioRenderer::AudioRendererParameters params{request.Pop<IAudioRenderer::AudioRendererParameters>()};
 
-        state.logger->Debug("Opening a rev {} IAudioRenderer with sample rate: {}, voice count: {}, effect count: {}", IAudioRenderer::ExtractVersionFromRevision(params.revision), params.sampleRate, params.voiceCount, params.effectCount);
+        Logger::Debug("Opening a rev {} IAudioRenderer with sample rate: {}, voice count: {}, effect count: {}", IAudioRenderer::ExtractVersionFromRevision(params.revision), params.sampleRate, params.voiceCount, params.effectCount);
 
         manager.RegisterService(std::make_shared<IAudioRenderer::IAudioRenderer>(state, manager, params), session, response);
 
@@ -78,7 +78,7 @@ namespace skyline::service::audio {
 
         size = util::AlignUp(size, 0x1000);
 
-        state.logger->Debug("Work buffer size: 0x{:X}", size);
+        Logger::Debug("Work buffer size: 0x{:X}", size);
         response.Push<u64>(size);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/base_service.cpp
+++ b/app/src/main/cpp/skyline/services/base_service.cpp
@@ -23,9 +23,9 @@ namespace skyline::service {
         ServiceFunctionDescriptor function;
         try {
             function = GetServiceFunction(request.payload->value);
-            state.logger->DebugNoPrefix("Service: {}", function.name);
+            Logger::DebugNoPrefix("Service: {}", function.name);
         } catch (const std::out_of_range &) {
-            state.logger->Warn("Cannot find function in service '{0}': 0x{1:X} ({1})", GetName(), static_cast<u32>(request.payload->value));
+            Logger::Warn("Cannot find function in service '{0}': 0x{1:X} ({1})", GetName(), static_cast<u32>(request.payload->value));
             return {};
         }
         TRACE_EVENT("service", perfetto::StaticString{function.name});

--- a/app/src/main/cpp/skyline/services/codec/IHardwareOpusDecoderManager.cpp
+++ b/app/src/main/cpp/skyline/services/codec/IHardwareOpusDecoderManager.cpp
@@ -19,7 +19,7 @@ namespace skyline::service::codec {
         u32 workBufferSize{request.Pop<u32>()};
         KHandle workBuffer{request.copyHandles.at(0)};
 
-        state.logger->Debug("Creating Opus decoder: Sample rate: {}, Channel count: {}, Work buffer handle: 0x{:X} (Size: 0x{:X})", sampleRate, channelCount, workBuffer, workBufferSize);
+        Logger::Debug("Creating Opus decoder: Sample rate: {}, Channel count: {}, Work buffer handle: 0x{:X} (Size: 0x{:X})", sampleRate, channelCount, workBuffer, workBufferSize);
 
         manager.RegisterService(std::make_shared<IHardwareOpusDecoder>(state, manager, sampleRate, channelCount, workBufferSize, workBuffer), session, response);
         return {};

--- a/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/INotificationService.cpp
@@ -11,7 +11,7 @@ namespace skyline::service::friends {
 
     Result INotificationService::GetEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         KHandle handle{state.process->InsertItem(notificationEvent)};
-        state.logger->Debug("Friend Notification Event Handle: 0x{:X}", handle);
+        Logger::Debug("Friend Notification Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
         return {};

--- a/app/src/main/cpp/skyline/services/fssrv/IFile.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFile.cpp
@@ -16,12 +16,12 @@ namespace skyline::service::fssrv {
         auto size{request.Pop<i64>()};
 
         if (offset < 0) {
-            state.logger->Warn("Trying to read a file with a negative offset");
+            Logger::Warn("Trying to read a file with a negative offset");
             return result::InvalidOffset;
         }
 
         if (size < 0) {
-            state.logger->Warn("Trying to read a file with a negative size");
+            Logger::Warn("Trying to read a file with a negative size");
             return result::InvalidSize;
         }
 
@@ -36,22 +36,22 @@ namespace skyline::service::fssrv {
         auto size{request.Pop<i64>()};
 
         if (offset < 0) {
-            state.logger->Warn("Trying to write to a file with a negative offset");
+            Logger::Warn("Trying to write to a file with a negative offset");
             return result::InvalidOffset;
         }
 
         if (size < 0) {
-            state.logger->Warn("Trying to write to a file with a negative size");
+            Logger::Warn("Trying to write to a file with a negative size");
             return result::InvalidSize;
         }
 
         if (request.inputBuf.at(0).size() < size) {
-            state.logger->Warn("The input buffer is not large enough to fit the requested size");
+            Logger::Warn("The input buffer is not large enough to fit the requested size");
             return result::InvalidSize;
         }
 
         if (backing->Write(request.inputBuf.at(0), static_cast<size_t>(offset)) != size) {
-            state.logger->Warn("Failed to write all data to the backing");
+            Logger::Warn("Failed to write all data to the backing");
             return result::UnexpectedFailure;
         }
 

--- a/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IStorage.cpp
@@ -12,12 +12,12 @@ namespace skyline::service::fssrv {
         auto size{request.Pop<i64>()};
 
         if (offset < 0) {
-            state.logger->Warn("Trying to read a file with a negative offset");
+            Logger::Warn("Trying to read a file with a negative offset");
             return result::InvalidOffset;
         }
 
         if (size < 0) {
-            state.logger->Warn("Trying to read a file with a negative size");
+            Logger::Warn("Trying to read a file with a negative size");
             return result::InvalidSize;
         }
 

--- a/app/src/main/cpp/skyline/services/glue/ITimeZoneService.cpp
+++ b/app/src/main/cpp/skyline/services/glue/ITimeZoneService.cpp
@@ -80,7 +80,7 @@ namespace skyline::service::glue {
 
     Result ITimeZoneService::GetDeviceLocationNameOperationEventReadableHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(locationNameUpdateEvent)};
-        state.logger->Debug("Location Name Update Event Handle: 0x{:X}", handle);
+        Logger::Debug("Location Name Update Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IAppletResource.cpp
@@ -10,7 +10,7 @@ namespace skyline::service::hid {
 
     Result IAppletResource::GetSharedMemoryHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem<type::KSharedMemory>(state.input->kHid)};
-        state.logger->Debug("HID Shared Memory Handle: 0x{:X}", handle);
+        Logger::Debug("HID Shared Memory Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
         return {};

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -31,7 +31,7 @@ namespace skyline::service::hid {
         state.input->npad.styles = styleSet;
         state.input->npad.Update();
 
-        state.logger->Debug("Controller Support:\nPro-Controller: {}\nJoy-Con: Handheld: {}, Dual: {}, L: {}, R: {}\nGameCube: {}\nPokeBall: {}\nNES: {}, NES Handheld: {}, SNES: {}", static_cast<bool>(styleSet.proController), static_cast<bool>(styleSet.joyconHandheld), static_cast<bool>(styleSet.joyconDual), static_cast<bool>(styleSet.joyconLeft), static_cast<bool>
+        Logger::Debug("Controller Support:\nPro-Controller: {}\nJoy-Con: Handheld: {}, Dual: {}, L: {}, R: {}\nGameCube: {}\nPokeBall: {}\nNES: {}, NES Handheld: {}, SNES: {}", static_cast<bool>(styleSet.proController), static_cast<bool>(styleSet.joyconHandheld), static_cast<bool>(styleSet.joyconDual), static_cast<bool>(styleSet.joyconLeft), static_cast<bool>
         (styleSet.joyconRight), static_cast<bool>(styleSet.gamecube), static_cast<bool>(styleSet.palma), static_cast<bool>(styleSet.nes), static_cast<bool>(styleSet.nesHandheld), static_cast<bool>(styleSet.snes));
         return {};
     }
@@ -63,7 +63,7 @@ namespace skyline::service::hid {
         auto id{request.Pop<NpadId>()};
         auto handle{state.process->InsertItem(state.input->npad.at(id).updateEvent)};
 
-        state.logger->Debug("Npad {} Style Set Update Event Handle: 0x{:X}", id, handle);
+        Logger::Debug("Npad {} Style Set Update Event Handle: 0x{:X}", id, handle);
         response.copyHandles.push_back(handle);
         return {};
     }
@@ -147,7 +147,7 @@ namespace skyline::service::hid {
         auto &device{state.input->npad.at(handle.id)};
         if (device.type == handle.GetType()) {
             const auto &value{request.Pop<NpadVibrationValue>()};
-            state.logger->Debug("Vibration - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", static_cast<u8>(handle.id), static_cast<u8>(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
+            Logger::Debug("Vibration - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", static_cast<u8>(handle.id), static_cast<u8>(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
             device.VibrateSingle(handle.isRight, value);
         }
 
@@ -165,13 +165,13 @@ namespace skyline::service::hid {
             auto &device{state.input->npad.at(handle.id)};
             if (device.type == handle.GetType()) {
                 if (i + 1 != handles.size() && handles[i + 1].id == handle.id && handles[i + 1].isRight && !handle.isRight) {
-                    state.logger->Debug("Vibration #{}&{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz - {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, i + 1, static_cast<u8>(handle.id), static_cast<u8>(handle.type), values[i].amplitudeLow, values[i].frequencyLow, values[i].amplitudeHigh, values[i].frequencyHigh, values[i + 1].amplitudeLow, values[i + 1].frequencyLow, values[i + 1]
+                    Logger::Debug("Vibration #{}&{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz - {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, i + 1, static_cast<u8>(handle.id), static_cast<u8>(handle.type), values[i].amplitudeLow, values[i].frequencyLow, values[i].amplitudeHigh, values[i].frequencyHigh, values[i + 1].amplitudeLow, values[i + 1].frequencyLow, values[i + 1]
                         .amplitudeHigh, values[i + 1].frequencyHigh);
                     device.Vibrate(values[i], values[i + 1]);
                     i++;
                 } else {
                     const auto &value{values[i]};
-                    state.logger->Debug("Vibration #{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, static_cast<u8>(handle.id), static_cast<u8>(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
+                    Logger::Debug("Vibration #{} - Handle: 0x{:02X} (0b{:05b}), Vibration: {:.2f}@{:.2f}Hz, {:.2f}@{:.2f}Hz", i, static_cast<u8>(handle.id), static_cast<u8>(handle.type), value.amplitudeLow, value.frequencyLow, value.amplitudeHigh, value.frequencyHigh);
                     device.VibrateSingle(handle.isRight, value);
                 }
             }

--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
@@ -45,7 +45,7 @@ namespace skyline::service::hosbinder {
                 layerStrongReferenceCount = value;
 
             if (layerStrongReferenceCount < 0) {
-                state.logger->Warn("Strong reference count is lower than 0: {} + {} = {}", (layerStrongReferenceCount - value), value, layerStrongReferenceCount);
+                Logger::Warn("Strong reference count is lower than 0: {} + {} = {}", (layerStrongReferenceCount - value), value, layerStrongReferenceCount);
                 layerStrongReferenceCount = 0;
             }
 
@@ -55,7 +55,7 @@ namespace skyline::service::hosbinder {
             layerWeakReferenceCount += value;
 
             if (layerWeakReferenceCount < 0) {
-                state.logger->Warn("Weak reference count is lower than 0: {} + {} = {}", (layerWeakReferenceCount - value), value, layerWeakReferenceCount);
+                Logger::Warn("Weak reference count is lower than 0: {} + {} = {}", (layerWeakReferenceCount - value), value, layerWeakReferenceCount);
                 layerWeakReferenceCount = 0;
             }
 
@@ -63,7 +63,7 @@ namespace skyline::service::hosbinder {
                 layer.reset();
         }
 
-        state.logger->Debug("Reference Change: {} {} reference (S{} W{})", value, isStrong ? "strong" : "weak", layerStrongReferenceCount, layerWeakReferenceCount);
+        Logger::Debug("Reference Change: {} {} reference (S{} W{})", value, isStrong ? "strong" : "weak", layerStrongReferenceCount, layerWeakReferenceCount);
 
         return {};
     }
@@ -79,7 +79,7 @@ namespace skyline::service::hosbinder {
             throw exception("Getting unknown handle from binder object: 0x{:X}", handleId);
 
         KHandle handle{state.process->InsertItem(layer->bufferEvent)};
-        state.logger->Debug("Display Buffer Event Handle: 0x{:X}", handle);
+        Logger::Debug("Display Buffer Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
 
         return {};

--- a/app/src/main/cpp/skyline/services/lm/ILogger.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogger.cpp
@@ -122,7 +122,7 @@ namespace skyline::service::lm {
         if (logMessage.dropCount)
             message << " (Dropped Messages: " << logMessage.time << ')';
 
-        state.logger->Write(hostLevel, message.str());
+        Logger::Write(hostLevel, message.str());
 
         return {};
     }

--- a/app/src/main/cpp/skyline/services/mmnv/IRequest.cpp
+++ b/app/src/main/cpp/skyline/services/mmnv/IRequest.cpp
@@ -53,13 +53,13 @@ namespace skyline::service::mmnv {
         for (auto &req : requests) {
             if (req && req->module == module) {
                 req->freqHz = freqHz;
-                state.logger->Debug("Set frequency for module {}: {} Hz", static_cast<u32>(module), freqHz);
+                Logger::Debug("Set frequency for module {}: {} Hz", static_cast<u32>(module), freqHz);
                 return {};
             }
         }
 
         // This doesn't return any errors in HOS
-        state.logger->Warn("Tried to set frequency to {} Hz for unregistered module {}", freqHz,  static_cast<u32>(module));
+        Logger::Warn("Tried to set frequency to {} Hz for unregistered module {}", freqHz,  static_cast<u32>(module));
 
         return {};
     }
@@ -70,14 +70,14 @@ namespace skyline::service::mmnv {
         std::lock_guard lock(requestsMutex);
         for (auto &req : requests) {
             if (req && req->module == module) {
-                state.logger->Debug("Get frequency for module {}: {} Hz", static_cast<u32>(module), req->freqHz);
+                Logger::Debug("Get frequency for module {}: {} Hz", static_cast<u32>(module), req->freqHz);
                 response.Push<u32>(req->freqHz);
                 return {};
             }
         }
 
         // This doesn't return any errors in HOS
-        state.logger->Warn("Tried to get frequency of unregistered module {}", static_cast<u32>(module));
+        Logger::Warn("Tried to get frequency of unregistered module {}", static_cast<u32>(module));
         response.Push<u32>(0);
         return {};
     }
@@ -114,13 +114,13 @@ namespace skyline::service::mmnv {
             auto &req{requests[id]};
             if (req) {
                 req->freqHz = freqHz;
-                state.logger->Debug("Set frequency for request {}: {} Hz", id, freqHz);
+                Logger::Debug("Set frequency for request {}: {} Hz", id, freqHz);
                 return {};
             }
         }
 
         // This doesn't return any errors in HOS
-        state.logger->Warn("Tried to set frequency for unregistered request {}", id);
+        Logger::Warn("Tried to set frequency for unregistered request {}", id);
         return {};
     }
 
@@ -131,14 +131,14 @@ namespace skyline::service::mmnv {
         if (id < requests.size()) {
             auto &req{requests[id]};
             if (req) {
-                state.logger->Debug("Get frequency for request {}: {} Hz", id, req->freqHz);
+                Logger::Debug("Get frequency for request {}: {} Hz", id, req->freqHz);
                 response.Push<u32>(req->freqHz);
                 return {};
             }
         }
 
         // This doesn't return any errors in HOS
-        state.logger->Warn("Tried to get frequency of unregistered request {}", id);
+        Logger::Warn("Tried to get frequency of unregistered request {}", id);
         response.Push<u32>(0);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
+++ b/app/src/main/cpp/skyline/services/nifm/IRequest.cpp
@@ -22,11 +22,11 @@ namespace skyline::service::nifm {
 
     Result IRequest::GetSystemEventReadableHandles(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(event0)};
-        state.logger->Debug("Request Event 0 Handle: 0x{:X}", handle);
+        Logger::Debug("Request Event 0 Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
 
         handle = state.process->InsertItem(event1);
-        state.logger->Debug("Request Event 1 Handle: 0x{:X}", handle);
+        Logger::Debug("Request Event 1 Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
 
         return {};

--- a/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/INvDrvServices.cpp
@@ -9,7 +9,7 @@
 
 #define NVRESULT(x) [&response, this](NvResult err) {         \
         if (err != NvResult::Success)                         \
-            state.logger->Debug("IOCTL Failed: 0x{:X}", err); \
+            Logger::Debug("IOCTL Failed: 0x{:X}", err); \
                                                               \
         response.Push<NvResult>(err);                         \
         return Result{};                                      \
@@ -73,7 +73,7 @@ namespace skyline::service::nvdrv {
 
     Result INvDrvServices::Close(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto fd{request.Pop<FileDescriptor>()};
-        state.logger->Debug("Closing NVDRV device ({})", fd);
+        Logger::Debug("Closing NVDRV device ({})", fd);
 
         driver.CloseDevice(fd);
 
@@ -93,7 +93,7 @@ namespace skyline::service::nvdrv {
         if (event != nullptr) {
             auto handle{state.process->InsertItem<type::KEvent>(event)};
 
-            state.logger->Debug("FD: {}, Event ID: {}, Handle: 0x{:X}", fd, eventId, handle);
+            Logger::Debug("FD: {}, Event ID: {}, Handle: 0x{:X}", fd, eventId, handle);
             response.copyHandles.push_back(handle);
 
             return NVRESULT(NvResult::Success);

--- a/app/src/main/cpp/skyline/services/nvdrv/core/nvmap.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/core/nvmap.cpp
@@ -164,7 +164,7 @@ namespace skyline::service::nvdrv::core {
 
         std::scoped_lock lock(handleDesc->mutex);
         if (--handleDesc->pins < 0) {
-            state.logger->Warn("Pin count imbalance detected!");
+            Logger::Warn("Pin count imbalance detected!");
         } else if (!handleDesc->pins) {
             std::scoped_lock queueLock(unmapQueueLock);
 
@@ -184,10 +184,10 @@ namespace skyline::service::nvdrv::core {
 
             if (internalSession) {
                 if (--handleDesc->internalDupes < 0)
-                    state.logger->Warn("Internal duplicate count imbalance detected!");
+                    Logger::Warn("Internal duplicate count imbalance detected!");
             } else {
                 if (--handleDesc->dupes < 0) {
-                    state.logger->Warn("User duplicate count imbalance detected!");
+                    Logger::Warn("User duplicate count imbalance detected!");
                 } else if (handleDesc->dupes == 0) {
                     // Force unmap the handle
                     if (handleDesc->pinVirtAddress) {
@@ -200,11 +200,11 @@ namespace skyline::service::nvdrv::core {
             }
 
             // Try to remove the shared ptr to the handle from the map, if nothing else is using the handle
-            // then it will now be freed when `handleDesc` goes out of scope
+            // then it will now be freed when `h` goes out of scope
             if (TryRemoveHandle(*handleDesc))
-                state.logger->Debug("Removed nvmap handle: {}", handle);
+                Logger::Debug("Removed nvmap handle: {}", handle);
             else
-                state.logger->Debug("Tried to free nvmap handle: {} but didn't as it still has duplicates", handle);
+                Logger::Debug("Tried to free nvmap handle: {} but didn't as it still has duplicates", handle);
 
             freeInfo = {
                 .address = handleDesc->address,
@@ -217,7 +217,7 @@ namespace skyline::service::nvdrv::core {
 
         // Handle hasn't been freed from memory, set address to 0 to mark that the handle wasn't freed
         if (!hWeak.expired()) {
-            state.logger->Debug("nvmap handle: {} wasn't freed as it is still in use", handle);
+            Logger::Debug("nvmap handle: {} wasn't freed as it is still in use", handle);
             freeInfo.address = 0;
         }
 

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl.cpp
@@ -70,7 +70,7 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Ctrl::SyncpointWaitEventImpl(In<Fence> fence, In<i32> timeout, InOut<SyncpointEventValue> value, bool allocate) {
-        state.logger->Debug("fence: ( id: {}, threshold: {} ), timeout: {}, value: {}, allocate: {}",
+        Logger::Debug("fence: ( id: {}, threshold: {} ), timeout: {}, value: {}, allocate: {}",
                             fence.id, fence.threshold, timeout, value.val, allocate);
 
         if (fence.id >= soc::host1x::SyncpointCount)
@@ -80,7 +80,7 @@ namespace skyline::service::nvdrv::device::nvhost {
         if (fence.threshold == 0) {
             // oss-nvjpg waits on syncpoint 0 during initialisation without reserving it, this is technically valid with a zero threshold but could also be a sign of a bug on our side in other cases, hence the warn
             if (!core.syncpointManager.IsSyncpointAllocated(fence.id))
-                state.logger->Warn("Tried to wait on an unreserved syncpoint with no threshold");
+                Logger::Warn("Tried to wait on an unreserved syncpoint with no threshold");
 
             return PosixResult::Success;
         }
@@ -121,7 +121,7 @@ namespace skyline::service::nvdrv::device::nvhost {
             return PosixResult::InvalidArgument;
 
         if (!event->IsInUse()) {
-            state.logger->Debug("Waiting on syncpoint event: {} with fence: ({}, {})", slot, fence.id, fence.threshold);
+            Logger::Debug("Waiting on syncpoint event: {} with fence: ({}, {})", slot, fence.id, fence.threshold);
             event->RegisterWaiter(state.soc->host1x, fence);
 
             value.val = 0;
@@ -159,7 +159,7 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Ctrl::SyncpointClearEventWait(In<SyncpointEventValue> value) {
-        state.logger->Debug("slot: {}", value.slot);
+        Logger::Debug("slot: {}", value.slot);
 
         u16 slot{value.slot};
         if (slot >= SyncpointEventCount)
@@ -172,7 +172,7 @@ namespace skyline::service::nvdrv::device::nvhost {
             return PosixResult::InvalidArgument;
 
         if (event->state.exchange(SyncpointEvent::State::Cancelling) == SyncpointEvent::State::Waiting) {
-            state.logger->Debug("Cancelling waiting syncpoint event: {}", slot);
+            Logger::Debug("Cancelling waiting syncpoint event: {}", slot);
             event->Cancel(state.soc->host1x);
             core.syncpointManager.UpdateMin(event->fence.id);
         }
@@ -192,7 +192,7 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Ctrl::SyncpointAllocateEvent(In<u32> slot) {
-        state.logger->Debug("slot: {}", slot);
+        Logger::Debug("slot: {}", slot);
 
         if (slot >= SyncpointEventCount)
             return PosixResult::InvalidArgument;
@@ -210,14 +210,14 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Ctrl::SyncpointFreeEvent(In<u32> slot) {
-        state.logger->Debug("slot: {}", slot);
+        Logger::Debug("slot: {}", slot);
 
         std::lock_guard lock(syncpointEventMutex);
         return SyncpointFreeEventLocked(slot);
     }
 
     PosixResult Ctrl::SyncpointFreeEventBatch(In<u64> bitmask) {
-        state.logger->Debug("bitmask: 0x{:X}", bitmask);
+        Logger::Debug("bitmask: 0x{:X}", bitmask);
 
         auto err{PosixResult::Success};
 

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/gpu_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/gpu_channel.cpp
@@ -66,12 +66,12 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult GpuChannel::SetNvmapFd(In<FileDescriptor> fd) {
-        state.logger->Debug("fd: {}", fd);
+        Logger::Debug("fd: {}", fd);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::SetTimeout(In<u32> timeout) {
-        state.logger->Debug("timeout: {}", timeout);
+        Logger::Debug("timeout: {}", timeout);
         return PosixResult::Success;
     }
 
@@ -79,7 +79,7 @@ namespace skyline::service::nvdrv::device::nvhost {
                                          InOut<SubmitGpfifoFlags> flags,
                                          InOut<Fence> fence,
                                          span<soc::gm20b::GpEntry> gpEntries) {
-        state.logger->Debug("userAddress: 0x{:X}, numEntries: {},"
+        Logger::Debug("userAddress: 0x{:X}, numEntries: {},"
                             "flags ( fenceWait: {}, fenceIncrement: {}, hwFormat: {}, suppressWfi: {}, incrementWithValue: {}),"
                             "fence ( id: {}, threshold: {} )",
                             userAddress, numEntries,
@@ -137,36 +137,36 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult GpuChannel::AllocObjCtx(In<u32> classId, In<u32> flags, Out<u64> objId) {
-        state.logger->Debug("classId: 0x{:X}, flags: 0x{:X}", classId, flags);
+        Logger::Debug("classId: 0x{:X}, flags: 0x{:X}", classId, flags);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::ZcullBind(In<u64> gpuVa, In<u32> mode) {
-        state.logger->Debug("gpuVa: 0x{:X}, mode: {}", gpuVa, mode);
+        Logger::Debug("gpuVa: 0x{:X}, mode: {}", gpuVa, mode);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::SetErrorNotifier(In<u64> offset, In<u64> size, In<u32> mem) {
-        state.logger->Debug("offset: 0x{:X}, size: 0x{:X}, mem: 0x{:X}", offset, size, mem);
+        Logger::Debug("offset: 0x{:X}, size: 0x{:X}, mem: 0x{:X}", offset, size, mem);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::SetPriority(In<u32> priority) {
-        state.logger->Debug("priority: {}", priority);
+        Logger::Debug("priority: {}", priority);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::AllocGpfifoEx2(In<u32> numEntries, In<u32> numJobs, In<u32> flags, Out<Fence> fence) {
-        state.logger->Debug("numEntries: {}, numJobs: {}, flags: 0x{:X}", numEntries, numJobs, flags);
+        Logger::Debug("numEntries: {}, numJobs: {}, flags: 0x{:X}", numEntries, numJobs, flags);
 
         std::scoped_lock lock(channelMutex);
         if (!asCtx || !asAllocator) {
-            state.logger->Warn("Trying to allocate a channel without a bound address space");
+            Logger::Warn("Trying to allocate a channel without a bound address space");
             return PosixResult::InvalidArgument;
         }
 
         if (channelCtx) {
-            state.logger->Warn("Trying to allocate a channel twice!");
+            Logger::Warn("Trying to allocate a channel twice!");
             return PosixResult::FileExists;
         }
 
@@ -192,12 +192,12 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult GpuChannel::SetTimeslice(In<u32> timeslice) {
-        state.logger->Debug("timeslice: {}", timeslice);
+        Logger::Debug("timeslice: {}", timeslice);
         return PosixResult::Success;
     }
 
     PosixResult GpuChannel::SetUserData(In<u64> userData) {
-        state.logger->Debug("userData: 0x{:X}", userData);
+        Logger::Debug("userData: 0x{:X}", userData);
         channelUserData = userData;
         return PosixResult::Success;
     }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/host1x_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/host1x_channel.cpp
@@ -17,14 +17,14 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Host1xChannel::SetNvmapFd(In<FileDescriptor> fd) {
-        state.logger->Debug("fd: {}", fd);
+        Logger::Debug("fd: {}", fd);
         return PosixResult::Success;
     }
 
     PosixResult Host1xChannel::Submit(span<SubmitCmdBuf> cmdBufs,
                                       span<SubmitReloc> relocs, span<u32> relocShifts,
                                       span<SubmitSyncpointIncr> syncpointIncrs, span<u32> fenceThresholds) {
-        state.logger->Debug("numCmdBufs: {}, numRelocs: {}, numSyncpointIncrs: {}, numFenceThresholds: {}",
+        Logger::Debug("numCmdBufs: {}, numRelocs: {}, numSyncpointIncrs: {}, numFenceThresholds: {}",
                             cmdBufs.size(), relocs.size(), syncpointIncrs.size(), fenceThresholds.size());
 
         if (fenceThresholds.size() > syncpointIncrs.size())
@@ -49,7 +49,7 @@ namespace skyline::service::nvdrv::device::nvhost {
                 throw exception("Invalid handle passed for a command buffer!");
 
             u64 gatherAddress{handleDesc->address + cmdBuf.offset};
-            state.logger->Debug("Submit gather, CPU address: 0x{:X}, words: 0x{:X}", gatherAddress, cmdBuf.words);
+            Logger::Debug("Submit gather, CPU address: 0x{:X}, words: 0x{:X}", gatherAddress, cmdBuf.words);
 
             span gather(reinterpret_cast<u32 *>(gatherAddress), cmdBuf.words);
             state.soc->host1x.channels[static_cast<size_t>(channelType)].Push(gather);
@@ -59,7 +59,7 @@ namespace skyline::service::nvdrv::device::nvhost {
     }
 
     PosixResult Host1xChannel::GetSyncpoint(In<u32> channelSyncpointIdx, Out<u32> syncpointId) {
-        state.logger->Debug("channelSyncpointIdx: {}", channelSyncpointIdx);
+        Logger::Debug("channelSyncpointIdx: {}", channelSyncpointIdx);
 
         if (channelSyncpointIdx > 0)
             throw exception("Multiple channel syncpoints are unimplemented!");
@@ -68,39 +68,39 @@ namespace skyline::service::nvdrv::device::nvhost {
         if (!id)
             throw exception("Requested syncpoint for a channel with none specified!");
 
-        state.logger->Debug("syncpointId: {}", id);
+        Logger::Debug("syncpointId: {}", id);
         syncpointId = id;
         return PosixResult::Success;
     }
 
     PosixResult Host1xChannel::GetWaitBase(In<core::ChannelType> pChannelType, Out<u32> waitBase) {
-        state.logger->Debug("channelType: {}", static_cast<u32>(pChannelType));
+        Logger::Debug("channelType: {}", static_cast<u32>(pChannelType));
         waitBase = 0;
         return PosixResult::Success;
     }
 
     PosixResult Host1xChannel::SetSubmitTimeout(In<u32> timeout) {
-        state.logger->Debug("timeout: {}", timeout);
+        Logger::Debug("timeout: {}", timeout);
         return PosixResult::Success;
     }
 
     PosixResult Host1xChannel::MapBuffer(u8 compressed, span<BufferHandle> handles) {
-        state.logger->Debug("compressed: {}", compressed);
+        Logger::Debug("compressed: {}", compressed);
 
         for (auto &bufferHandle : handles) {
             bufferHandle.address = core.nvMap.PinHandle(bufferHandle.handle);
-            state.logger->Debug("handle: {}, address: 0x{:X}", bufferHandle.handle, bufferHandle.address);
+            Logger::Debug("handle: {}, address: 0x{:X}", bufferHandle.handle, bufferHandle.address);
         }
 
         return PosixResult::Success;
     }
 
     PosixResult Host1xChannel::UnmapBuffer(u8 compressed, span<BufferHandle> handles) {
-        state.logger->Debug("compressed: {}", compressed);
+        Logger::Debug("compressed: {}", compressed);
 
         for (auto &bufferHandle : handles) {
             core.nvMap.UnpinHandle(bufferHandle.handle);
-            state.logger->Debug("handle: {}", bufferHandle.handle);
+            Logger::Debug("handle: {}", bufferHandle.handle);
         }
 
         return PosixResult::Success;

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvmap.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvmap.cpp
@@ -13,14 +13,14 @@ namespace skyline::service::nvdrv::device {
         if (handleDesc) {
             (*handleDesc)->origSize = size; // Orig size is the unaligned size
             handle = (*handleDesc)->id;
-            state.logger->Debug("handle: {}, size: 0x{:X}", (*handleDesc)->id, size);
+            Logger::Debug("handle: {}, size: 0x{:X}", (*handleDesc)->id, size);
         }
 
         return handleDesc;
     }
 
     PosixResult NvMap::FromId(In<NvMapCore::Handle::Id> id, Out<NvMapCore::Handle::Id> handle) {
-        state.logger->Debug("id: {}", id);
+        Logger::Debug("id: {}", id);
 
         // Handles and IDs are always the same value in nvmap however IDs can be used globally given the right permissions.
         // Since we don't plan on ever supporting multiprocess we can skip implementing handle refs and so this function just does simple validation and passes through the handle id.
@@ -41,7 +41,7 @@ namespace skyline::service::nvdrv::device {
     PosixResult NvMap::Alloc(In<NvMapCore::Handle::Id> handle,
                              In<u32> heapMask, In<NvMapCore::Handle::Flags> flags,
                              InOut<u32> align, In<u8> kind, In<u64> address) {
-        state.logger->Debug("handle: {}, flags: ( mapUncached: {}, keepUncachedAfterFree: {} ), align: 0x{:X}, kind: {}, address: 0x{:X}",
+        Logger::Debug("handle: {}, flags: ( mapUncached: {}, keepUncachedAfterFree: {} ), align: 0x{:X}, kind: {}, address: 0x{:X}",
                             handle, flags.mapUncached, flags.keepUncachedAfterFree, align, kind, address);
 
         if (!handle) [[unlikely]]
@@ -64,7 +64,7 @@ namespace skyline::service::nvdrv::device {
     PosixResult NvMap::Free(In<NvMapCore::Handle::Id> handle,
                             Out<u64> address, Out<u32> size,
                             Out<NvMapCore::Handle::Flags> flags) {
-        state.logger->Debug("handle: {}", handle);
+        Logger::Debug("handle: {}", handle);
 
         if (!handle) [[unlikely]]
             return PosixResult::Success;
@@ -74,14 +74,14 @@ namespace skyline::service::nvdrv::device {
             size = static_cast<u32>(freeInfo->size);
             flags = NvMapCore::Handle::Flags{ .mapUncached = freeInfo->wasUncached };
         } else {
-            state.logger->Debug("Handle not freed");
+            Logger::Debug("Handle not freed");
         }
 
         return PosixResult::Success;
     }
 
     PosixResult NvMap::Param(In<NvMapCore::Handle::Id> handle, In<HandleParameterType> param, Out<u32> result) {
-        state.logger->Debug("handle: {}, param: {}", handle, param);
+        Logger::Debug("handle: {}, param: {}", handle, param);
 
         if (!handle)
             return PosixResult::InvalidArgument;
@@ -119,7 +119,7 @@ namespace skyline::service::nvdrv::device {
     }
 
     PosixResult NvMap::GetId(Out<NvMapCore::Handle::Id> id, In<NvMapCore::Handle::Id> handle) {
-        state.logger->Debug("handle: {}", handle);
+        Logger::Debug("handle: {}", handle);
 
         // See the comment in FromId for extra info on this function
         if (!handle) [[unlikely]]

--- a/app/src/main/cpp/skyline/services/nvdrv/driver.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/driver.cpp
@@ -13,7 +13,7 @@ namespace skyline::service::nvdrv {
     Driver::Driver(const DeviceState &state) : state(state), core(state) {}
 
     NvResult Driver::OpenDevice(std::string_view path, FileDescriptor fd, const SessionContext &ctx) {
-        state.logger->Debug("Opening NvDrv device ({}): {}", fd, path);
+        Logger::Debug("Opening NvDrv device ({}): {}", fd, path);
         auto pathHash{util::Hash(path)};
 
         #define DEVICE_SWITCH(cases) \
@@ -84,7 +84,7 @@ namespace skyline::service::nvdrv {
     }
 
     NvResult Driver::Ioctl(FileDescriptor fd, IoctlDescriptor cmd, span<u8> buffer) {
-        state.logger->Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
+        Logger::Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
 
         try {
             std::shared_lock lock(deviceMutex);
@@ -95,7 +95,7 @@ namespace skyline::service::nvdrv {
     }
 
     NvResult Driver::Ioctl2(FileDescriptor fd, IoctlDescriptor cmd, span<u8> buffer, span<u8> inlineBuffer) {
-        state.logger->Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
+        Logger::Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
 
         try {
             std::shared_lock lock(deviceMutex);
@@ -106,7 +106,7 @@ namespace skyline::service::nvdrv {
     }
 
     NvResult Driver::Ioctl3(FileDescriptor fd, IoctlDescriptor cmd, span<u8> buffer, span<u8> inlineBuffer) {
-        state.logger->Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
+        Logger::Debug("fd: {}, cmd: 0x{:X}, device: {}", fd, cmd.raw, devices.at(fd)->GetName());
 
         try {
             std::shared_lock lock(deviceMutex);
@@ -121,12 +121,12 @@ namespace skyline::service::nvdrv {
             std::unique_lock lock(deviceMutex);
             devices.erase(fd);
         } catch (const std::out_of_range &) {
-            state.logger->Warn("Trying to close invalid fd: {}");
+            Logger::Warn("Trying to close invalid fd: {}");
         }
     }
 
     std::shared_ptr<kernel::type::KEvent> Driver::QueryEvent(FileDescriptor fd, u32 eventId) {
-        state.logger->Debug("fd: {}, eventId: 0x{:X}, device: {}", fd, eventId, devices.at(fd)->GetName());
+        Logger::Debug("fd: {}, eventId: 0x{:X}, device: {}", fd, eventId, devices.at(fd)->GetName());
 
         try {
             std::shared_lock lock(deviceMutex);

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -120,7 +120,7 @@ namespace skyline::service {
             handle = state.process->NewHandle<type::KSession>(serviceObject).handle;
             response.moveHandles.push_back(handle);
         }
-        state.logger->Debug("Service has been created: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
+        Logger::Debug("Service has been created: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
         return serviceObject;
     }
 
@@ -137,7 +137,7 @@ namespace skyline::service {
             response.moveHandles.push_back(handle);
         }
 
-        state.logger->Debug("Service has been registered: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
+        Logger::Debug("Service has been registered: \"{}\" (0x{:X})", serviceObject->GetName(), handle);
     }
 
     void ServiceManager::CloseSession(KHandle handle) {
@@ -161,8 +161,8 @@ namespace skyline::service {
     void ServiceManager::SyncRequestHandler(KHandle handle) {
         TRACE_EVENT("kernel", "ServiceManager::SyncRequestHandler");
         auto session{state.process->GetHandle<type::KSession>(handle)};
-        state.logger->Verbose("----IPC Start----");
-        state.logger->Verbose("Handle is 0x{:X}", handle);
+        Logger::Verbose("----IPC Start----");
+        Logger::Verbose("Handle is 0x{:X}", handle);
 
         if (session->isOpen) {
             ipc::IpcRequest request(session->isDomain, state);
@@ -199,7 +199,7 @@ namespace skyline::service {
 
                 case ipc::CommandType::Control:
                 case ipc::CommandType::ControlWithContext:
-                    state.logger->Debug("Control IPC Message: 0x{:X}", request.payload->value);
+                    Logger::Debug("Control IPC Message: 0x{:X}", request.payload->value);
                     switch (static_cast<ipc::ControlCommand>(request.payload->value)) {
                         case ipc::ControlCommand::ConvertCurrentObjectToDomain:
                             response.Push(session->ConvertDomain());
@@ -221,15 +221,15 @@ namespace skyline::service {
                     break;
 
                 case ipc::CommandType::Close:
-                    state.logger->Debug("Closing Session");
+                    Logger::Debug("Closing Session");
                     CloseSession(handle);
                     break;
                 default:
                     throw exception("Unimplemented IPC message type: {}", static_cast<u16>(request.header->type));
             }
         } else {
-            state.logger->Warn("svcSendSyncRequest called on closed handle: 0x{:X}", handle);
+            Logger::Warn("svcSendSyncRequest called on closed handle: 0x{:X}", handle);
         }
-        state.logger->Verbose("====IPC End====");
+        Logger::Verbose("====IPC End====");
     }
 }

--- a/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
+++ b/app/src/main/cpp/skyline/services/sm/IUserInterface.cpp
@@ -21,7 +21,7 @@ namespace skyline::service::sm {
             return {};
         } catch (std::out_of_range &) {
             std::string_view stringName(span(reinterpret_cast<char *>(&name), sizeof(u64)).as_string(true));
-            state.logger->Warn("Service has not been implemented: \"{}\"", stringName);
+            Logger::Warn("Service has not been implemented: \"{}\"", stringName);
             return result::InvalidServiceName;
         }
     }

--- a/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/ISystemClock.cpp
@@ -62,7 +62,7 @@ namespace skyline::service::timesrv {
         }
 
         auto handle{state.process->InsertItem(operationEvent)};
-        state.logger->Debug("ISystemClock Operation Event Handle: 0x{:X}", handle);
+        Logger::Debug("ISystemClock Operation Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
@@ -42,14 +42,14 @@ namespace skyline::service::visrv {
 
     Result IApplicationDisplayService::OpenDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto displayName(request.PopString());
-        state.logger->Debug("Opening display: {}", displayName);
+        Logger::Debug("Opening display: {}", displayName);
         response.Push(hosbinder->OpenDisplay(displayName));
         return {};
     }
 
     Result IApplicationDisplayService::CloseDisplay(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto displayId{request.Pop<hosbinder::DisplayId>()};
-        state.logger->Debug("Closing display: {}", hosbinder::ToString(displayId));
+        Logger::Debug("Closing display: {}", hosbinder::ToString(displayId));
         hosbinder->CloseDisplay(displayId);
         return {};
     }
@@ -57,7 +57,7 @@ namespace skyline::service::visrv {
     Result IApplicationDisplayService::OpenLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto displayName{request.PopString(0x40)};
         auto layerId{request.Pop<u64>()};
-        state.logger->Debug("Opening layer #{} on display: {}", layerId, displayName);
+        Logger::Debug("Opening layer #{} on display: {}", layerId, displayName);
 
         auto displayId{hosbinder->OpenDisplay(displayName)};
         auto parcel{hosbinder->OpenLayer(displayId, layerId)};
@@ -68,7 +68,7 @@ namespace skyline::service::visrv {
 
     Result IApplicationDisplayService::CloseLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         u64 layerId{request.Pop<u64>()};
-        state.logger->Debug("Closing layer #{}", layerId);
+        Logger::Debug("Closing layer #{}", layerId);
         hosbinder->CloseLayer(layerId);
         return {};
     }
@@ -76,13 +76,13 @@ namespace skyline::service::visrv {
     Result IApplicationDisplayService::SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto scalingMode{request.Pop<u64>()};
         auto layerId{request.Pop<u64>()};
-        state.logger->Debug("Setting Layer Scaling mode to '{}' for layer {}", scalingMode, layerId);
+        Logger::Debug("Setting Layer Scaling mode to '{}' for layer {}", scalingMode, layerId);
         return {};
     }
 
     Result IApplicationDisplayService::GetDisplayVsyncEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         KHandle handle{state.process->InsertItem(state.gpu->presentation.vsyncEvent)};
-        state.logger->Debug("V-Sync Event Handle: 0x{:X}", handle);
+        Logger::Debug("V-Sync Event Handle: 0x{:X}", handle);
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IDisplayService.cpp
@@ -15,7 +15,7 @@ namespace skyline::service::visrv {
         auto layerId{hosbinder->CreateLayer(displayId)};
         response.Push(layerId);
 
-        state.logger->Debug("Creating Stray Layer #{} on Display: {}", layerId, hosbinder::ToString(displayId));
+        Logger::Debug("Creating Stray Layer #{} on Display: {}", layerId, hosbinder::ToString(displayId));
 
         auto parcel{hosbinder->OpenLayer(displayId, layerId)};
         response.Push<u64>(parcel.WriteParcel(request.outputBuf.at(0)));
@@ -25,7 +25,7 @@ namespace skyline::service::visrv {
 
     Result IDisplayService::DestroyStrayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId{request.Pop<u64>()};
-        state.logger->Debug("Destroying Stray Layer #{}", layerId);
+        Logger::Debug("Destroying Stray Layer #{}", layerId);
 
         hosbinder->CloseLayer(layerId);
 

--- a/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IManagerDisplayService.cpp
@@ -12,7 +12,7 @@ namespace skyline::service::visrv {
         auto displayId{request.Pop<hosbinder::DisplayId>()};
 
         auto layerId{hosbinder->CreateLayer(displayId)};
-        state.logger->Debug("Creating Managed Layer #{} on Display: {}", layerId, hosbinder::ToString(displayId));
+        Logger::Debug("Creating Managed Layer #{} on Display: {}", layerId, hosbinder::ToString(displayId));
         response.Push(layerId);
 
         return {};
@@ -20,7 +20,7 @@ namespace skyline::service::visrv {
 
     Result IManagerDisplayService::DestroyManagedLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto layerId{request.Pop<u64>()};
-        state.logger->Debug("Destroying Managed Layer #{}", layerId);
+        Logger::Debug("Destroying Managed Layer #{}", layerId);
         hosbinder->DestroyLayer(layerId);
         return {};
     }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
@@ -23,7 +23,7 @@ namespace skyline::soc::gm20b {
              * @brief Calls an engine method with the given parameters
              */
             void CallMethod(u32 method, u32 argument, bool lastCall) {
-                state.logger->Warn("Called method in unimplemented engine: 0x{:X} args: 0x{:X}", method, argument);
+                Logger::Warn("Called method in unimplemented engine: 0x{:X} args: 0x{:X}", method, argument);
             };
         };
     }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/gpfifo.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/gpfifo.cpp
@@ -9,7 +9,7 @@ namespace skyline::soc::gm20b::engine {
     GPFIFO::GPFIFO(const DeviceState &state, ChannelContext &channelCtx) : Engine(state), channelCtx(channelCtx) {}
 
     void GPFIFO::CallMethod(u32 method, u32 argument, bool lastCall) {
-        state.logger->Debug("Called method in GPFIFO: 0x{:X} args: 0x{:X}", method, argument);
+        Logger::Debug("Called method in GPFIFO: 0x{:X} args: 0x{:X}", method, argument);
 
         registers.raw[method] = argument;
 
@@ -27,11 +27,11 @@ namespace skyline::soc::gm20b::engine {
         switch (method) {
             GPFIFO_STRUCT_CASE(syncpoint, action, {
                 if (action.operation == Registers::SyncpointOperation::Incr) {
-                    state.logger->Debug("Increment syncpoint: {}", +action.index);
+                    Logger::Debug("Increment syncpoint: {}", +action.index);
                     channelCtx.executor.Execute();
                     state.soc->host1x.syncpoints.at(action.index).Increment();
                 } else if (action.operation == Registers::SyncpointOperation::Wait) {
-                    state.logger->Debug("Wait syncpoint: {}, thresh: {}", +action.index, registers.syncpoint.payload);
+                    Logger::Debug("Wait syncpoint: {}, thresh: {}", +action.index, registers.syncpoint.payload);
 
                     // Wait forever for another channel to increment
                     state.soc->host1x.syncpoints.at(action.index).Wait(registers.syncpoint.payload, std::chrono::steady_clock::duration::max());

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
@@ -76,7 +76,7 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
     }
 
     void Maxwell3D::CallMethod(u32 method, u32 argument, bool lastCall) {
-        state.logger->Debug("Called method in Maxwell 3D: 0x{:X} args: 0x{:X}", method, argument);
+        Logger::Debug("Called method in Maxwell 3D: 0x{:X} args: 0x{:X}", method, argument);
 
         // Methods that are greater than the register size are for macro control
         if (method >= RegisterCount) [[unlikely]] {
@@ -248,7 +248,7 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
             })
 
             MAXWELL3D_CASE(syncpointAction, {
-                state.logger->Debug("Increment syncpoint: {}", static_cast<u16>(syncpointAction.id));
+                Logger::Debug("Increment syncpoint: {}", static_cast<u16>(syncpointAction.id));
                 channelCtx.executor.Execute();
                 state.soc->host1x.syncpoints.at(syncpointAction.id).Increment();
             })
@@ -270,14 +270,14 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
                                 break;
 
                             default:
-                                state.logger->Warn("Unsupported semaphore counter type: 0x{:X}", static_cast<u8>(info.counterType));
+                                Logger::Warn("Unsupported semaphore counter type: 0x{:X}", static_cast<u8>(info.counterType));
                                 break;
                         }
                         break;
                     }
 
                     default:
-                        state.logger->Warn("Unsupported semaphore operation: 0x{:X}", static_cast<u8>(info.op));
+                        Logger::Warn("Unsupported semaphore operation: 0x{:X}", static_cast<u8>(info.op));
                         break;
                 }
             })

--- a/app/src/main/cpp/skyline/soc/gm20b/gpfifo.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/gpfifo.cpp
@@ -73,7 +73,7 @@ namespace skyline::soc::gm20b {
         constexpr u32 TwoDSubChannel{3};
         constexpr u32 CopySubChannel{4}; // HW forces a memory flush on a switch from this subchannel to others
 
-        state.logger->Debug("Called GPU method - method: 0x{:X} argument: 0x{:X} subchannel: 0x{:X} last: {}", method, argument, subChannel, lastCall);
+        Logger::Debug("Called GPU method - method: 0x{:X} argument: 0x{:X} subchannel: 0x{:X} last: {}", method, argument, subChannel, lastCall);
 
         if (method < engine::GPFIFO::RegisterCount) {
             gpfifoEngine.CallMethod(method, argument, lastCall);
@@ -107,7 +107,7 @@ namespace skyline::soc::gm20b {
                 case GpEntry::Opcode::Nop:
                     return;
                 default:
-                    state.logger->Warn("Unsupported GpEntry control opcode used: {}", static_cast<u8>(gpEntry.opcode));
+                    Logger::Warn("Unsupported GpEntry control opcode used: {}", static_cast<u8>(gpEntry.opcode));
                     return;
             }
         }
@@ -220,17 +220,17 @@ namespace skyline::soc::gm20b {
             signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
 
             gpEntries.Process([this](GpEntry gpEntry) {
-                state.logger->Debug("Processing pushbuffer: 0x{:X}, Size: 0x{:X}", gpEntry.Address(), +gpEntry.size);
+                Logger::Debug("Processing pushbuffer: 0x{:X}, Size: 0x{:X}", gpEntry.Address(), +gpEntry.size);
                 Process(gpEntry);
             });
         } catch (const signal::SignalException &e) {
             if (e.signal != SIGINT) {
-                state.logger->Error("{}\nStack Trace:{}", e.what(), state.loader->GetStackTrace(e.frames));
+                Logger::Error("{}\nStack Trace:{}", e.what(), state.loader->GetStackTrace(e.frames));
                 signal::BlockSignal({SIGINT});
                 state.process->Kill(false);
             }
         } catch (const std::exception &e) {
-            state.logger->Error(e.what());
+            Logger::Error(e.what());
             signal::BlockSignal({SIGINT});
             state.process->Kill(false);
         }

--- a/app/src/main/cpp/skyline/soc/host1x/classes/host1x.cpp
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/host1x.cpp
@@ -6,7 +6,7 @@
 #include "host1x.h"
 
 namespace skyline::soc::host1x {
-    Host1xClass::Host1xClass(const DeviceState &state, SyncpointSet &syncpoints) : state(state), syncpoints(syncpoints) {}
+    Host1xClass::Host1xClass(SyncpointSet &syncpoints) : syncpoints(syncpoints) {}
 
     void Host1xClass::CallMethod(u32 method, u32 argument) {
         constexpr static u32 LoadSyncpointPayload32MethodId{0x4E}; //!< See '14.3.2.12 32-Bit Sync Point Comparison Methods' in TRM
@@ -17,7 +17,7 @@ namespace skyline::soc::host1x {
                 IncrementSyncpointMethod incrSyncpoint{.raw = argument};
 
                 // incrSyncpoint.condition doesn't matter for Host1x class increments
-                state.logger->Debug("Increment syncpoint: {}", incrSyncpoint.index);
+                Logger::Debug("Increment syncpoint: {}", incrSyncpoint.index);
                 syncpoints.at(incrSyncpoint.index).Increment();
                 break;
             }
@@ -28,14 +28,14 @@ namespace skyline::soc::host1x {
 
             case WaitSyncpoint32MethodId: {
                 u32 syncpointId{static_cast<u8>(argument)};
-                state.logger->Debug("Wait syncpoint: {}, thresh: {}", syncpointId, syncpointPayload);
+                Logger::Debug("Wait syncpoint: {}, thresh: {}", syncpointId, syncpointPayload);
 
                 syncpoints.at(syncpointId).Wait(syncpointPayload, std::chrono::steady_clock::duration::max());
                 break;
             }
 
             default:
-                state.logger->Error("Unknown host1x class method called: 0x{:X}", method);
+                Logger::Error("Unknown host1x class method called: 0x{:X}", method);
                 break;
         }
     }

--- a/app/src/main/cpp/skyline/soc/host1x/classes/host1x.h
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/host1x.h
@@ -12,12 +12,11 @@ namespace skyline::soc::host1x {
      */
     class Host1xClass {
       private:
-        const DeviceState &state;
         SyncpointSet &syncpoints;
         u32 syncpointPayload{}; //!< Holds the current payload for the 32-bit syncpoint comparison methods
 
       public:
-        Host1xClass(const DeviceState &state, SyncpointSet &syncpoints);
+        Host1xClass(SyncpointSet &syncpoints);
 
         void CallMethod(u32 method, u32 argument);
     };

--- a/app/src/main/cpp/skyline/soc/host1x/classes/nvdec.cpp
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/nvdec.cpp
@@ -4,11 +4,10 @@
 #include "nvdec.h"
 
 namespace skyline::soc::host1x {
-    NvDecClass::NvDecClass(const DeviceState &state, std::function<void()> opDoneCallback)
-        : state(state),
-          opDoneCallback(std::move(opDoneCallback)) {}
+    NvDecClass::NvDecClass(std::function<void()> opDoneCallback)
+        : opDoneCallback(std::move(opDoneCallback)) {}
 
     void NvDecClass::CallMethod(u32 method, u32 argument) {
-        state.logger->Warn("Unknown NVDEC class method called: 0x{:X} argument: 0x{:X}", method, argument);
+        Logger::Warn("Unknown NVDEC class method called: 0x{:X} argument: 0x{:X}", method, argument);
     }
 }

--- a/app/src/main/cpp/skyline/soc/host1x/classes/nvdec.h
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/nvdec.h
@@ -11,11 +11,10 @@ namespace skyline::soc::host1x {
      */
     class NvDecClass {
       private:
-        const DeviceState &state;
         std::function<void()> opDoneCallback;
 
       public:
-        NvDecClass(const DeviceState &state, std::function<void()> opDoneCallback);
+        NvDecClass(std::function<void()> opDoneCallback);
 
         void CallMethod(u32 method, u32 argument);
     };

--- a/app/src/main/cpp/skyline/soc/host1x/classes/vic.cpp
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/vic.cpp
@@ -4,11 +4,10 @@
 #include "vic.h"
 
 namespace skyline::soc::host1x {
-    VicClass::VicClass(const DeviceState &state, std::function<void()> opDoneCallback)
-        : state(state),
-          opDoneCallback(std::move(opDoneCallback)) {}
+    VicClass::VicClass(std::function<void()> opDoneCallback)
+        : opDoneCallback(std::move(opDoneCallback)) {}
 
     void VicClass::CallMethod(u32 method, u32 argument) {
-        state.logger->Warn("Unknown VIC class method called: 0x{:X} argument: 0x{:X}", method, argument);
+        Logger::Warn("Unknown VIC class method called: 0x{:X} argument: 0x{:X}", method, argument);
     }
 }

--- a/app/src/main/cpp/skyline/soc/host1x/classes/vic.h
+++ b/app/src/main/cpp/skyline/soc/host1x/classes/vic.h
@@ -11,11 +11,10 @@ namespace skyline::soc::host1x {
      */
     class VicClass {
       private:
-        const DeviceState &state;
         std::function<void()> opDoneCallback;
 
       public:
-        VicClass(const DeviceState &state, std::function<void()> opDoneCallback);
+        VicClass(std::function<void()> opDoneCallback);
 
         void CallMethod(u32 method, u32 argument);
     };

--- a/app/src/main/cpp/skyline/vfs/npdm.cpp
+++ b/app/src/main/cpp/skyline/vfs/npdm.cpp
@@ -36,7 +36,7 @@ namespace skyline::vfs {
         };
     }
 
-    NPDM::NPDM(const std::shared_ptr<vfs::Backing> &backing, const DeviceState &state) {
+    NPDM::NPDM(const std::shared_ptr<vfs::Backing> &backing) {
         meta = backing->Read<NpdmMeta>();
         if (meta.magic != MetaMagic)
             throw exception("NPDM Meta Magic isn't correct: 0x{:X} (\"META\" = 0x{:X})", meta.magic, MetaMagic);
@@ -77,6 +77,6 @@ namespace skyline::vfs {
         if (!threadInfo.coreMask.test(meta.idealCore))
             throw exception("NPDM Ideal Core isn't valid: {} ({})", meta.idealCore, threadInfo.coreMask);
 
-        state.logger->Debug("NPDM Metadata:\nTitle: ID: {:X}, Version: {}\nMain Thread: Priority: {}, Stack Size: 0x{:X}\nScheduler: Ideal Core: {}, Core Mask: {}, Priority: {} - {}\nKernel Version: v{}.{}", aci0.programId, meta.version, meta.mainThreadPriority, meta.mainThreadStackSize, meta.idealCore, threadInfo.coreMask, threadInfo.priority.min, threadInfo.priority.max, kernelVersion.majorVersion, kernelVersion.minorVersion);
+        Logger::Debug("NPDM Metadata:\nTitle: ID: {:X}, Version: {}\nMain Thread: Priority: {}, Stack Size: 0x{:X}\nScheduler: Ideal Core: {}, Core Mask: {}, Priority: {} - {}\nKernel Version: v{}.{}", aci0.programId, meta.version, meta.mainThreadPriority, meta.mainThreadStackSize, meta.idealCore, threadInfo.coreMask, threadInfo.priority.min, threadInfo.priority.max, kernelVersion.majorVersion, kernelVersion.minorVersion);
     }
 }

--- a/app/src/main/cpp/skyline/vfs/npdm.h
+++ b/app/src/main/cpp/skyline/vfs/npdm.h
@@ -117,7 +117,7 @@ namespace skyline {
           public:
             NPDM();
 
-            NPDM(const std::shared_ptr<vfs::Backing> &backing, const DeviceState &state);
+            NPDM(const std::shared_ptr<vfs::Backing> &backing);
         };
     }
 }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -37,10 +37,6 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         private var emulationThread : Thread? = null
     }
 
-    init {
-        System.loadLibrary("skyline") // libskyline.so
-    }
-
     private val binding by lazy { EmuActivityBinding.inflate(layoutInflater) }
 
     /**

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -130,7 +130,7 @@ class MainActivity : AppCompatActivity() {
 
         binding.searchBar.apply {
             binding.logIcon.setOnClickListener {
-                val file = applicationContext.filesDir.resolve("skyline.log")
+                val file = applicationContext.filesDir.resolve("emulation.sklog")
                 if (file.length() != 0L) {
                     val intent = Intent(Intent.ACTION_SEND)
                         .setType("text/plain")

--- a/app/src/main/java/emu/skyline/SkylineApplication.kt
+++ b/app/src/main/java/emu/skyline/SkylineApplication.kt
@@ -7,6 +7,15 @@ package emu.skyline
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import emu.skyline.di.getSettings
 
 @HiltAndroidApp
-class SkylineApplication : Application()
+class SkylineApplication : Application() {
+    private external fun initializeLog(appFilesPath : String, logLevel : Int)
+
+    override fun onCreate() {
+        super.onCreate()
+        System.loadLibrary("skyline")
+        initializeLog(applicationContext.filesDir.canonicalPath + "/", getSettings().logLevel.toInt())
+    }
+}

--- a/app/src/main/java/emu/skyline/loader/RomFile.kt
+++ b/app/src/main/java/emu/skyline/loader/RomFile.kt
@@ -127,8 +127,6 @@ internal class RomFile(context : Context, format : RomFormat, uri : Uri, systemL
         get() = result == LoaderResult.Success
 
     init {
-        System.loadLibrary("skyline")
-
         context.contentResolver.openFileDescriptor(uri, "r")!!.use {
             result = LoaderResult.get(populate(format.ordinal, it.fd, context.filesDir.canonicalPath + "/", systemLanguage))
         }


### PR DESCRIPTION
We needed a way to call log functions where the DeviceState instance was not available, as previously the logger class was a member of the DeviceState class. Instead, now we have a static logger class which only takes care of constructing the log string and logging it to android logcat. Instance dependant data is held by a thread local `LoggerContext`, which holds an ofstream to the output file and the required logic to make writes to the stream thread safe.

Two logger contexts are made available in this PR:
- EmulationContext: default, used by all emulation code, writes to `emulation.sklog`
- LoaderContext: used by rom loaders when populating the games view, writes to `loader.sklog`