### PR TITLE
navbar sticking out workaround for certain android roms

### DIFF
--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -344,7 +344,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
         changeAudioStatus(true)
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
             @Suppress("DEPRECATION")
             window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
                     or View.SYSTEM_UI_FLAG_LAYOUT_STABLE

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -121,7 +121,7 @@ class OnScreenEditActivity : AppCompatActivity() {
     }
 
     private fun fullScreen() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
             @Suppress("DEPRECATION")
             window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
                     or View.SYSTEM_UI_FLAG_LAYOUT_STABLE


### PR DESCRIPTION
Some older android roms may have broken immersive mode implementation that causes navigation bar to stick out indefinitely after touching the screen.
This workaround should fix it.