### PR TITLE
stub IClient::Poll and implement IApplicationDisplayService::GetIndirectLayerImageRequiredMemoryInfo

### DIFF
--- a/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
+++ b/app/src/main/cpp/skyline/services/socket/bsd/IClient.cpp
@@ -14,4 +14,8 @@ namespace skyline::service::socket {
     Result IClient::StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         return {};
     }
+
+    Result IClient::Poll(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/socket/bsd/IClient.h
+++ b/app/src/main/cpp/skyline/services/socket/bsd/IClient.h
@@ -25,9 +25,15 @@ namespace skyline::service::socket {
          */
         Result StartMonitoring(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Polls the socket for events
+         */
+        Result Poll(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x0, IClient, RegisterClient),
-            SFUNC(0x1, IClient, StartMonitoring)
+            SFUNC(0x1, IClient, StartMonitoring),
+            SFUNC(0x6, IClient, Poll),
         )
     };
 }


### PR DESCRIPTION
These changes allow Dark Souls (maybe some other games) go to in game with save file (without save file it crashes on inline swkbd) on ftx1, didn't try with gpu-new.
P.S. I don't know what to write in @brief of GetIndirectLayerImageRequiredMemoryInfo. And I'm not cpp dev, so I'm sorry if I did something wrong.