### PR TITLE
Ignore empty lines in key files

### DIFF
--- a/app/src/main/java/emu/skyline/KeyReader.kt
+++ b/app/src/main/java/emu/skyline/KeyReader.kt
@@ -37,7 +37,7 @@ object KeyReader {
         tmpOutputFile.bufferedWriter().use { writer ->
             val valid = inputStream!!.bufferedReader().useLines {
                 for (line in it) {
-                    if (line.startsWith(";")) continue
+                    if (line.startsWith(";") || line.isBlank()) continue
 
                     val pair = line.split("=")
                     if (pair.size != 2)


### PR DESCRIPTION
I wanted to try skyline and it kept rejecting my prod.keys file. Turned out to be caused by an empty line.