### PR TITLE
Add support for drawing inside the display cutout areas

### DIFF
--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -7,10 +7,7 @@ package emu.skyline.input.onscreen
 
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.WindowInsets
-import android.view.WindowInsetsController
+import android.view.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -90,7 +87,20 @@ class OnScreenEditActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
+        window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
         setContentView(binding.root)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Android might not allow child views to overlap the system bars
+            // Override this behavior and force content to extend into the cutout area
+            window.setDecorFitsSystemWindows(false)
+
+            window.insetsController?.let {
+                it.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                it.hide(WindowInsets.Type.systemBars())
+            }
+        }
+
         binding.onScreenControllerView.recenterSticks = settings.onScreenControlRecenterSticks
 
         actions.forEach { pair ->
@@ -99,11 +109,6 @@ class OnScreenEditActivity : AppCompatActivity() {
                 setOnClickListener { pair.second.invoke() }
                 fabMapping[pair.first] = this
             })
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.insetsController?.hide(WindowInsets.Type.navigationBars() or WindowInsets.Type.systemBars() or WindowInsets.Type.systemGestures() or WindowInsets.Type.statusBars())
-            window.insetsController?.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
     }
 

--- a/app/src/main/java/emu/skyline/utils/Settings.kt
+++ b/app/src/main/java/emu/skyline/utils/Settings.kt
@@ -44,4 +44,6 @@ class Settings @Inject constructor(@ApplicationContext private val context : Con
     var systemLanguage by sharedPreferences(context, 1)
 
     var orientation by sharedPreferences(context, ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE)
+
+    var respectDisplayCutout by sharedPreferences(context, false)
 }

--- a/app/src/main/res/layout/emu_activity.xml
+++ b/app/src/main/res/layout/emu_activity.xml
@@ -4,9 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:keepScreenOn="true"
     android:background="@android:color/black"
-    tools:context=".EmulationActivity">
+    android:keepScreenOn="true"
+    tools:context=".EmulationActivity"
+    tools:ignore="RtlHardcoded">
 
     <emu.skyline.views.FixedRatioSurfaceView
         android:id="@+id/game_view"
@@ -23,16 +24,18 @@
         android:id="@+id/perf_stats"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="5dp"
+        android:layout_marginLeft="@dimen/onScreenItemHorizontalMargin"
         android:layout_marginTop="5dp"
         android:textColor="#9fffff00" />
 
     <ImageButton
         android:id="@+id/on_screen_controller_toggle"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:background="?attr/selectableItemBackgroundBorderless"
+        android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
+        android:background="?android:attr/actionBarItemBackground"
+        android:padding="8dp"
         android:src="@drawable/ic_show"
         app:tint="#40FFFFFF"
         tools:ignore="ContentDescription" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="grid_padding">8dp</dimen>
+    <dimen name="onScreenItemHorizontalMargin">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
     <string name="max_refresh_rate_enabled">Sets the display refresh rate as high as possible (Will break most games)</string>
     <string name="max_refresh_rate_disabled">Sets the display refresh rate to 60Hz</string>
     <string name="aspect_ratio">Aspect Ratio</string>
+    <string name="respect_display_cutout">Respect Display Cutout</string>
+    <string name="respect_display_cutout_enabled">Do not draw UI elements in the cutout area</string>
+    <string name="respect_display_cutout_disabled">Allow UI elements to be drawn in the cutout area</string>
     <!-- Input -->
     <string name="input">Input</string>
     <string name="osc">On-Screen Controls</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -116,6 +116,12 @@
             app:key="aspect_ratio"
             app:title="@string/aspect_ratio"
             app:useSimpleSummaryProvider="true" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:summaryOff="@string/respect_display_cutout_disabled"
+            android:summaryOn="@string/respect_display_cutout_enabled"
+            app:key="respect_display_cutout"
+            app:title="@string/respect_display_cutout" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="category_input"


### PR DESCRIPTION
* The game view now extends from edge to edge of the screen when stretched, and is properly centered when 16:9
* Added a setting to force respecting display cutouts for on-screen elements (FPS counter, OSC toggle), forcing margin to be applied to those elements to render outside of the cutout area. Most users will not need this, but it might be necessary for some devices that have the camera pinhole on the top right of the screen.