### PR TITLE
Compile-time Logger Format String Validation + Async Logger

### DIFF
--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -62,6 +62,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_SkylineApplication_initializeLog(
 ) {
     std::string appFilesPath{env->GetStringUTFChars(appFilesPathJstring, nullptr)};
     skyline::Logger::configLevel = static_cast<skyline::Logger::LogLevel>(logLevel);
+    skyline::Logger::StartLoggerThread();
     skyline::Logger::LoaderContext.Initialize(appFilesPath + "loader.sklog");
 }
 
@@ -128,7 +129,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
     InputWeak.reset();
 
     auto end{std::chrono::steady_clock::now()};
-    skyline::Logger::Write(skyline::Logger::LogLevel::Info, fmt::format("Emulation has ended in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()));
+    skyline::Logger::InfoNoPrefix("Emulation has ended in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
     skyline::Logger::EmulationContext.Finalize();
     close(romFd);

--- a/app/src/main/cpp/skyline/common/base.h
+++ b/app/src/main/cpp/skyline/common/base.h
@@ -21,6 +21,9 @@ namespace fmt {
         }
     };
 
+    /**
+     * @brief An {fmt} formatter for enum values, which formats them to their underlying integer value
+     */
     template<class T> requires std::is_enum_v<T>
     struct formatter<T> : formatter<std::underlying_type_t<T>> {
         template<typename FormatContext>

--- a/app/src/main/cpp/skyline/common/base.h
+++ b/app/src/main/cpp/skyline/common/base.h
@@ -20,6 +20,14 @@ namespace fmt {
             return formatter<std::string>::format(s.to_string(), ctx);
         }
     };
+
+    template<class T> requires std::is_enum_v<T>
+    struct formatter<T> : formatter<std::underlying_type_t<T>> {
+        template<typename FormatContext>
+        constexpr auto format(T s, FormatContext &ctx) {
+            return formatter<std::underlying_type_t<T>>::format(static_cast<std::underlying_type_t<T>>(s), ctx);
+        }
+    };
 }
 
 namespace skyline {
@@ -46,15 +54,40 @@ namespace skyline {
 
     namespace util {
         /**
+         * @brief A way to apply a transformation to a paramater pack.
+         * @tparam Out The output type
+         * @tparam Fun The transformation to apply to the parameter pack
+         */
+        template<template<typename...> class Out,
+            template<typename> class Fun,
+            typename... Args>
+        struct TransformArgs {
+            using Type = Out<typename Fun<Args>::Type...>;
+        };
+
+        /**
+         * @brief A way to implicitly cast all pointer types to uintptr_t, this is used for {fmt} as we use 0x{:X} to print pointers
+         * @note There's the exception of signed char pointers as they represent C Strings
+         * @note This does not cover std::shared_ptr or std::unique_ptr and those will have to be explicitly casted to uintptr_t or passed through fmt::ptr
+         */
+        template<typename T>
+        struct FmtCast {
+            using Type = std::conditional_t<std::is_pointer_v<T>,
+                                            std::conditional_t<std::is_same_v<char, std::remove_cv_t<std::remove_pointer_t<T>>>,
+                                                               char *, uintptr_t>,
+                                            T>;
+        };
+
+        /**
          * @brief A way to implicitly cast all pointers to uintptr_t, this is used for {fmt} as we use 0x{:X} to print pointers
          * @note There's the exception of signed char pointers as they represent C Strings
          * @note This does not cover std::shared_ptr or std::unique_ptr and those will have to be explicitly casted to uintptr_t or passed through fmt::ptr
          */
         template<typename T>
-        constexpr auto FmtCast(T object) {
-            if constexpr (std::is_pointer<T>::value)
-                if constexpr (std::is_same<char, typename std::remove_cv<typename std::remove_pointer<T>::type>::type>::value)
-                    return reinterpret_cast<typename std::common_type<char *, T>::type>(object);
+        constexpr auto FmtCastObj(T object) {
+            if constexpr (std::is_pointer_v<T>)
+                if constexpr (std::is_same_v<char, typename std::remove_cv_t<typename std::remove_pointer_t<T>>>)
+                    return reinterpret_cast<typename std::common_type_t<char *, T>>(object);
                 else
                     return reinterpret_cast<const uintptr_t>(object);
             else
@@ -62,11 +95,17 @@ namespace skyline {
         }
 
         /**
+         * @brief A wrapper around fmt::format_string which casts all pointer types to uintptr_t
+         */
+        template<typename... Args>
+        using FormatString = typename TransformArgs<fmt::format_string, FmtCast, Args...>::Type;
+
+        /**
          * @brief {fmt}::format but with FmtCast built into it
          */
-        template<typename S, typename... Args>
-        constexpr auto Format(S formatString, Args &&... args) {
-            return fmt::format(fmt::runtime(formatString), FmtCast(args)...);
+        template<typename... Args>
+        constexpr auto Format(FormatString<Args...> formatString, Args... args) {
+            return fmt::vformat(formatString, fmt::make_format_args(std::forward<decltype(FmtCastObj(args))>(FmtCastObj(args))...));
         }
     }
 
@@ -75,8 +114,11 @@ namespace skyline {
      */
     class exception : public std::runtime_error {
       public:
-        template<typename S, typename... Args>
-        exception(const S &formatStr, Args &&... args) : runtime_error(util::Format(formatStr, args...)) {}
+        template<typename... Args>
+        exception(util::FormatString<Args...> formatStr, Args... args) : runtime_error(util::Format(formatStr, std::forward<Args>(args)...)) {}
+
+        template<typename S>
+        exception(S string) : runtime_error(string) {}
     };
 
     /**

--- a/app/src/main/cpp/skyline/common/logger.cpp
+++ b/app/src/main/cpp/skyline/common/logger.cpp
@@ -35,6 +35,8 @@ namespace skyline {
     void Logger::Run() {
         pthread_setname_np(pthread_self(), "Logger");
 
+        // We don't need to setup signal exception handling here because a SIGINT will never be issued to the logger thread to stop, since its lifetime is equivalent to the process
+        // Any other signal crashes are used to log a stack trace, but if the logger thread crashes then we cannot ensure that trying to log the stack trace won't cause recursive crashes
         logQueue.Process([&](const LogEntry &next) {
             Write(next);
         });

--- a/app/src/main/cpp/skyline/common/logger.cpp
+++ b/app/src/main/cpp/skyline/common/logger.cpp
@@ -43,19 +43,21 @@ namespace skyline {
     }
 
     void Logger::UpdateTag() {
-        if (threadName.empty()) {
+        if (!threadId) {
             std::array<char, 16> name;
-            if (!pthread_getname_np(pthread_self(), name.data(), name.size()))
-                threadName = name.data();
-            else
-                threadName = "unk";
+            if (!pthread_getname_np(pthread_self(), name.data(), name.size())) {
+                threadNamePool.emplace_back(name.data());
+                threadId = threadNamePool.size() - 1;
+            } else {
+                threadId = 0;
+            }
         }
     }
 
     void Logger::WriteAndroid(const LogEntry &logEntry) {
         constexpr std::array<int, 5> levelAlog{ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_INFO, ANDROID_LOG_DEBUG, ANDROID_LOG_VERBOSE}; // This corresponds to LogLevel and provides its equivalent for NDK Logging
 
-        std::string tag = "emu-cpp-" + logEntry.threadName;
+        std::string tag = "emu-cpp-" + threadNamePool[logEntry.threadId];
         __android_log_write(levelAlog[static_cast<u8>(logEntry.level)], tag.c_str(), logEntry.str.c_str());
     }
 
@@ -65,7 +67,7 @@ namespace skyline {
 
         if (logEntry.context)
             // We use RS (\036) and GS (\035) as our delimiters
-            logEntry.context->Write(fmt::format("\036{}\035{}\035{}\035{}\n", levelCharacter[static_cast<u8>(logEntry.level)], (util::GetTimeNs() / constant::NsInMillisecond) - logEntry.context->start, logEntry.threadName, logEntry.str));
+            logEntry.context->Write(fmt::format("\036{}\035{}\035{}\035{}\n", levelCharacter[static_cast<u8>(logEntry.level)], (util::GetTimeNs() / constant::NsInMillisecond) - logEntry.context->start, threadNamePool[logEntry.threadId], logEntry.str));
     }
 
     void Logger::LoggerContext::Write(const std::string &str) {

--- a/app/src/main/cpp/skyline/common/logger.cpp
+++ b/app/src/main/cpp/skyline/common/logger.cpp
@@ -19,18 +19,6 @@ namespace skyline {
         logFile.flush();
     }
 
-    thread_local static std::string logTag, threadName;
-    thread_local static Logger::LoggerContext *context{&Logger::EmulationContext};
-
-    void Logger::UpdateTag() {
-        std::array<char, 16> name;
-        if (!pthread_getname_np(pthread_self(), name.data(), name.size()))
-            threadName = name.data();
-        else
-            threadName = "unk";
-        logTag = std::string("emu-cpp-") + threadName;
-    }
-
     Logger::LoggerContext *Logger::GetContext() {
         return context;
     }
@@ -39,21 +27,43 @@ namespace skyline {
         context = pContext;
     }
 
-    void Logger::WriteAndroid(LogLevel level, const std::string &str) {
-        constexpr std::array<int, 5> levelAlog{ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_INFO, ANDROID_LOG_DEBUG, ANDROID_LOG_VERBOSE}; // This corresponds to LogLevel and provides its equivalent for NDK Logging
-        if (logTag.empty())
-            UpdateTag();
-
-        __android_log_write(levelAlog[static_cast<u8>(level)], logTag.c_str(), str.c_str());
+    void Logger::StartLoggerThread() {
+        if (!thread.joinable())
+            thread = std::thread(&Logger::Run);
     }
 
-    void Logger::Write(LogLevel level, const std::string &str) {
-        constexpr std::array<char, 5> levelCharacter{'E', 'W', 'I', 'D', 'V'}; // The LogLevel as written out to a file
-        WriteAndroid(level, str);
+    void Logger::Run() {
+        pthread_setname_np(pthread_self(), "Logger");
 
-        if (context)
+        logQueue.Process([&](const LogEntry &next) {
+            Write(next);
+        });
+    }
+
+    void Logger::UpdateTag() {
+        if (threadName.empty()) {
+            std::array<char, 16> name;
+            if (!pthread_getname_np(pthread_self(), name.data(), name.size()))
+                threadName = name.data();
+            else
+                threadName = "unk";
+        }
+    }
+
+    void Logger::WriteAndroid(const LogEntry &logEntry) {
+        constexpr std::array<int, 5> levelAlog{ANDROID_LOG_ERROR, ANDROID_LOG_WARN, ANDROID_LOG_INFO, ANDROID_LOG_DEBUG, ANDROID_LOG_VERBOSE}; // This corresponds to LogLevel and provides its equivalent for NDK Logging
+
+        std::string tag = "emu-cpp-" + logEntry.threadName;
+        __android_log_write(levelAlog[static_cast<u8>(logEntry.level)], tag.c_str(), logEntry.str.c_str());
+    }
+
+    void Logger::Write(const LogEntry &logEntry) {
+        constexpr std::array<char, 5> levelCharacter{'E', 'W', 'I', 'D', 'V'}; // The LogLevel as written out to a file
+        WriteAndroid(logEntry);
+
+        if (logEntry.context)
             // We use RS (\036) and GS (\035) as our delimiters
-            context->Write(fmt::format("\036{}\035{}\035{}\035{}\n", levelCharacter[static_cast<u8>(level)], (util::GetTimeNs() / constant::NsInMillisecond) - context->start, threadName, str));
+            logEntry.context->Write(fmt::format("\036{}\035{}\035{}\035{}\n", levelCharacter[static_cast<u8>(logEntry.level)], (util::GetTimeNs() / constant::NsInMillisecond) - logEntry.context->start, logEntry.threadName, logEntry.str));
     }
 
     void Logger::LoggerContext::Write(const std::string &str) {

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -59,111 +59,153 @@ namespace skyline {
 
         static void Write(LogLevel level, const std::string &str);
 
-        /**
-         * @brief A wrapper around a string which captures the calling function using Clang source location builtins
-         * @note A function needs to be declared for every argument template specialization as CTAD cannot work with implicit casting
-         * @url https://clang.llvm.org/docs/LanguageExtensions.html#source-location-builtins
-         */
         template<typename... Args>
-        struct FunctionString {
-            fmt::format_string<Args...> string;
-            const char *function;
+        static void Log(LogLevel level, const char *function, util::FormatString<Args...> formatString, Args... args) {
+            UpdateTag();
+            if (level <= configLevel)
+                Write(level, std::string(function) + ": " + util::Format(formatString, std::forward<Args>(args)...));
+        }
 
-            constexpr FunctionString(fmt::format_string<Args...> string, const char *function = __builtin_FUNCTION()) : string(std::move(string)), function(function) {}
+        template<typename... Args>
+        static void LogNoPrefix(LogLevel level, util::FormatString<Args...> formatString, Args... args) {
+            UpdateTag();
+            if (level <= configLevel)
+                Write(level, util::Format(formatString, std::forward<Args>(args)...));
+        }
 
-            constexpr fmt::format_string<Args...> operator*() {
-                return util::Format("{}: {}", function, string);
-            }
-        };
+        #define LOG(level, formatString, ...)                                                                       \
+        do {                                                                                                        \
+            skyline::Logger::Log(level, __func__, formatString, ##__VA_ARGS__);                                     \
+        } while (false)
+
+        #define LOG_NOPREFIX(level, formatString, ...)                                                              \
+        do {                                                                                                        \
+            skyline::Logger::LogNoPrefix(level, formatString, ##__VA_ARGS__);                                       \
+        } while (false)
+
+        #define LOG_ERROR(formatString, ...)                                                                        \
+        do {                                                                                                        \
+            LOG(LogLevel::Error, formatString, __VA_ARGS__);                                                        \
+        } while (false)
+
+        #define LOG_ERROR_NOPREFIX(formatString, ...)                                                               \
+        do {                                                                                                        \
+            LOG_NOPREFIX(LogLevel::Error, formatString, __VA_ARGS__);                                               \
+        } while (false)
+
+        #define LOG_WARN(formatString, ...)                                                                         \
+        do {                                                                                                        \
+            LOG(LogLevel::Warn, formatString, __VA_ARGS__);                                                         \
+        } while (false)
+
+        #define LOG_WARN_NOPREFIX(formatString, ...)                                                                \
+        do {                                                                                                        \
+            LOG_NOPREFIX(LogLevel::Warn, formatString, __VA_ARGS__);                                                \
+        } while (false)
+
+        #define LOG_INFO(formatString, ...)                                                                         \
+        do {                                                                                                        \
+            LOG(LogLevel::Info, formatString, __VA_ARGS__);                                                         \
+        } while (false)
+
+        #define LOG_INFO_NOPREFIX(formatString, ...)                                                                \
+        do {                                                                                                        \
+            LOG_NOPREFIX(LogLevel::Info, formatString, __VA_ARGS__);                                                \
+        } while (false)
+
+        #define LOG_DEBUG(formatString, ...)                                                                        \
+        do {                                                                                                        \
+            LOG(LogLevel::Debug, formatString, __VA_ARGS__);                                                        \
+        } while (false)
+
+        #define LOG_DEBUG_NOPREFIX(formatString, ...)                                                               \
+        do {                                                                                                        \
+            LOG_NOPREFIX(LogLevel::Debug, formatString, __VA_ARGS__);                                               \
+        } while (false)
+
+        #define LOG_VERBOSE(formatString, ...)                                                                      \
+        do {                                                                                                        \
+            LOG(LogLevel::Verbose, formatString, __VA_ARGS__);                                                      \
+        } while (false)
+
+        #define LOG_VERBOSE_NOPREFIX(formatString, ...)                                                             \
+        do {                                                                                                        \
+            LOG_NOPREFIX(LogLevel::Verbose, formatString, __VA_ARGS__);                                             \
+        } while (false)
 
         template<typename... Args>
         static void Error(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Error, formatString, std::forward<Args>(args)...);
         }
 
         template<typename S>
         static void Error(const S &string) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, string);
+            LOG_NOPREFIX(LogLevel::Error, "{}", string);
         }
 
         template<typename... Args>
         static void ErrorNoPrefix(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Error, formatString, std::forward<Args>(args)...);
         }
 
         template<typename... Args>
         static void Warn(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Warn, formatString, std::forward<Args>(args)...);
         }
 
         template<typename S>
         static void Warn(const S &string) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, string);
+            LOG_NOPREFIX(LogLevel::Warn, "{}", string);
         }
 
         template<typename... Args>
         static void WarnNoPrefix(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Warn, formatString, std::forward<Args>(args)...);
         }
 
         template<typename... Args>
         static void Info(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Info, formatString, std::forward<Args>(args)...);
         }
 
         template<typename S>
         static void Info(const S &string) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, string);
+            LOG_NOPREFIX(LogLevel::Info, "{}", string);
         }
 
         template<typename... Args>
         static void InfoNoPrefix(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Info, formatString, std::forward<Args>(args)...);
         }
 
         template<typename... Args>
         static void Debug(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Debug, formatString, std::forward<Args>(args)...);
         }
 
         template<typename S>
         static void Debug(const S &string) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, string);
+            LOG_NOPREFIX(LogLevel::Debug, "{}", string);
         }
 
         template<typename... Args>
         static void DebugNoPrefix(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Debug, formatString, std::forward<Args>(args)...);
         }
 
         template<typename... Args>
         static void Verbose(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Verbose, formatString, std::forward<Args>(args)...);
         }
 
         template<typename S>
         static void Verbose(const S &string) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, string);
+            LOG_NOPREFIX(LogLevel::Verbose, "{}", string);
         }
 
         template<typename... Args>
         static void VerboseNoPrefix(util::FormatString<Args...> formatString, Args... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(formatString, std::forward<Args>(args)...));
+            LOG_NOPREFIX(LogLevel::Verbose, formatString, std::forward<Args>(args)...);
         }
     };
 }

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -36,8 +36,15 @@ namespace skyline {
 
             LoggerContext() {}
 
+            /**
+             * @brief Initialises a LoggerContext and opens an output file stream at the given path
+             */
             void Initialize(const std::string &path);
 
+            /**
+             * @brief Closes the output file stream
+             * @note After this has been called, the context must be re-initialised before any other logging operation
+             */
             void Finalize();
 
             void Flush();
@@ -53,13 +60,17 @@ namespace skyline {
             std::string threadName;
         };
 
+        static constexpr size_t LogQueueSize{1024}; //!< Maximum size of the log queue, this value is arbritary
         static inline LogLevel configLevel{LogLevel::Verbose}; //!< The minimum level of logs to write
-        static inline CircularQueue<LogEntry> logQueue{1024}; //!< The queue where all log messages are sent
+        static inline CircularQueue<LogEntry> logQueue{LogQueueSize}; //!< The queue where all log messages are sent
         static inline std::thread thread; //!< The thread that handles writing log entries from the logger queue
 
         thread_local static inline std::string threadName;
-        thread_local static inline LoggerContext *context{&EmulationContext}; //!< The logger context of a particular thread
+        thread_local static inline LoggerContext *context{&EmulationContext}; //!< The logger context attached to the current thread
 
+        /**
+         * @note The logger thread is launched at application startup via a JNI call, and will keep running until the app is closed
+         */
         static void StartLoggerThread();
 
         static void Run();

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -57,7 +57,7 @@ namespace skyline {
             LoggerContext *context;
             LogLevel level;
             std::string str;
-            std::string threadName;
+            size_t threadId;
         };
 
         static constexpr size_t LogQueueSize{1024}; //!< Maximum size of the log queue, this value is arbritary
@@ -65,7 +65,8 @@ namespace skyline {
         static inline CircularQueue<LogEntry> logQueue{LogQueueSize}; //!< The queue where all log messages are sent
         static inline std::thread thread; //!< The thread that handles writing log entries from the logger queue
 
-        thread_local static inline std::string threadName;
+        thread_local static inline std::vector<std::string> threadNamePool{"unk"}; //!< Names of all threads that write logs to avoid copying the thread name on every log
+        thread_local static inline std::optional<size_t> threadId; //!< The index of the current thread's name in the vector
         thread_local static inline LoggerContext *context{&EmulationContext}; //!< The logger context attached to the current thread
 
         /**
@@ -102,7 +103,7 @@ namespace skyline {
                                   .context = context,
                                   .level = level,
                                   .str = std::move(std::string(function) + ": " + util::Format(formatString, std::forward<Args>(args)...)),
-                                  .threadName = threadName,
+                                  .threadId = threadId.value_or(0),
                               });
         }
 
@@ -114,7 +115,7 @@ namespace skyline {
                                   .context = context,
                                   .level = level,
                                   .str = std::move(util::Format(formatString, std::forward<Args>(args)...)),
-                                  .threadName = threadName,
+                                  .threadId = threadId.value_or(0),
                               });
         }
 

--- a/app/src/main/cpp/skyline/common/logger.h
+++ b/app/src/main/cpp/skyline/common/logger.h
@@ -64,106 +64,106 @@ namespace skyline {
          * @note A function needs to be declared for every argument template specialization as CTAD cannot work with implicit casting
          * @url https://clang.llvm.org/docs/LanguageExtensions.html#source-location-builtins
          */
-        template<typename S>
+        template<typename... Args>
         struct FunctionString {
-            S string;
+            fmt::format_string<Args...> string;
             const char *function;
 
-            FunctionString(S string, const char *function = __builtin_FUNCTION()) : string(std::move(string)), function(function) {}
+            constexpr FunctionString(fmt::format_string<Args...> string, const char *function = __builtin_FUNCTION()) : string(std::move(string)), function(function) {}
 
-            std::string operator*() {
-                return std::string(function) + ": " + std::string(string);
+            constexpr fmt::format_string<Args...> operator*() {
+                return util::Format("{}: {}", function, string);
             }
         };
 
         template<typename... Args>
-        static void Error(FunctionString<const char *> formatString, Args &&... args) {
+        static void Error(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(*formatString, args...));
+                Write(LogLevel::Error, util::Format(formatString, std::forward<Args>(args)...));
         }
 
-        template<typename... Args>
-        static void Error(FunctionString<std::string> formatString, Args &&... args) {
+        template<typename S>
+        static void Error(const S &string) {
             if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(*formatString, args...));
+                Write(LogLevel::Error, string);
         }
 
-        template<typename S, typename... Args>
-        static void ErrorNoPrefix(S formatString, Args &&... args) {
+        template<typename... Args>
+        static void ErrorNoPrefix(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Error <= configLevel)
-                Write(LogLevel::Error, util::Format(formatString, args...));
+                Write(LogLevel::Error, util::Format(formatString, std::forward<Args>(args)...));
         }
 
         template<typename... Args>
-        static void Warn(FunctionString<const char *> formatString, Args &&... args) {
+        static void Warn(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(*formatString, args...));
+                Write(LogLevel::Warn, util::Format(formatString, std::forward<Args>(args)...));
         }
 
-        template<typename... Args>
-        static void Warn(FunctionString<std::string> formatString, Args &&... args) {
+        template<typename S>
+        static void Warn(const S &string) {
             if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(*formatString, args...));
+                Write(LogLevel::Warn, string);
         }
 
-        template<typename S, typename... Args>
-        static void WarnNoPrefix(S formatString, Args &&... args) {
+        template<typename... Args>
+        static void WarnNoPrefix(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Warn <= configLevel)
-                Write(LogLevel::Warn, util::Format(formatString, args...));
+                Write(LogLevel::Warn, util::Format(formatString, std::forward<Args>(args)...));
         }
 
         template<typename... Args>
-        static void Info(FunctionString<const char *> formatString, Args &&... args) {
+        static void Info(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(*formatString, args...));
+                Write(LogLevel::Info, util::Format(formatString, std::forward<Args>(args)...));
         }
 
-        template<typename... Args>
-        static void Info(FunctionString<std::string> formatString, Args &&... args) {
+        template<typename S>
+        static void Info(const S &string) {
             if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(*formatString, args...));
+                Write(LogLevel::Info, string);
         }
 
-        template<typename S, typename... Args>
-        static void InfoNoPrefix(S formatString, Args &&... args) {
+        template<typename... Args>
+        static void InfoNoPrefix(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Info <= configLevel)
-                Write(LogLevel::Info, util::Format(formatString, args...));
+                Write(LogLevel::Info, util::Format(formatString, std::forward<Args>(args)...));
         }
 
         template<typename... Args>
-        static void Debug(FunctionString<const char *> formatString, Args &&... args) {
+        static void Debug(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(*formatString, args...));
+                Write(LogLevel::Debug, util::Format(formatString, std::forward<Args>(args)...));
         }
 
-        template<typename... Args>
-        static void Debug(FunctionString<std::string> formatString, Args &&... args) {
+        template<typename S>
+        static void Debug(const S &string) {
             if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(*formatString, args...));
+                Write(LogLevel::Debug, string);
         }
 
-        template<typename S, typename... Args>
-        static void DebugNoPrefix(S formatString, Args &&... args) {
+        template<typename... Args>
+        static void DebugNoPrefix(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Debug <= configLevel)
-                Write(LogLevel::Debug, util::Format(formatString, args...));
+                Write(LogLevel::Debug, util::Format(formatString, std::forward<Args>(args)...));
         }
 
         template<typename... Args>
-        static void Verbose(FunctionString<const char *> formatString, Args &&... args) {
+        static void Verbose(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(*formatString, args...));
+                Write(LogLevel::Verbose, util::Format(formatString, std::forward<Args>(args)...));
+        }
+
+        template<typename S>
+        static void Verbose(const S &string) {
+            if (LogLevel::Verbose <= configLevel)
+                Write(LogLevel::Verbose, string);
         }
 
         template<typename... Args>
-        static void Verbose(FunctionString<std::string> formatString, Args &&... args) {
+        static void VerboseNoPrefix(util::FormatString<Args...> formatString, Args... args) {
             if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(*formatString, args...));
-        }
-
-        template<typename S, typename... Args>
-        static void VerboseNoPrefix(S formatString, Args &&... args) {
-            if (LogLevel::Verbose <= configLevel)
-                Write(LogLevel::Verbose, util::Format(formatString, args...));
+                Write(LogLevel::Verbose, util::Format(formatString, std::forward<Args>(args)...));
         }
     };
 }

--- a/app/src/main/cpp/skyline/common/trace.h
+++ b/app/src/main/cpp/skyline/common/trace.h
@@ -2,7 +2,7 @@
 
 #include <limits>
 #include <perfetto.h>
-#include <common.h>
+#include "base.h"
 
 #define TRACE_EVENT_FMT(category, formatString, ...) TRACE_EVENT(category, nullptr, [&](perfetto::EventContext ctx) { \
     ctx.event()->set_name(skyline::util::Format(formatString, __VA_ARGS__));                                          \

--- a/app/src/main/cpp/skyline/gpu.cpp
+++ b/app/src/main/cpp/skyline/gpu.cpp
@@ -110,7 +110,7 @@ namespace skyline::gpu {
             #undef IGNORE_TYPE
         }
 
-        Logger::Write(severityLookup.at(static_cast<size_t>(std::countr_zero(static_cast<u32>(flags)))), util::Format("Vk{}:{}[0x{:X}]:I{}:L{}: {}", layerPrefix, vk::to_string(vk::DebugReportObjectTypeEXT(objectType)), object, messageCode, location, message));
+        LOG(severityLookup.at(static_cast<size_t>(std::countr_zero(static_cast<u32>(flags)))), "Vk{}:{}[0x{:X}]:I{}:L{}: {}", layerPrefix, vk::to_string(vk::DebugReportObjectTypeEXT(objectType)).c_str(), object, messageCode, location, message);
 
         return VK_FALSE;
     }

--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -647,7 +647,7 @@ namespace skyline::kernel::svc {
             Logger::Debug("Waiting on handles:\n{}Timeout: {}ns", handleString, timeout);
         }
 
-        TRACE_EVENT_FMT("kernel", waitHandles.size() == 1 ? "WaitSynchronization 0x{:X}" : "WaitSynchronizationMultiple 0x{:X}", waitHandles[0]);
+        TRACE_EVENT_FMT("kernel", fmt::runtime(waitHandles.size() == 1 ? "WaitSynchronization 0x{:X}" : "WaitSynchronizationMultiple 0x{:X}"), waitHandles[0]);
 
         std::unique_lock lock(type::KSyncObject::syncObjectMutex);
         if (state.thread->cancelSync) {

--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
@@ -167,6 +167,6 @@ namespace skyline::service::hosbinder {
         if (layerId != DefaultLayerId)
             throw exception("Destroying non-existent layer #{}", layerId);
         else if (layer)
-            throw exception("Destroying layer #{} which hasn't been closed: Weak References: {}, Strong References: {}", layerWeakReferenceCount, layerStrongReferenceCount);
+            throw exception("Destroying layer #{} which hasn't been closed: Weak References: {}, Strong References: {}", layerId, layerWeakReferenceCount, layerStrongReferenceCount);
     }
 }

--- a/app/src/main/cpp/skyline/services/lm/ILogger.cpp
+++ b/app/src/main/cpp/skyline/services/lm/ILogger.cpp
@@ -122,7 +122,7 @@ namespace skyline::service::lm {
         if (logMessage.dropCount)
             message << " (Dropped Messages: " << logMessage.time << ')';
 
-        Logger::Write(hostLevel, message.str());
+        LOG_NOPREFIX(hostLevel, "{}", message.str());
 
         return {};
     }


### PR DESCRIPTION
This PR accomplishes the following:
1. {fmt} [8.0.0](https://github.com/fmtlib/fmt/releases/tag/8.0.0) enabled compile-time format string checking by default on compilers with C++20 `consteval` support. All format strings were previously wrapped in `fmt::runtime` waiting to comply with the new change. This PR finally makes use of compile-time checking by taking `fmt::format_string` as format string argument type in the `Logger` calls.
2. We noticed logging IO operations took almost as much as shader compilation. This PR offloads IO operations to a dedicated thread, log messages are pushed to a FIFO and will be written to logcat/file by the logger thread.

TODO:
- [ ] Merge `ftx1` branch
- [ ] Refactor all Logger calls to the new macro ones