### PR TITLE
Implement some IAccountServiceForApplication functions

### DIFF
--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
@@ -8,6 +8,11 @@
 namespace skyline::service::account {
     IAccountServiceForApplication::IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
 
+    Result IAccountServiceForApplication::GetUserCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(1); // We only support one user currently
+        return {};
+    }
+
     Result IAccountServiceForApplication::GetUserExistence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto id{request.Pop<UserId>()};
 
@@ -74,6 +79,15 @@ namespace skyline::service::account {
             return result::NullArgument;
 
         manager.RegisterService(SRVREG(IManagerForApplication), session, response);
+        return {};
+    }
+
+    Result IAccountServiceForApplication::InitializeApplicationInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
+
+    Result IAccountServiceForApplication::IsUserAccountSwitchLocked(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(0); // We don't want to lock the user
         return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
@@ -41,6 +41,11 @@ namespace skyline {
             IAccountServiceForApplication(const DeviceState &state, ServiceManager &manager);
 
             /**
+             * @brief Returns the amount of user accounts on the console
+             */
+            Result GetUserCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+            /**
              * @brief Checks if the given user ID exists
              */
             Result GetUserExistence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -76,14 +81,28 @@ namespace skyline {
              */
             Result GetBaasAccountManagerForApplication(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+            /**
+             * @brief Returns if the user's account is locked or unlocked
+             */
+            Result IsUserAccountSwitchLocked(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+            /**
+            * @brief Provides information about the running application for account services to use
+            * @url https://switchbrew.org/wiki/Account_services#InitializeApplicationInfo
+            */
+            Result InitializeApplicationInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
             SERVICE_DECL(
+                SFUNC(0x0, IAccountServiceForApplication, GetUserCount),
                 SFUNC(0x1, IAccountServiceForApplication, GetUserExistence),
                 SFUNC(0x2, IAccountServiceForApplication, ListAllUsers),
                 SFUNC(0x3, IAccountServiceForApplication, ListOpenUsers),
                 SFUNC(0x4, IAccountServiceForApplication, GetLastOpenedUser),
                 SFUNC(0x5, IAccountServiceForApplication, GetProfile),
                 SFUNC(0x64, IAccountServiceForApplication, InitializeApplicationInfoV0),
-                SFUNC(0x65, IAccountServiceForApplication, GetBaasAccountManagerForApplication)
+                SFUNC(0x65, IAccountServiceForApplication, GetBaasAccountManagerForApplication),
+                SFUNC(0x8C, IAccountServiceForApplication, InitializeApplicationInfo),
+                SFUNC(0x96, IAccountServiceForApplication, IsUserAccountSwitchLocked)
             )
         };
     }


### PR DESCRIPTION
This PR stubs some functions in [IAccountServiceForApplication](https://switchbrew.org/wiki/Account_services#acc:u0) :
- IAccountServiceForApplication::GetUserCount (0x0)
- IAccountServiceForApplication::InitializeApplicationInfo (0x8C)
- IAccountServiceForApplication::IsUserAccountSwitchLocked (0x96)

This is required by New Pokémon Snap, implementing these services makes this game boot a bit further and display a (broken) splash screen.

![image](https://user-images.githubusercontent.com/10391562/157418335-eb20d67b-13bb-448d-970e-708c2b3602a0.png)

