### PR TITLE
Swap out boostorg/boost for skyline-emu/boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,16 @@ jobs:
           submodules: recursive
 
       - name: Restore Gradle Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /root/.gradle/
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Restore CXX Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: app/.cxx/
           key: ${{ runner.os }}-cxx-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-cxx-
 
       - name: Install Ninja Build
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	url = https://github.com/xiph/opus
 [submodule "Boost"]
 	path = app/libraries/boost
-	url = https://github.com/boostorg/boost.git
+	url = https://github.com/skyline-emu/boost.git
 	ignore = all
 [submodule "LLVM"]
 	path = app/libraries/llvm

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -38,6 +38,11 @@ set(LIBCXXABI_LIBCXX_INCLUDES "${LIBCXX_TARGET_INCLUDE_DIRECTORY}" CACHE STRING 
 add_subdirectory("libraries/llvm/libcxxabi")
 link_libraries(cxxabi_static)
 
+# Skyline's Boost fork
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_MULTITHREADED ON)
+add_subdirectory("libraries/boost")
+
 # {fmt}
 add_subdirectory("libraries/fmt")
 
@@ -93,11 +98,6 @@ target_compile_definitions(opus PRIVATE OPUS_WILL_BE_SLOW=1) # libopus will warn
 include_directories(SYSTEM "libraries/perfetto/sdk")
 add_library(perfetto STATIC libraries/perfetto/sdk/perfetto.cc)
 target_compile_options(perfetto PRIVATE -Wno-everything)
-
-# Boost
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-add_subdirectory("libraries/boost")
 
 # C++ Range v3
 add_subdirectory("libraries/range")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ android {
         disable 'IconLocation'
     }
 
-    /* NDK */
+    /* NDK and CMake */
     ndkVersion '25.0.8221429'
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
Using [boostorg/boost](https://github.com/boostorg/boost) slowed down GitKraken and git-cmd to unusable levels because of the amount of recursive submodules that repository has. We have decided to solve this issue by making a fork of that repo, [skyline-emu/boost](https://github.com/skyline-emu/boost), tailored down to only the submodules we use in Skyline's codebase, cloned with depth 1 (shallow). This speeds up `git` operations significantly across the repository.

Note: if you have used the repository prior to this point, after this PR is merged you'll need to reset the boost submodule and clean CMake and Gradle cache:
```sh
# Sync boost to the new remote
cd app/libraries
git submodule sync boost

# Enter the boost submodule
cd boost
# Verify that the new remote is skyline-emu/boost
git remote -vv

# Reset the submodule to the new HEAD
git checkout origin/HEAD
git submodule deinit

# Exit from the boost submodule and update it
cd ..
git submodule update --init --recursive boost

# Clean CMake cache
cd ..
rm -rf .gradle && rm -rf build && rm -rf app/build && rm -rf app/.cxx
# On Windows either run this command in powershell without the `-rf` argument and select [A] Yes to All or delete the folders from Explorer
```