### PR TITLE
Stub ICommonStateGetter::SetCpuBoostMode

### DIFF
--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.cpp
@@ -71,4 +71,19 @@ namespace skyline::service::am {
         }
         return {};
     }
+
+    Result ICommonStateGetter::SetCpuBoostMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        cpuBoostMode = request.Pop<CpuBoostMode>();
+        switch (cpuBoostMode) {
+            case CpuBoostMode::Normal:
+            case CpuBoostMode::FastLoad:
+            case CpuBoostMode::PowerSaving:
+                Logger::Info("Set CPU boost mode to {}", ToString(cpuBoostMode));
+                return {};
+            default:
+                Logger::Error("Unknown CPU boost mode value: 0x{:X}", cpuBoostMode);
+                return result::InvalidParameters;
+        }
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.h
+++ b/app/src/main/cpp/skyline/services/am/controller/ICommonStateGetter.h
@@ -5,10 +5,12 @@
 
 #include <kernel/types/KEvent.h>
 #include <services/serviceman.h>
+#include <common/macros.h>
 
 namespace skyline::service::am {
     namespace result {
         constexpr Result NoMessages(128, 3);
+        constexpr Result InvalidParameters(128, 506);
     }
 
     /**
@@ -43,6 +45,18 @@ namespace skyline::service::am {
             Handheld = 0, //!< The device is in handheld mode
             Docked = 1,   //!< The device is in docked mode
         } operationMode;
+
+        enum class CpuBoostMode : u32 {
+            Normal = 0,     //!< The device runs at stock CPU and CPU clocks
+            FastLoad = 1,   //!< The device runs at boosted CPU clocks and minimum GPU clocks
+            PowerSaving = 2 //!< The device runs at stock CPU clocks and minimum GPU clocks
+        } cpuBoostMode;
+
+        ENUM_STRING(CpuBoostMode, {
+            ENUM_CASE_PAIR(Normal, "Normal");
+            ENUM_CASE_PAIR(FastLoad, "Fast Load");
+            ENUM_CASE_PAIR(PowerSaving, "Power Saving");
+        })
 
         /**
          * @brief Queues a message for the application to read via ReceiveMessage
@@ -95,6 +109,12 @@ namespace skyline::service::am {
          */
         Result GetDefaultDisplayResolution(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Sets the CPU boost mode to the supplied value
+         * @url https://switchbrew.org/wiki/Applet_Manager_services#SetCpuBoostMode
+         */
+        Result SetCpuBoostMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x0, ICommonStateGetter, GetEventHandle),
             SFUNC(0x1, ICommonStateGetter, ReceiveMessage),
@@ -102,7 +122,8 @@ namespace skyline::service::am {
             SFUNC(0x6, ICommonStateGetter, GetPerformanceMode),
             SFUNC(0x9, ICommonStateGetter, GetCurrentFocusState),
             SFUNC(0x32, ICommonStateGetter, IsVrModeEnabled),
-            SFUNC(0x3C, ICommonStateGetter, GetDefaultDisplayResolution)
+            SFUNC(0x3C, ICommonStateGetter, GetDefaultDisplayResolution),
+            SFUNC(0x42, ICommonStateGetter, SetCpuBoostMode)
         )
     };
 }


### PR DESCRIPTION
This makes Metroid Dread boot, although it has very major graphical glitches. (Screenshot is from the game's gallery)
![image](https://user-images.githubusercontent.com/10391562/160426348-885e6eb1-ef84-4ff4-b330-4db1ddbadcf1.png)
