### PR TITLE
Store KMemory object ptrs in memory class to avoid linear-time unmap

### DIFF
--- a/app/src/main/cpp/skyline/kernel/memory.cpp
+++ b/app/src/main/cpp/skyline/kernel/memory.cpp
@@ -210,6 +210,7 @@ namespace skyline::kernel {
             lower->state = chunk.state;
             lower->permission = chunk.permission;
             lower->attributes = chunk.attributes;
+            lower->memory = chunk.memory;
         } else if (lower->ptr + lower->size > chunk.ptr + chunk.size) {
             auto lowerExtension{*lower};
             lowerExtension.ptr = chunk.ptr + chunk.size;

--- a/app/src/main/cpp/skyline/kernel/memory.h
+++ b/app/src/main/cpp/skyline/kernel/memory.h
@@ -8,6 +8,10 @@
 #include <common/file_descriptor.h>
 
 namespace skyline {
+    namespace kernel::type {
+        class KMemory;
+    }
+
     namespace memory {
         union Permission {
             /**
@@ -195,9 +199,10 @@ namespace skyline {
             memory::Permission permission;
             memory::MemoryState state;
             memory::MemoryAttribute attributes;
+            kernel::type::KMemory *memory{};
 
             constexpr bool IsCompatible(const ChunkDescriptor &chunk) const {
-                return chunk.permission == permission && chunk.state.value == state.value && chunk.attributes.value == attributes.value;
+                return chunk.permission == permission && chunk.state.value == state.value && chunk.attributes.value == attributes.value && chunk.memory == memory;
             }
         };
 

--- a/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.h
+++ b/app/src/main/cpp/skyline/kernel/types/KPrivateMemory.h
@@ -14,12 +14,13 @@ namespace skyline::kernel::type {
       public:
         memory::Permission permission;
         memory::MemoryState memoryState;
+        KHandle handle;
 
         /**
          * @param permission The permissions for the allocated memory (As reported to the application, host memory permissions aren't reflected by this)
          * @note 'ptr' needs to be in guest-reserved address space
          */
-        KPrivateMemory(const DeviceState &state, span<u8> guest, memory::Permission permission, memory::MemoryState memState);
+        KPrivateMemory(const DeviceState &state, KHandle handle, span<u8> guest, memory::Permission permission, memory::MemoryState memState);
 
         /**
          * @note There is no check regarding if any expansions will cause the memory mapping to leak into other mappings

--- a/app/src/main/cpp/skyline/kernel/types/KProcess.h
+++ b/app/src/main/cpp/skyline/kernel/types/KProcess.h
@@ -117,7 +117,7 @@ namespace skyline {
                 std::unique_lock lock(handleMutex);
 
                 std::shared_ptr<objectClass> item;
-                if constexpr (std::is_same<objectClass, KThread>())
+                if constexpr (std::is_same<objectClass, KThread>() || std::is_same<objectClass, KPrivateMemory>())
                     item = std::make_shared<objectClass>(state, constant::BaseHandleIndex + handles.size(), args...);
                 else
                     item = std::make_shared<objectClass>(state, args...);

--- a/app/src/main/cpp/skyline/kernel/types/KSharedMemory.cpp
+++ b/app/src/main/cpp/skyline/kernel/types/KSharedMemory.cpp
@@ -43,6 +43,7 @@ namespace skyline::kernel::type {
             .attributes = memory::MemoryAttribute{
                 .isBorrowed = objectType == KType::KTransferMemory,
             },
+            .memory = this
         });
 
         return guest.data();
@@ -85,6 +86,7 @@ namespace skyline::kernel::type {
                 .attributes = memory::MemoryAttribute{
                     .isBorrowed = objectType == KType::KTransferMemory,
                 },
+                .memory = this
             });
         }
     }
@@ -118,7 +120,8 @@ namespace skyline::kernel::type {
                     .state = memoryState,
                     .attributes = memory::MemoryAttribute{
                         .isBorrowed = false,
-                    }
+                    },
+                    .memory = this
                 });
             }
         }


### PR DESCRIPTION
This is quite a horrible solution but fixing it properly would require a whole rewrite of how we handle memory. Vastly reduces stutters in skyrim from searching over thousands of handles every unmap.