### PR TITLE
service: hid: Improve npad device detection

### DIFF
--- a/app/src/main/cpp/skyline/input/npad_device.cpp
+++ b/app/src/main/cpp/skyline/input/npad_device.cpp
@@ -188,8 +188,8 @@ namespace skyline::input {
 
         info.header.timestamp = util::GetTimeTicks();
         info.header.entryCount = std::min(static_cast<u8>(info.header.entryCount + 1), constant::HidEntryCount);
-        info.header.maxEntry = info.header.entryCount;
-        info.header.currentEntry = (info.header.currentEntry != constant::HidEntryCount - 1) ? info.header.currentEntry + 1 : 0;
+        info.header.maxEntry = info.header.entryCount - 1;
+        info.header.currentEntry = (info.header.currentEntry < info.header.maxEntry) ? info.header.currentEntry + 1 : 0;
 
         auto &nextEntry{info.state.at(info.header.currentEntry)};
 

--- a/app/src/main/cpp/skyline/input/npad_device.cpp
+++ b/app/src/main/cpp/skyline/input/npad_device.cpp
@@ -10,7 +10,14 @@ namespace skyline::input {
         : manager(manager),
           section(section),
           id(id),
-          updateEvent(std::make_shared<kernel::type::KEvent>(manager.state, false)) {}
+          updateEvent(std::make_shared<kernel::type::KEvent>(manager.state, false)) {
+        constexpr std::size_t InitializeEntryCount{19}; //!< HW initializes the first 19 entries
+
+        ResetDeviceProperties();
+        for (std::size_t i{}; i < InitializeEntryCount; ++i) {
+            WriteEmptyEntries();
+        }
+    }
 
     void NpadDevice::Connect(NpadControllerType newType) {
         if (type == newType) {
@@ -29,10 +36,11 @@ namespace skyline::input {
             return;
         }
 
-        section = {};
+        ResetDeviceProperties();
         controllerInfo = nullptr;
 
-        connectionState = {.connected = true};
+        connectionState.raw = 0;
+        connectionState.connected = true;
 
         switch (newType) {
             case NpadControllerType::ProController:
@@ -154,8 +162,7 @@ namespace skyline::input {
         if (type == NpadControllerType::None)
             return;
 
-        section = {};
-        globalTimestamp = 0;
+        ResetDeviceProperties();
 
         index = -1;
         partnerIndex = -1;
@@ -164,6 +171,7 @@ namespace skyline::input {
         controllerInfo = nullptr;
 
         updateEvent->Signal();
+        WriteEmptyEntries();
     }
 
     NpadControllerInfo &NpadDevice::GetControllerInfo() {
@@ -201,6 +209,36 @@ namespace skyline::input {
         nextEntry.rightX = entry.rightX;
         nextEntry.rightY = entry.rightY;
         nextEntry.status.raw = connectionState.raw;
+    }
+
+    void NpadDevice::WriteEmptyEntries() {
+        NpadControllerState emptyEntry{};
+
+        WriteNextEntry(section.fullKeyController, emptyEntry);
+        WriteNextEntry(section.handheldController, emptyEntry);
+        WriteNextEntry(section.leftController, emptyEntry);
+        WriteNextEntry(section.rightController, emptyEntry);
+        WriteNextEntry(section.palmaController, emptyEntry);
+        WriteNextEntry(section.dualController, emptyEntry);
+        WriteNextEntry(section.defaultController, emptyEntry);
+
+        globalTimestamp++;
+    }
+
+    void NpadDevice::ResetDeviceProperties() {
+        // Don't reset assignment mode or ring lifo entries these values are persistent
+        section.header.type = NpadControllerType::None;
+        section.header.singleColor = {};
+        section.header.leftColor = {};
+        section.header.rightColor = {};
+        section.header.singleColorStatus =  NpadColorReadStatus::Disconnected;
+        section.header.dualColorStatus = NpadColorReadStatus::Disconnected;
+        section.deviceType.raw = 0;
+        section.buttonProperties.raw = 0;
+        section.systemProperties.raw = 0;
+        section.singleBatteryLevel = NpadBatteryLevel::Empty;
+        section.leftBatteryLevel = NpadBatteryLevel::Empty;
+        section.rightBatteryLevel = NpadBatteryLevel::Empty;
     }
 
     void NpadDevice::UpdateSharedMemory() {

--- a/app/src/main/cpp/skyline/input/npad_device.h
+++ b/app/src/main/cpp/skyline/input/npad_device.h
@@ -146,6 +146,16 @@ namespace skyline::input {
         void WriteNextEntry(NpadControllerInfo &info, NpadControllerState entry);
 
         /**
+         * @brief Writes on all ring lifo buffers a new empty entry in HID Shared Memory
+         */
+        void WriteEmptyEntries();
+
+        /**
+         * @brief Reverts all device properties to the default state
+         */
+        void ResetDeviceProperties();
+
+        /**
          * @return The NpadControllerInfo for this controller based on its type
          */
         NpadControllerInfo &GetControllerInfo();

--- a/app/src/main/cpp/skyline/input/touch.cpp
+++ b/app/src/main/cpp/skyline/input/touch.cpp
@@ -74,15 +74,15 @@ namespace skyline::input {
             return;
 
         const auto &lastEntry{section.entries[section.header.currentEntry]};
-        auto entryIndex{(section.header.currentEntry != constant::HidEntryCount - 1) ? section.header.currentEntry + 1 : 0};
-        auto &entry{section.entries[entryIndex]};
-        entry = screenState;
-        entry.globalTimestamp = lastEntry.globalTimestamp + 1;
-        entry.localTimestamp = lastEntry.localTimestamp + 1;
 
         section.header.timestamp = util::GetTimeTicks();
         section.header.entryCount = std::min(static_cast<u8>(section.header.entryCount + 1), constant::HidEntryCount);
-        section.header.maxEntry = section.header.entryCount;
-        section.header.currentEntry = entryIndex;
+        section.header.maxEntry = section.header.entryCount - 1;
+        section.header.currentEntry = (section.header.currentEntry < section.header.maxEntry) ? section.header.currentEntry + 1 : 0;
+
+        auto &entry{section.entries[section.header.currentEntry]};
+        entry = screenState;
+        entry.globalTimestamp = lastEntry.globalTimestamp + 1;
+        entry.localTimestamp = lastEntry.localTimestamp + 1;
     }
 }

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -79,6 +79,8 @@ namespace skyline::service::hid {
         auto id{request.Pop<NpadId>()};
         auto handle{state.process->InsertItem(state.input->npad.at(id).updateEvent)};
 
+        state.input->npad.at(id).updateEvent->Signal();
+
         Logger::Debug("Npad {} Style Set Update Event Handle: 0x{:X}", id, handle);
         response.copyHandles.push_back(handle);
         return {};

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -248,4 +248,8 @@ namespace skyline::service::hid {
 
         return {};
     }
+
+    Result IHidServer::SetPalmaBoostMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.h
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.h
@@ -178,6 +178,12 @@ namespace skyline::service::hid {
          */
         Result SendVibrationValues(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Sets boost mode to a Palma device
+         * @url https://switchbrew.org/wiki/HID_services#SetPalmaBoostMode
+         */
+        Result SetPalmaBoostMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x0, IHidServer, CreateAppletResource),
             SFUNC(0x1, IHidServer, ActivateDebugPad),
@@ -206,7 +212,8 @@ namespace skyline::service::hid {
             SFUNC(0xCB, IHidServer, CreateActiveVibrationDeviceList),
             SFUNC(0xC8, IHidServer, GetVibrationDeviceInfo),
             SFUNC(0xC9, IHidServer, SendVibrationValue),
-            SFUNC(0xCE, IHidServer, SendVibrationValues)
+            SFUNC(0xCE, IHidServer, SendVibrationValues),
+            SFUNC(0x20D, IHidServer, SetPalmaBoostMode)
         )
     };
 }


### PR DESCRIPTION
This PR should fix random input in some games like Pokemon Sword. Random disconnects on games like Flip Wars.

- Stubs SetPalmaBoostMode
- Signal the update event on AcquireNpadStyleSetUpdateEventHandle
- Initialize and reset shared memory properly instead of fully deleting the contents