### PR TITLE
Use spans instead of ptr and size in kernel memory

### DIFF
--- a/app/src/main/cpp/skyline/common/span.h
+++ b/app/src/main/cpp/skyline/common/span.h
@@ -87,6 +87,13 @@ namespace skyline {
         }
 
         /**
+         * @return If a supplied address is located inside this span
+         */
+        constexpr bool contains(const T *address) const {
+            return this->data() <= address && this->end().base() > address;
+        }
+
+        /**
          * @return If the span is valid by not being null
          */
         constexpr bool valid() const {

--- a/app/src/main/cpp/skyline/gpu/buffer.cpp
+++ b/app/src/main/cpp/skyline/gpu/buffer.cpp
@@ -17,7 +17,7 @@ namespace skyline::gpu {
         u8 *alignedData{util::AlignDown(guest->data(), PAGE_SIZE)};
         size_t alignedSize{static_cast<size_t>(util::AlignUp(guest->data() + guest->size(), PAGE_SIZE) - alignedData)};
 
-        alignedMirror = gpu.state.process->memory.CreateMirror(alignedData, alignedSize);
+        alignedMirror = gpu.state.process->memory.CreateMirror(span<u8>{alignedData, alignedSize});
         mirror = alignedMirror.subspan(static_cast<size_t>(guest->data() - alignedData), guest->size());
 
         trapHandle = gpu.state.nce->TrapRegions(*guest, true, [this] {
@@ -264,7 +264,7 @@ namespace skyline::gpu {
         return BufferView{shared_from_this(), &(*it)};
     }
 
-    vk::DeviceSize Buffer::AcquireMegaBuffer(MegaBuffer& megaBuffer) {
+    vk::DeviceSize Buffer::AcquireMegaBuffer(MegaBuffer &megaBuffer) {
         SynchronizeGuest(false, true); // First try and enable megabuffering by doing an immediate sync
 
         if (!megaBufferingEnabled)
@@ -367,7 +367,7 @@ namespace skyline::gpu {
         bufferDelegate->buffer->Write(pCycle, flushHostCallback, gpuCopyCallback, data, offset + bufferDelegate->view->offset);
     }
 
-    vk::DeviceSize BufferView::AcquireMegaBuffer(MegaBuffer& megaBuffer) const {
+    vk::DeviceSize BufferView::AcquireMegaBuffer(MegaBuffer &megaBuffer) const {
         vk::DeviceSize bufferOffset{bufferDelegate->buffer->AcquireMegaBuffer(megaBuffer)};
 
         // Propagate 0 results since they signify that megabuffering isn't supported for a buffer

--- a/app/src/main/cpp/skyline/gpu/texture/texture.cpp
+++ b/app/src/main/cpp/skyline/gpu/texture/texture.cpp
@@ -134,7 +134,7 @@ namespace skyline::gpu {
             u8 *alignedData{util::AlignDown(mapping.data(), PAGE_SIZE)};
             size_t alignedSize{static_cast<size_t>(util::AlignUp(mapping.data() + mapping.size(), PAGE_SIZE) - alignedData)};
 
-            alignedMirror = gpu.state.process->memory.CreateMirror(alignedData, alignedSize);
+            alignedMirror = gpu.state.process->memory.CreateMirror(span<u8>{alignedData, alignedSize});
             mirror = alignedMirror.subspan(static_cast<size_t>(mapping.data() - alignedData), mapping.size());
         } else {
             std::vector<span<u8>> alignedMappings;

--- a/app/src/main/cpp/skyline/input.h
+++ b/app/src/main/cpp/skyline/input.h
@@ -27,7 +27,7 @@ namespace skyline::input {
         Input(const DeviceState &state)
             : state(state),
               kHid(std::make_shared<kernel::type::KSharedMemory>(state, sizeof(HidSharedMemory))),
-              hid(reinterpret_cast<HidSharedMemory *>(kHid->host.ptr)),
+              hid(reinterpret_cast<HidSharedMemory *>(kHid->host.data())),
               npad(state, hid),
               touch(state, hid) {}
     };

--- a/app/src/main/cpp/skyline/kernel/types/KMemory.h
+++ b/app/src/main/cpp/skyline/kernel/types/KMemory.h
@@ -12,12 +12,12 @@ namespace skyline::kernel::type {
      */
     class KMemory : public KObject {
       public:
-        KMemory(const DeviceState &state, KType objectType) : KObject(state, objectType) {}
+        KMemory(const DeviceState &state, KType objectType, span <u8> guest) : KObject(state, objectType), guest(guest) {}
 
         /**
          * @return A span representing the memory object on the guest
          */
-        virtual span<u8> Get() = 0;
+        span <u8> guest;
 
         /**
          * @brief Updates the permissions of a block of mapped memory
@@ -25,12 +25,7 @@ namespace skyline::kernel::type {
          * @param size The size of the partition to change the permissions of
          * @param permission The new permissions to be set for the memory
          */
-        virtual void UpdatePermission(u8 *ptr, size_t size, memory::Permission permission) = 0;
-
-        bool IsInside(u8 *ptr) {
-            auto spn{Get()};
-            return (spn.data() <= ptr) && ((spn.data() + spn.size()) > ptr);
-        }
+        virtual void UpdatePermission(span <u8> map, memory::Permission permission) = 0;
 
         virtual ~KMemory() = default;
     };

--- a/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.cpp
+++ b/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.cpp
@@ -8,87 +8,84 @@
 #include "KProcess.h"
 
 namespace skyline::kernel::type {
-    KPrivateMemory::KPrivateMemory(const DeviceState &state, u8 *ptr, size_t size, memory::Permission permission, memory::MemoryState memState)
-        : ptr(ptr),
-          size(size),
-          permission(permission),
+    KPrivateMemory::KPrivateMemory(const DeviceState &state, span<u8> guest, memory::Permission permission, memory::MemoryState memState)
+        : permission(permission),
           memoryState(memState),
-          KMemory(state, KType::KPrivateMemory) {
-        if (!state.process->memory.base.IsInside(ptr) || !state.process->memory.base.IsInside(ptr + size))
-            throw exception("KPrivateMemory allocation isn't inside guest address space: 0x{:X} - 0x{:X}", ptr, ptr + size);
-        if (!util::IsPageAligned(ptr) || !util::IsPageAligned(size))
-            throw exception("KPrivateMemory mapping isn't page-aligned: 0x{:X} - 0x{:X} (0x{:X})", ptr, ptr + size, size);
+          KMemory(state, KType::KPrivateMemory, guest) {
+        if (!state.process->memory.base.contains(guest))
+            throw exception("KPrivateMemory allocation isn't inside guest address space: 0x{:X} - 0x{:X}", guest.data(), guest.data() + guest.size());
+        if (!util::IsPageAligned(guest.data()) || !util::IsPageAligned(guest.size()))
+            throw exception("KPrivateMemory mapping isn't page-aligned: 0x{:X} - 0x{:X} (0x{:X})", guest.data(), guest.data() + guest.size());
 
-        if (mprotect(ptr, size, PROT_READ | PROT_WRITE | PROT_EXEC) < 0) // We only need to reprotect as the allocation has already been reserved by the MemoryManager
-            throw exception("An occurred while mapping private memory: {} with 0x{:X} @ 0x{:X}", strerror(errno), ptr, size);
+        if (mprotect(guest.data(), guest.size(), PROT_READ | PROT_WRITE | PROT_EXEC) < 0) // We only need to reprotect as the allocation has already been reserved by the MemoryManager
+            throw exception("An occurred while mapping private memory: {} with 0x{:X} @ 0x{:X}", strerror(errno), guest.data(), guest.size());
 
         state.process->memory.InsertChunk(ChunkDescriptor{
-            .ptr = ptr,
-            .size = size,
+            .ptr = guest.data(),
+            .size = guest.size(),
             .permission = permission,
             .state = memState,
         });
     }
 
     void KPrivateMemory::Resize(size_t nSize) {
-        if (mprotect(ptr, nSize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
+        if (mprotect(guest.data(), nSize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
             throw exception("An occurred while resizing private memory: {}", strerror(errno));
 
-        if (nSize < size) {
+        if (nSize < guest.size()) {
             state.process->memory.InsertChunk(ChunkDescriptor{
-                .ptr = ptr + nSize,
-                .size = size - nSize,
+                .ptr = guest.data() + nSize,
+                .size = guest.size() - nSize,
                 .state = memory::states::Unmapped,
             });
-        } else if (size < nSize) {
+        } else if (guest.size() < nSize) {
             state.process->memory.InsertChunk(ChunkDescriptor{
-                .ptr = ptr + size,
-                .size = nSize - size,
+                .ptr = guest.data() + guest.size(),
+                .size = nSize - guest.size(),
                 .permission = permission,
                 .state = memoryState,
             });
         }
-
-        size = nSize;
+        guest = span<u8>{guest.data(), nSize};
     }
 
-    void KPrivateMemory::Remap(u8 *nPtr, size_t nSize) {
-        if (!state.process->memory.base.IsInside(nPtr) || !state.process->memory.base.IsInside(nPtr + nSize))
-            throw exception("KPrivateMemory remapping isn't inside guest address space: 0x{:X} - 0x{:X}", nPtr, nPtr + nSize);
-        if (!util::IsPageAligned(nPtr) || !util::IsPageAligned(nSize))
-            throw exception("KPrivateMemory remapping isn't page-aligned: 0x{:X} - 0x{:X} (0x{:X})", nPtr, nPtr + nSize, nSize);
+    void KPrivateMemory::Remap(span<u8> map) {
+        if (!state.process->memory.base.contains(map))
+            throw exception("KPrivateMemory remapping isn't inside guest address space: 0x{:X} - 0x{:X}", map.data(), map.end().base());
+        if (!util::IsPageAligned(map.data()) || !util::IsPageAligned(map.size()))
+            throw exception("KPrivateMemory remapping isn't page-aligned: 0x{:X} - 0x{:X} (0x{:X})", map.data(), map.end().base(), map.size());
 
-        if (mprotect(ptr, size, PROT_NONE) < 0)
+        if (mprotect(guest.data(), guest.size(), PROT_NONE) < 0)
             throw exception("An occurred while remapping private memory: {}", strerror(errno));
 
-        if (mprotect(nPtr, nSize, PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
+        if (mprotect(map.data(), map.size(), PROT_READ | PROT_WRITE | PROT_EXEC) < 0)
             throw exception("An occurred while remapping private memory: {}", strerror(errno));
     }
 
-    void KPrivateMemory::UpdatePermission(u8 *pPtr, size_t pSize, memory::Permission pPermission) {
-        pPtr = std::clamp(pPtr, ptr, ptr + size);
-        pSize = std::min(pSize, static_cast<size_t>((ptr + size) - pPtr));
+    void KPrivateMemory::UpdatePermission(span<u8> map, memory::Permission pPermission) {
+        auto ptr{std::clamp(map.data(), guest.data(), guest.end().base())};
+        auto size{std::min(map.size(), static_cast<size_t>((guest.end().base()) - ptr))};
 
-        if (pPtr && !util::IsPageAligned(pPtr))
-            throw exception("KPrivateMemory permission updated with a non-page-aligned address: 0x{:X}", pPtr);
+        if (ptr && !util::IsPageAligned(ptr))
+            throw exception("KPrivateMemory permission updated with a non-page-aligned address: 0x{:X}", ptr);
 
         // If a static code region has been mapped as writable it needs to be changed to mutable
         if (memoryState == memory::states::CodeStatic && pPermission.w)
             memoryState = memory::states::CodeMutable;
 
         state.process->memory.InsertChunk(ChunkDescriptor{
-            .ptr = pPtr,
-            .size = pSize,
+            .ptr = ptr,
+            .size = size,
             .permission = pPermission,
             .state = memoryState,
         });
     }
 
     KPrivateMemory::~KPrivateMemory() {
-        mprotect(ptr, size, PROT_NONE);
+        mprotect(guest.data(), guest.size(), PROT_NONE);
         state.process->memory.InsertChunk(ChunkDescriptor{
-            .ptr = ptr,
-            .size = size,
+            .ptr = guest.data(),
+            .size = guest.size(),
             .state = memory::states::Unmapped,
         });
     }

--- a/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.h
+++ b/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.h
@@ -12,8 +12,6 @@ namespace skyline::kernel::type {
      */
     class KPrivateMemory : public KMemory {
       public:
-        u8 *ptr{};
-        size_t size{};
         memory::Permission permission;
         memory::MemoryState memoryState;
 
@@ -21,7 +19,7 @@ namespace skyline::kernel::type {
          * @param permission The permissions for the allocated memory (As reported to the application, host memory permissions aren't reflected by this)
          * @note 'ptr' needs to be in guest-reserved address space
          */
-        KPrivateMemory(const DeviceState &state, u8 *ptr, size_t size, memory::Permission permission, memory::MemoryState memState);
+        KPrivateMemory(const DeviceState &state, span<u8> guest, memory::Permission permission, memory::MemoryState memState);
 
         /**
          * @note There is no check regarding if any expansions will cause the memory mapping to leak into other mappings
@@ -32,13 +30,9 @@ namespace skyline::kernel::type {
         /**
          * @note This does not copy over anything, only contents of any overlapping regions will be retained
          */
-        void Remap(u8 *ptr, size_t size);
+        void Remap(span<u8> map);
 
-        span<u8> Get() override {
-            return span(ptr, size);
-        }
-
-        void UpdatePermission(u8 *pPtr, size_t pSize, memory::Permission pPermission) override;
+        void UpdatePermission(span<u8> map, memory::Permission pPermission) override;
 
         /**
          * @brief The destructor of private memory, it deallocates the memory

--- a/app/src/main/cpp/skyline/kernel/types/KSharedMemory.h
+++ b/app/src/main/cpp/skyline/kernel/types/KSharedMemory.h
@@ -15,32 +15,21 @@ namespace skyline::kernel::type {
         memory::MemoryState memoryState; //!< The state of the memory as supplied initially, this is retained for any mappings
 
       public:
-        struct MapInfo {
-            u8 *ptr;
-            size_t size;
-
-            constexpr bool Valid() {
-                return ptr && size;
-            }
-        } host{}, guest{}; //!< We keep two mirrors of the underlying shared memory for guest access and host access, the host mirror is persistently mapped and should be used by anything accessing the memory on the host
+        span<u8> host; //!< We also keep a host mirror of the underlying shared memory for host access, it is persistently mapped and should be used by anything accessing the memory on the host
 
         KSharedMemory(const DeviceState &state, size_t size, memory::MemoryState memState = memory::states::SharedMemory, KType type = KType::KSharedMemory);
 
         /**
          * @note 'ptr' needs to be in guest-reserved address space
          */
-        u8 *Map(u8 *ptr, u64 size, memory::Permission permission);
+        u8 *Map(span<u8> map, memory::Permission permission);
 
         /**
          * @note 'ptr' needs to be in guest-reserved address space
          */
-        void Unmap(u8 *ptr, u64 size);
+        void Unmap(span<u8> map);
 
-        span<u8> Get() override {
-            return span(guest.ptr, guest.size);
-        }
-
-        void UpdatePermission(u8 *ptr, size_t size, memory::Permission permission) override;
+        void UpdatePermission(span<u8> map, memory::Permission permission) override;
 
         /**
          * @brief The destructor of shared memory, it deallocates the memory from all processes

--- a/app/src/main/cpp/skyline/kernel/types/KTransferMemory.h
+++ b/app/src/main/cpp/skyline/kernel/types/KTransferMemory.h
@@ -17,8 +17,8 @@ namespace skyline::kernel::type {
          */
         KTransferMemory(const DeviceState &state, u8 *ptr, size_t size, memory::Permission permission, memory::MemoryState memState = memory::states::TransferMemory)
             : KSharedMemory(state, size, memState, KType::KTransferMemory) {
-            std::memcpy(host.ptr, ptr, size);
-            Map(ptr, size, permission);
+            std::memcpy(host.data(), ptr, size);
+            Map(span<u8>{ptr, size}, permission);
         }
     };
 }

--- a/app/src/main/cpp/skyline/loader/nca.cpp
+++ b/app/src/main/cpp/skyline/loader/nca.cpp
@@ -41,7 +41,7 @@ namespace skyline::loader {
             offset += loadInfo.size;
         }
 
-        state.process->memory.InitializeRegions(base, offset);
+        state.process->memory.InitializeRegions(span<u8>{base, offset});
 
         return entry;
     }

--- a/app/src/main/cpp/skyline/loader/nro.cpp
+++ b/app/src/main/cpp/skyline/loader/nro.cpp
@@ -66,7 +66,7 @@ namespace skyline::loader {
         state.process->memory.InitializeVmm(memory::AddressSpaceType::AddressSpace39Bit);
         auto applicationName{nacp ? nacp->GetApplicationName(nacp->GetFirstSupportedTitleLanguage()) : ""};
         auto loadInfo{LoadExecutable(process, state, executable, 0, applicationName.empty() ? "main.nro" : applicationName + ".nro")};
-        state.process->memory.InitializeRegions(loadInfo.base, loadInfo.size);
+        state.process->memory.InitializeRegions(span<u8>{loadInfo.base, loadInfo.size});
 
         return loadInfo.entry;
     }

--- a/app/src/main/cpp/skyline/loader/nso.cpp
+++ b/app/src/main/cpp/skyline/loader/nso.cpp
@@ -62,7 +62,7 @@ namespace skyline::loader {
     void *NsoLoader::LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) {
         state.process->memory.InitializeVmm(memory::AddressSpaceType::AddressSpace39Bit);
         auto loadInfo{LoadNso(this, backing, process, state)};
-        state.process->memory.InitializeRegions(loadInfo.base, loadInfo.size);
+        state.process->memory.InitializeRegions(span<u8>{loadInfo.base, loadInfo.size});
         return loadInfo.entry;
     }
 }

--- a/app/src/main/cpp/skyline/nce.cpp
+++ b/app/src/main/cpp/skyline/nce.cpp
@@ -461,7 +461,7 @@ namespace skyline::nce {
 
                 constexpr ssize_t MinimumPageoutSize{PAGE_SIZE}; //!< The minimum size to page out, we don't want to page out small intervals for performance reasons
                 if (freeSize > MinimumPageoutSize)
-                    state.process->memory.FreeMemory(freeStart, static_cast<size_t>(freeSize));
+                    state.process->memory.FreeMemory(span<u8>{freeStart, static_cast<size_t>(freeSize)});
             }
         }
     }

--- a/app/src/main/cpp/skyline/services/am/storage/TransferMemoryIStorage.cpp
+++ b/app/src/main/cpp/skyline/services/am/storage/TransferMemoryIStorage.cpp
@@ -9,7 +9,7 @@ namespace skyline::service::am {
     TransferMemoryIStorage::TransferMemoryIStorage(const DeviceState &state, ServiceManager &manager, std::shared_ptr<kernel::type::KTransferMemory> transferMemory, bool writable) : transferMemory(std::move(transferMemory)), IStorage(state, manager, writable) {}
 
     span<u8> TransferMemoryIStorage::GetSpan() {
-        return transferMemory->Get();
+        return transferMemory->host;
     }
 
     TransferMemoryIStorage::~TransferMemoryIStorage() = default;

--- a/app/src/main/cpp/skyline/services/codec/IHardwareOpusDecoder.cpp
+++ b/app/src/main/cpp/skyline/services/codec/IHardwareOpusDecoder.cpp
@@ -21,7 +21,7 @@ namespace skyline::service::codec {
             throw exception("Work Buffer doesn't have adequate space for Opus Decoder: 0x{:X} (Required: 0x{:X})", workBufferSize, decoderOutputBufferSize);
 
         // We utilize the guest-supplied work buffer for allocating the OpusDecoder object into
-        decoderState = reinterpret_cast<OpusDecoder *>(workBuffer->host.ptr);
+        decoderState = reinterpret_cast<OpusDecoder *>(workBuffer->host.data());
 
         if (int result = opus_decoder_init(decoderState, sampleRate, channelCount) != OPUS_OK)
             throw OpusException(result);

--- a/app/src/main/cpp/skyline/services/pl/shared_font_core.h
+++ b/app/src/main/cpp/skyline/services/pl/shared_font_core.h
@@ -38,11 +38,11 @@ namespace skyline::service::pl {
             constexpr u32 SharedFontKey{SharedFontMagic ^ SharedFontResult}; //!< The XOR key for encrypting the font size
 
             auto fontsDirectory{std::make_shared<vfs::OsFileSystem>(state.os->publicAppFilesPath + "fonts/")};
-            auto ptr{reinterpret_cast<u32 *>(sharedFontMemory->host.ptr)};
+            auto ptr{reinterpret_cast<u32 *>(sharedFontMemory->host.data())};
             for (auto &font : fonts) {
                 *ptr++ = 0x18029a7f;
                 *ptr++ = util::SwapEndianness(font.length ^ 0x49621806);
-                font.offset = static_cast<u32>(reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(sharedFontMemory->host.ptr));
+                font.offset = static_cast<u32>(reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(sharedFontMemory->host.data()));
 
                 std::shared_ptr<vfs::Backing> fontFile;
                 if (fontsDirectory->FileExists(font.path))

--- a/app/src/main/cpp/skyline/services/timesrv/time_shared_memory.cpp
+++ b/app/src/main/cpp/skyline/services/timesrv/time_shared_memory.cpp
@@ -59,7 +59,7 @@ namespace skyline::service::timesrv::core {
 
     TimeSharedMemory::TimeSharedMemory(const DeviceState &state)
         : kTimeSharedMemory(std::make_shared<kernel::type::KSharedMemory>(state, TimeSharedMemorySize)),
-          timeSharedMemory(reinterpret_cast<TimeSharedMemoryLayout *>(kTimeSharedMemory->host.ptr)) {}
+          timeSharedMemory(reinterpret_cast<TimeSharedMemoryLayout *>(kTimeSharedMemory->host.data())) {}
 
     void TimeSharedMemory::SetupStandardSteadyClock(UUID rtcId, TimeSpanType baseTimePoint) {
         SteadyClockTimePoint context{


### PR DESCRIPTION
This makes the code more readable and allowed removing a bunch of one-liner functions