### PR TITLE
add GetAvailableLanguageCodeCount for both language code lists

### DIFF
--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.cpp
@@ -19,8 +19,18 @@ namespace skyline::service::settings {
         return {};
     }
 
+    Result ISettingsServer::GetAvailableLanguageCodeCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<i32>(constant::OldLanguageCodeListSize);
+        return {};
+    }
+
     Result ISettingsServer::GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         request.outputBuf.at(0).copy_from(language::LanguageCodeList);
+        response.Push<i32>(constant::NewLanguageCodeListSize);
+        return {};
+    }
+
+    Result ISettingsServer::GetAvailableLanguageCodeCount2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<i32>(constant::NewLanguageCodeListSize);
         return {};
     }

--- a/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
+++ b/app/src/main/cpp/skyline/services/settings/ISettingsServer.h
@@ -25,6 +25,11 @@ namespace skyline::service::settings {
         Result MakeLanguageCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Returns the number of available language codes that an application can use (pre 4.0.0)
+         */
+        Result GetAvailableLanguageCodeCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Returns the user-selected region's code
          */
         Result GetRegionCode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -34,11 +39,18 @@ namespace skyline::service::settings {
          */
         Result GetAvailableLanguageCodes2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Returns the number of available language codes that an application can use (post 4.0.0)
+         */
+        Result GetAvailableLanguageCodeCount2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x1, ISettingsServer, GetAvailableLanguageCodes),
             SFUNC(0x2, ISettingsServer, MakeLanguageCode),
+            SFUNC(0x3, ISettingsServer, GetAvailableLanguageCodeCount),
             SFUNC(0x4, ISettingsServer, GetRegionCode),
-            SFUNC(0x5, ISettingsServer, GetAvailableLanguageCodes2)
+            SFUNC(0x5, ISettingsServer, GetAvailableLanguageCodes2),
+            SFUNC(0x6, ISettingsServer, GetAvailableLanguageCodeCount2)
         )
     };
 }


### PR DESCRIPTION
fixes `Data being copied is larger than this span` in some games like Tales of Vesperia, V-Rally 4 and etc.