### PR TITLE
Automatically import key files from search location

### DIFF
--- a/app/src/main/java/emu/skyline/KeyReader.kt
+++ b/app/src/main/java/emu/skyline/KeyReader.kt
@@ -19,6 +19,20 @@ object KeyReader {
 
         companion object {
             fun parse(keyName : String) = values().first { it.keyName == keyName }
+            fun parse(documentFile : DocumentFile) = values().first { it.fileName == documentFile.name }
+            fun parseOrNull(documentFile : DocumentFile) = values().find { it.fileName == documentFile.name }
+        }
+    }
+
+    fun importFromLocation(context : Context, searchLocation : Uri) = importFromDirectory(context, DocumentFile.fromTreeUri(context, searchLocation)!!)
+
+    private fun importFromDirectory(context : Context, directory : DocumentFile) {
+        directory.listFiles().forEach { file ->
+            if (file.isDirectory) {
+                importFromDirectory(context, file)
+            } else {
+                KeyType.parseOrNull(file)?.let { import(context, file.uri, it) }
+            }
         }
     }
 

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -292,7 +292,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadRoms(loadFromFile : Boolean) {
-        viewModel.loadRoms(loadFromFile, Uri.parse(settings.searchLocation), settings.systemLanguage)
+        viewModel.loadRoms(this, loadFromFile, Uri.parse(settings.searchLocation), settings.systemLanguage)
         settings.refreshRequired = false
     }
 

--- a/app/src/main/java/emu/skyline/MainViewModel.kt
+++ b/app/src/main/java/emu/skyline/MainViewModel.kt
@@ -41,7 +41,7 @@ class MainViewModel @Inject constructor(@ApplicationContext context : Context, p
      *
      * @param loadFromFile If this is false then trying to load cached adapter data is skipped entirely
      */
-    fun loadRoms(loadFromFile : Boolean, searchLocation : Uri, systemLanguage : Int) {
+    fun loadRoms(context : Context, loadFromFile : Boolean, searchLocation : Uri, systemLanguage : Int) {
         if (state == MainState.Loading) return
         state = MainState.Loading
 
@@ -62,6 +62,7 @@ class MainViewModel @Inject constructor(@ApplicationContext context : Context, p
                 MainState.Loaded(HashMap())
             } else {
                 try {
+                    KeyReader.importFromLocation(context, searchLocation)
                     val romElements = romProvider.loadRoms(searchLocation, systemLanguage)
                     romElements.toFile(romsFile)
                     MainState.Loaded(romElements)


### PR DESCRIPTION
`title.keys` and `prod.keys` files found in the search location folder are now imported automatically (subfolders included). This means it should no longer be necessary to manually import keys if they are kept in the same folder as games.