### PR TITLE
Add a rudimentary OSC button vibration setting

### DIFF
--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -265,6 +265,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             isGone = controllerType == ControllerType.None || !preferenceSettings.onScreenControl
             setOnButtonStateChangedListener(::onButtonStateChanged)
             setOnStickStateChangedListener(::onStickStateChanged)
+            hapticFeedback = preferenceSettings.onScreenControl && preferenceSettings.onScreenControlFeedback
             recenterSticks = preferenceSettings.onScreenControlRecenterSticks
         }
 

--- a/app/src/main/java/emu/skyline/input/ControllerActivity.kt
+++ b/app/src/main/java/emu/skyline/input/ControllerActivity.kt
@@ -91,7 +91,7 @@ class ControllerActivity : AppCompatActivity() {
                     adapter.notifyItemChanged(position)
                 })
 
-                items.add(ControllerCheckBoxViewItem(getString(R.string.osc_feedback), "", preferenceSettings.onScreenControlFeedback) { item, position ->
+                items.add(ControllerCheckBoxViewItem(getString(R.string.osc_feedback), getString(R.string.osc_feedback_description), preferenceSettings.onScreenControlFeedback) { item, position ->
                     preferenceSettings.onScreenControlFeedback = item.checked
                     adapter.notifyItemChanged(position)
                 })

--- a/app/src/main/java/emu/skyline/input/ControllerActivity.kt
+++ b/app/src/main/java/emu/skyline/input/ControllerActivity.kt
@@ -91,6 +91,11 @@ class ControllerActivity : AppCompatActivity() {
                     adapter.notifyItemChanged(position)
                 })
 
+                items.add(ControllerCheckBoxViewItem(getString(R.string.osc_feedback), "", preferenceSettings.onScreenControlFeedback) { item, position ->
+                    preferenceSettings.onScreenControlFeedback = item.checked
+                    adapter.notifyItemChanged(position)
+                })
+
                 items.add(ControllerCheckBoxViewItem(getString(R.string.osc_recenter_sticks), "", preferenceSettings.onScreenControlRecenterSticks) { item, position ->
                     preferenceSettings.onScreenControlRecenterSticks = item.checked
                     adapter.notifyItemChanged(position)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -74,6 +74,8 @@ abstract class OnScreenButton(
 
     var isPressed = false
 
+    var hapticFeedback = false
+
     var isEditing = false
         private set
 

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -66,6 +66,13 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
             field = value
             (controls.circularButtons + controls.rectangularButtons + controls.triggerButtons).forEach { it.hapticFeedback = hapticFeedback }
         }
+    private val vibrator: Vibrator =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+        } else {
+            @Suppress("DEPRECATION") (context.getSystemService(VIBRATOR_SERVICE) as Vibrator)
+        }
+    private val effectClick = VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
 
     override fun onDraw(canvas : Canvas) {
         super.onDraw(canvas)
@@ -81,16 +88,6 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
                 button.height = height
                 button.render(canvas)
             }
-        }
-    }
-
-    private val vibrationEffect = VibrationEffect.createOneShot(20, VibrationEffect.DEFAULT_AMPLITUDE)
-    private val vibrate = {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            (context.getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator.vibrate(vibrationEffect)
-        } else {
-            @Suppress("DEPRECATION")
-            (context.getSystemService(VIBRATOR_SERVICE) as Vibrator).vibrate(vibrationEffect)
         }
     }
 
@@ -123,7 +120,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
                     if (button.config.enabled && button.isTouched(x, y)) {
                         button.touchPointerId = pointerId
                         button.onFingerDown(x, y)
-                        if (hapticFeedback) vibrate()
+                        if (hapticFeedback) vibrator.vibrate(effectClick)
                         performClick()
                         onButtonStateChangedListener?.invoke(button.buttonId, ButtonState.Pressed)
                         handled = true

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -9,8 +9,14 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.content.Context
+import android.content.Context.VIBRATOR_MANAGER_SERVICE
+import android.content.Context.VIBRATOR_SERVICE
 import android.graphics.Canvas
 import android.graphics.PointF
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -55,6 +61,11 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
             field = value
             controls.joysticks.forEach { it.recenterSticks = recenterSticks }
         }
+    var hapticFeedback = false
+        set(value) {
+            field = value
+            (controls.circularButtons + controls.rectangularButtons + controls.triggerButtons).forEach { it.hapticFeedback = hapticFeedback }
+        }
 
     override fun onDraw(canvas : Canvas) {
         super.onDraw(canvas)
@@ -70,6 +81,16 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
                 button.height = height
                 button.render(canvas)
             }
+        }
+    }
+
+    private val vibrationEffect = VibrationEffect.createOneShot(20, VibrationEffect.DEFAULT_AMPLITUDE)
+    private val vibrate = {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator.vibrate(vibrationEffect)
+        } else {
+            @Suppress("DEPRECATION")
+            (context.getSystemService(VIBRATOR_SERVICE) as Vibrator).vibrate(vibrationEffect)
         }
     }
 
@@ -102,6 +123,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
                     if (button.config.enabled && button.isTouched(x, y)) {
                         button.touchPointerId = pointerId
                         button.onFingerDown(x, y)
+                        if (hapticFeedback) vibrate()
                         performClick()
                         onButtonStateChangedListener?.invoke(button.buttonId, ButtonState.Pressed)
                         handled = true

--- a/app/src/main/java/emu/skyline/utils/PreferenceSettings.kt
+++ b/app/src/main/java/emu/skyline/utils/PreferenceSettings.kt
@@ -51,6 +51,7 @@ class PreferenceSettings @Inject constructor(@ApplicationContext private val con
 
     // Input
     var onScreenControl by sharedPreferences(context, true)
+    var onScreenControlFeedback by sharedPreferences(context, true)
     var onScreenControlRecenterSticks by sharedPreferences(context, true)
 
     // Other

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="osc_not_shown">On-Screen Controls won\'t be shown</string>
     <string name="osc_shown">On-Screen Controls will be shown</string>
     <string name="osc_feedback">Enable Haptic Feedback</string>
+    <string name="osc_feedback_description">Excludes joysticks and hardware controls</string>
     <string name="osc_edit">Edit On-Screen Controls layout</string>
     <string name="setup_guide">Setup Guide</string>
     <string name="setup_guide_description">Sequentially map every stick and button</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="osc_enable">Enable On-Screen Controls</string>
     <string name="osc_not_shown">On-Screen Controls won\'t be shown</string>
     <string name="osc_shown">On-Screen Controls will be shown</string>
+    <string name="osc_feedback">Enable Haptic Feedback</string>
     <string name="osc_edit">Edit On-Screen Controls layout</string>
     <string name="setup_guide">Setup Guide</string>
     <string name="setup_guide_description">Sequentially map every stick and button</string>


### PR DESCRIPTION
No frills vibration for OSC buttons. Toggled from input settings, only activates for OSC, doesn't apply to joysticks. Vibration length / intensity mirrors pressing one of the navigation buttons (home, back, etc). Fulfills #2009 