### PR TITLE
Work around invalid values in `CNTFRQ_EL0` register

### DIFF
--- a/app/src/main/cpp/skyline/nce/guest.S
+++ b/app/src/main/cpp/skyline/nce/guest.S
@@ -93,23 +93,3 @@ LoadCtx:
     /* Restore Scratch Register */
     LDR LR, [SP, #8]
     RET
-
-.global RescaleClock
-RescaleClock:
-    SUB SP, SP, #32
-    STP X0, X1, [SP, #16]
-    MOV X0, #30787
-    MOVK X0, #29108, LSL #16
-    MOVK X0, #23236, LSL #32
-    MOVK X0, #2684, LSL #48
-    MRS X1, CNTFRQ_EL0
-    LSR X1, X1, #5
-    UMULH X1, X1, X0
-    LSR X1, X1, #7
-    MRS X0, CNTVCT_EL0
-    UDIV X1, X0, X1
-    ADD X1, X1, X1, LSL #1
-    LSL X0, X1, #6
-    STR X0, [SP, #0]
-    LDP X0, X1, [SP, #16]
-

--- a/app/src/main/cpp/skyline/nce/guest.h
+++ b/app/src/main/cpp/skyline/nce/guest.h
@@ -105,7 +105,6 @@ namespace skyline {
         namespace guest {
             constexpr size_t SaveCtxSize{34}; //!< The size of the SaveCtx function in 32-bit ARMv8 instructions
             constexpr size_t LoadCtxSize{34}; //!< The size of the LoadCtx function in 32-bit ARMv8 instructions
-            constexpr size_t RescaleClockSize{16}; //!< The size of the RescaleClock function in 32-bit ARMv8 instructions
 
             /**
              * @brief Saves the context from CPU registers into TLS
@@ -118,12 +117,6 @@ namespace skyline {
              * @note Assumes that 8B is reserved at an offset of 8B from SP
              */
             extern "C" void LoadCtx(void);
-
-            /**
-             * @brief Rescales the host clock to Tegra X1 levels
-             * @note Output is on stack with the stack pointer offset 32B from the initial point
-             */
-            extern "C" __noreturn void RescaleClock(void);
         }
     }
 }


### PR DESCRIPTION
Exynos SoCs have a bug where the `CNTFRQ_EL0` register is either set to 0 or contain incoherent values. With this patch, the frequency value is loaded into a static variable and used instead of reading the register. The value will be initialised to the correct value for affected SoCs, while unaffected ones will use the value from the register.