### PR TITLE
Stub some functions

### DIFF
--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.cpp
@@ -90,8 +90,7 @@ namespace skyline::service::account {
         return {};
     }
 
-    Result IAccountServiceForApplication::IsUserAccountSwitchLocked(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
-        response.Push<u32>(0); // We don't want to lock the user
+    Result IAccountServiceForApplication::LoadOpenContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         return {};
     }
 
@@ -101,6 +100,15 @@ namespace skyline::service::account {
         } catch (const std::out_of_range &) {
             return result::InvalidInputBuffer;
         }
+    }
+
+    Result IAccountServiceForApplication::IsUserAccountSwitchLocked(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(0); // We don't want to lock the user
+        return {};
+    }
+
+    Result IAccountServiceForApplication::InitializeApplicationInfoV2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
     }
 
     Result IAccountServiceForApplication::IsUserRegistrationRequestPermitted(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {

--- a/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IAccountServiceForApplication.h
@@ -66,14 +66,18 @@ namespace skyline {
 
             Result StoreSaveDataThumbnail(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+            Result LoadOpenContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+            Result ListOpenContextStoredUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
             /**
             * @url https://switchbrew.org/wiki/Account_services#InitializeApplicationInfo
             */
             Result InitializeApplicationInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
-            Result ListOpenContextStoredUsers(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
-
             Result IsUserAccountSwitchLocked(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+            Result InitializeApplicationInfoV2(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
           SERVICE_DECL(
               SFUNC(0x0, IAccountServiceForApplication, GetUserCount),
@@ -86,9 +90,11 @@ namespace skyline {
               SFUNC(0x64, IAccountServiceForApplication, InitializeApplicationInfoV0),
               SFUNC(0x65, IAccountServiceForApplication, GetBaasAccountManagerForApplication),
               SFUNC(0x6E, IAccountServiceForApplication, StoreSaveDataThumbnail),
+              SFUNC(0x82, IAccountServiceForApplication, LoadOpenContext),
               SFUNC(0x83, IAccountServiceForApplication, ListOpenContextStoredUsers),
               SFUNC(0x8C, IAccountServiceForApplication, InitializeApplicationInfo),
-              SFUNC(0x96, IAccountServiceForApplication, IsUserAccountSwitchLocked)
+              SFUNC(0x96, IAccountServiceForApplication, IsUserAccountSwitchLocked),
+              SFUNC(0xA0, IAccountServiceForApplication, InitializeApplicationInfoV2)
           )
         };
     }

--- a/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
@@ -2,12 +2,18 @@
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
 #include "IManagerForApplication.h"
+#include "IAccountServiceForApplication.h"
 
 namespace skyline::service::account {
     IManagerForApplication::IManagerForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
 
     Result IManagerForApplication::CheckAvailability(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push(false);
+        return {};
+    }
+
+    Result IManagerForApplication::GetAccountId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push(constant::DefaultUserId);
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/account/IManagerForApplication.cpp
@@ -10,4 +10,8 @@ namespace skyline::service::account {
         response.Push(false);
         return {};
     }
+
+    Result IManagerForApplication::StoreOpenContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/account/IManagerForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IManagerForApplication.h
@@ -19,10 +19,16 @@ namespace skyline::service::account {
         */
         Result CheckAvailability(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Returns the user ID of the current user
+         */
+        Result GetAccountId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         Result StoreOpenContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         SERVICE_DECL(
             SFUNC(0x0, IManagerForApplication, CheckAvailability),
+            SFUNC(0x1, IManagerForApplication, GetAccountId),
             SFUNC(0xA0, IManagerForApplication, StoreOpenContext)
         )
     };

--- a/app/src/main/cpp/skyline/services/account/IManagerForApplication.h
+++ b/app/src/main/cpp/skyline/services/account/IManagerForApplication.h
@@ -19,8 +19,11 @@ namespace skyline::service::account {
         */
         Result CheckAvailability(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result StoreOpenContext(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
-            SFUNC(0x0, IManagerForApplication, CheckAvailability)
+            SFUNC(0x0, IManagerForApplication, CheckAvailability),
+            SFUNC(0xA0, IManagerForApplication, StoreOpenContext)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -159,4 +159,8 @@ namespace skyline::service::am {
         response.copyHandles.push_back(handle);
         return {};
     }
+
+    Result IApplicationFunctions::TryPopFromFriendInvitationStorageChannel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return result::NotAvailable;
+    }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -146,6 +146,11 @@ namespace skyline::service::am {
         return {};
     }
 
+    Result IApplicationFunctions::GetPreviousProgramIndex(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<i32>(previousProgramIndex);
+        return {};
+    }
+
     Result IApplicationFunctions::GetGpuErrorDetectedSystemEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(gpuErrorEvent)};
         Logger::Debug("GPU Error Event Handle: 0x{:X}", handle);

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
@@ -21,6 +21,7 @@ namespace skyline::service::am {
       private:
         std::shared_ptr<type::KEvent> gpuErrorEvent; //!< The event signalled on GPU errors
         std::shared_ptr<type::KEvent> friendInvitationStorageChannelEvent; //!< The event signalled on friend invitations
+        i32 previousProgramIndex{-1}; //!< There was no previous title
 
       public:
         IApplicationFunctions(const DeviceState &state, ServiceManager &manager);
@@ -97,6 +98,12 @@ namespace skyline::service::am {
         Result SetApplicationCopyrightVisibility(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Gets the ProgramIndex of the Application which launched this title
+         * @url https://switchbrew.org/wiki/Applet_Manager_services#GetPreviousProgramIndex
+         */
+        Result GetPreviousProgramIndex(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Obtains a handle to the system GPU error KEvent
          * @url https://switchbrew.org/wiki/Applet_Manager_services#GetGpuErrorDetectedSystemEvent
          */
@@ -122,6 +129,7 @@ namespace skyline::service::am {
             SFUNC(0x64, IApplicationFunctions, InitializeApplicationCopyrightFrameBuffer),
             SFUNC(0x65, IApplicationFunctions, SetApplicationCopyrightImage),
             SFUNC(0x66, IApplicationFunctions, SetApplicationCopyrightVisibility),
+            SFUNC(0x7B, IApplicationFunctions, GetPreviousProgramIndex),
             SFUNC(0x82, IApplicationFunctions, GetGpuErrorDetectedSystemEvent),
             SFUNC(0x8C, IApplicationFunctions, GetFriendInvitationStorageChannelEvent),
             SFUNC(0x8D, IApplicationFunctions, TryPopFromFriendInvitationStorageChannel)

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
@@ -107,6 +107,8 @@ namespace skyline::service::am {
          */
         Result GetFriendInvitationStorageChannelEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result TryPopFromFriendInvitationStorageChannel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x1, IApplicationFunctions, PopLaunchParameter),
             SFUNC(0x14, IApplicationFunctions, EnsureSaveData),
@@ -121,7 +123,8 @@ namespace skyline::service::am {
             SFUNC(0x65, IApplicationFunctions, SetApplicationCopyrightImage),
             SFUNC(0x66, IApplicationFunctions, SetApplicationCopyrightVisibility),
             SFUNC(0x82, IApplicationFunctions, GetGpuErrorDetectedSystemEvent),
-            SFUNC(0x8C, IApplicationFunctions, GetFriendInvitationStorageChannelEvent)
+            SFUNC(0x8C, IApplicationFunctions, GetFriendInvitationStorageChannelEvent),
+            SFUNC(0x8D, IApplicationFunctions, TryPopFromFriendInvitationStorageChannel)
         )
 
     };

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.cpp
@@ -70,6 +70,12 @@ namespace skyline::service::am {
         return {};
     }
 
+    Result ISelfController::SetIdleTimeDetectionExtension(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto idleTimeDetectionExtension{request.Pop<u32>()};
+        Logger::Debug("Setting Idle Time Detection Extension: 0x{:X}", idleTimeDetectionExtension);
+        return {};
+    }
+
     Result ISelfController::GetAccumulatedSuspendedTickValue(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         // TODO: Properly handle this after we implement game suspending
         response.Push<u64>(0);
@@ -81,6 +87,12 @@ namespace skyline::service::am {
         Logger::Debug("Accumulated Suspended Tick Event Handle: 0x{:X}", handle);
 
         response.copyHandles.push_back(handle);
+        return {};
+    }
+
+    Result ISelfController::SetAlbumImageTakenNotificationEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto albumImageTakenNotificationEnabled{request.Pop<u8>()};;
+        Logger::Debug("Setting Album Image Taken Notification Enabled: {}", albumImageTakenNotificationEnabled);
         return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/ISelfController.h
+++ b/app/src/main/cpp/skyline/services/am/controller/ISelfController.h
@@ -94,6 +94,11 @@ namespace skyline::service::am {
         Result CreateManagedDisplayLayer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @url https://switchbrew.org/wiki/Applet_Manager_services#SetIdleTimeDetectionExtension
+         */
+        Result SetIdleTimeDetectionExtension(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Returns how long the process was suspended for in ticks
          * @url https://switchbrew.org/wiki/Applet_Manager_services#GetAccumulatedSuspendedTickValue
          */
@@ -104,6 +109,11 @@ namespace skyline::service::am {
          * @url https://switchbrew.org/wiki/Applet_Manager_services#GetAccumulatedSuspendedTickChangedEvent
          */
         Result GetAccumulatedSuspendedTickChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @url https://switchbrew.org/wiki/Applet_Manager_services#SetAlbumImageTakenNotificationEnabled
+         */
+        Result SetAlbumImageTakenNotificationEnabled(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         SERVICE_DECL(
             SFUNC(0x0, ISelfController, Exit),
@@ -118,8 +128,10 @@ namespace skyline::service::am {
             SFUNC(0x10, ISelfController, SetOutOfFocusSuspendingEnabled),
             SFUNC(0x13, ISelfController, SetAlbumImageOrientation),
             SFUNC(0x28, ISelfController, CreateManagedDisplayLayer),
+            SFUNC(0x3E, ISelfController, SetIdleTimeDetectionExtension),
             SFUNC(0x5A, ISelfController, GetAccumulatedSuspendedTickValue),
-            SFUNC(0x5B, ISelfController, GetAccumulatedSuspendedTickChangedEvent)
+            SFUNC(0x5B, ISelfController, GetAccumulatedSuspendedTickChangedEvent),
+            SFUNC(0x64, ISelfController, SetAlbumImageTakenNotificationEnabled)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
@@ -26,4 +26,16 @@ namespace skyline::service::aocsrv {
         response.copyHandles.push_back(handle);
         return {};
     }
+
+    Result IAddOnContentManager::GetAddOnContentListChangedEventWithProcessId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        KHandle handle{state.process->InsertItem(addOnContentListChangedEvent)};
+        Logger::Debug("Add On Content List Changed Event Handle: 0x{:X}", handle);
+
+        response.copyHandles.push_back(handle);
+        return {};
+    }
+
+    Result IAddOnContentManager::CheckAddOnContentMountStatus(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
@@ -24,10 +24,16 @@ namespace skyline::service::aocsrv {
 
         Result GetAddOnContentListChangedEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result GetAddOnContentListChangedEventWithProcessId(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        Result CheckAddOnContentMountStatus(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x2, IAddOnContentManager, CountAddOnContent),
             SFUNC(0x3, IAddOnContentManager, ListAddOnContent),
-            SFUNC(0x8, IAddOnContentManager, GetAddOnContentListChangedEvent)
+            SFUNC(0x8, IAddOnContentManager, GetAddOnContentListChangedEvent),
+            SFUNC(0xA, IAddOnContentManager, GetAddOnContentListChangedEventWithProcessId),
+            SFUNC(0x32, IAddOnContentManager, CheckAddOnContentMountStatus)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
@@ -10,4 +10,13 @@ namespace skyline::service::friends {
         response.Push<u32>(0); // Count of friends
         return {};
     }
+
+    Result IFriendService::GetBlockedUserListIds(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(0); // No blocked users
+        return {};
+    }
+
+    Result IFriendService::UpdateUserPresence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
@@ -5,4 +5,9 @@
 
 namespace skyline::service::friends {
     IFriendService::IFriendService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
+
+    Result IFriendService::GetFriendList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(0); // Count of friends
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.h
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.h
@@ -13,5 +13,11 @@ namespace skyline::service::friends {
     class IFriendService : public BaseService {
       public:
         IFriendService(const DeviceState &state, ServiceManager &manager);
+
+        Result GetFriendList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        SERVICE_DECL(
+            SFUNC(0x2775, IFriendService, GetFriendList)
+        )
     };
 }

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.h
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.h
@@ -16,8 +16,14 @@ namespace skyline::service::friends {
 
         Result GetFriendList(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result GetBlockedUserListIds(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        Result UpdateUserPresence(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
-            SFUNC(0x2775, IFriendService, GetFriendList)
+            SFUNC(0x2775, IFriendService, GetFriendList),
+            SFUNC(0x28A0, IFriendService, GetBlockedUserListIds),
+            SFUNC(0x2972, IFriendService, UpdateUserPresence)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/nim/IShopServiceAccessServerInterface.cpp
+++ b/app/src/main/cpp/skyline/services/nim/IShopServiceAccessServerInterface.cpp
@@ -11,4 +11,9 @@ namespace skyline::service::nim {
         manager.RegisterService(SRVREG(IShopServiceAccessServer), session, response);
         return {};
     }
+
+    Result IShopServiceAccessServerInterface::IsLargeResourceAvailable(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u8>(false);
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/nim/IShopServiceAccessServerInterface.h
+++ b/app/src/main/cpp/skyline/services/nim/IShopServiceAccessServerInterface.h
@@ -16,8 +16,11 @@ namespace skyline::service::nim {
 
         Result CreateServerInterface(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result IsLargeResourceAvailable(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
-            SFUNC(0x0, IShopServiceAccessServerInterface, CreateServerInterface)
+            SFUNC(0x0, IShopServiceAccessServerInterface, CreateServerInterface),
+            SFUNC(0x4, IShopServiceAccessServerInterface, IsLargeResourceAvailable)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlService.cpp
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlService.cpp
@@ -9,4 +9,14 @@ namespace skyline::service::pctl {
     Result IParentalControlService::Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         return {};
     }
+
+    Result IParentalControlService::CheckFreeCommunicationPermission(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u8>(0);
+        return {};
+    }
+
+    Result IParentalControlService::IsFreeCommunicationAvailable(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u8>(0);
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/pctl/IParentalControlService.h
+++ b/app/src/main/cpp/skyline/services/pctl/IParentalControlService.h
@@ -19,8 +19,14 @@ namespace skyline::service::pctl {
          */
         Result Initialize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result CheckFreeCommunicationPermission(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        Result IsFreeCommunicationAvailable(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
-            SFUNC(0x1, IParentalControlService, Initialize)
+            SFUNC(0x1, IParentalControlService, Initialize),
+            SFUNC(0x3E9, IParentalControlService, CheckFreeCommunicationPermission),
+            SFUNC(0x3FA, IParentalControlService, IsFreeCommunicationAvailable)
         )
     };
 }


### PR DESCRIPTION
Since there is no friend future, TryPopFromFriendInvitationStorageChannel can return `result::NotAvailable`.
`GetAddOnContentListChangedEventWithProcessId` should allow BLUE REFLECTION: Second Light go ingame and also needed for  Tony Hawk's™ Pro Skater™ 1 + 2, Harvestella and some other games. Other funcs also needed for some games.