### PR TITLE
fssrv: IFileSystemProxy: Implement OpenReadOnlySaveDataFileSystem

### DIFF
--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.cpp
@@ -61,6 +61,12 @@ namespace skyline::service::fssrv {
         return {};
     }
 
+    Result IFileSystemProxy::OpenReadOnlySaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        // Forward to OpenSaveDataFileSystem for now.
+        // TODO: This should wrap the underlying filesystem with nn::fs::ReadOnlyFileSystem.
+        return OpenSaveDataFileSystem(session, request, response);
+    }
+
     Result IFileSystemProxy::OpenDataStorageByCurrentProcess(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         if (!state.loader->romFs)
             return result::NoRomFsAvailable;

--- a/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
+++ b/app/src/main/cpp/skyline/services/fssrv/IFileSystemProxy.h
@@ -81,6 +81,13 @@ namespace skyline::service::fssrv {
         Result OpenSaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Returns a handle to a read-only instance of #IFileSystem
+         * @url https://switchbrew.org/wiki/Filesystem_services#IFileSystem for the requested save data area
+         * @url https://switchbrew.org/wiki/Filesystem_services#OpenReadOnlySaveDataFileSystem
+         */
+        Result OpenReadOnlySaveDataFileSystem(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Returns a handle to an instance of #IStorage
          * @url https://switchbrew.org/wiki/Filesystem_services#IStorage for the application's data storage
          */
@@ -102,6 +109,7 @@ namespace skyline::service::fssrv {
             SFUNC(0x1, IFileSystemProxy, SetCurrentProcess),
             SFUNC(0x12, IFileSystemProxy, OpenSdCardFileSystem),
             SFUNC(0x33, IFileSystemProxy, OpenSaveDataFileSystem),
+            SFUNC(0x35, IFileSystemProxy, OpenReadOnlySaveDataFileSystem),
             SFUNC(0xC8, IFileSystemProxy, OpenDataStorageByCurrentProcess),
             SFUNC(0xCA, IFileSystemProxy, OpenDataStorageByDataId),
             SFUNC(0x3ED, IFileSystemProxy, GetGlobalAccessLogMode)


### PR DESCRIPTION
Forward this function to OpenSaveDataFileSystem for now. A proper implementation should wrap the underlying filesystem with nn::fs::ReadOnlyFileSystem.