### PR TITLE
Fix American English language code.

### DIFF
--- a/app/src/main/cpp/skyline/common/language.h
+++ b/app/src/main/cpp/skyline/common/language.h
@@ -22,7 +22,7 @@ namespace skyline {
          */
         #define LANGUAGES                                               \
             LANG_ENTRY(Japanese,             ja,       0,  2, MAP)      \
-            LANG_ENTRY(AmericanEnglish,      en-us,    1,  0, MAP)      \
+            LANG_ENTRY(AmericanEnglish,      en-US,    1,  0, MAP)      \
             LANG_ENTRY(French,               fr,       2,  3, MAP)      \
             LANG_ENTRY(German,               de,       3,  4, MAP)      \
             LANG_ENTRY(Italian,              it,       4,  7, MAP)      \


### PR DESCRIPTION
The American English language code wasn't correctly capitalized, which led to bugs in some games like Metroid Dread when American English or British English was selected.

Without the fix:
![image](https://user-images.githubusercontent.com/10391562/166106678-394931a4-fbfe-4688-8d7c-67cc26852128.png)

With the fix:
![image](https://user-images.githubusercontent.com/10391562/166106662-db7a4a47-3658-4dc6-8929-0304c91dd5f5.png)
