### PR TITLE
Stub out InlineKeyboard

### DIFF
--- a/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.cpp
+++ b/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.cpp
@@ -69,11 +69,16 @@ namespace skyline::applet::swkbd {
                   std::move(onNormalDataPushFromApplet),
                   std::move(onInteractiveDataPushFromApplet),
                   appletMode} {
-        if (appletMode != service::applet::LibraryAppletMode::AllForeground)
-            throw exception("Inline Software Keyboard not implemeted");
+        mode = appletMode;
     }
 
     Result SoftwareKeyboardApplet::Start() {
+        if (mode != service::applet::LibraryAppletMode::AllForeground) {
+            Logger::Warn("Inline swkbd is unimplemented");
+            SendResult();
+            return {};
+        }
+
         std::scoped_lock lock{normalInputDataMutex};
         auto commonArgs{normalInputData.front()->GetSpan().as<service::applet::CommonArguments>()};
         normalInputData.pop();

--- a/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.h
+++ b/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.h
@@ -74,6 +74,7 @@ namespace skyline::applet::swkbd {
         #pragma pack(pop)
 
         KeyboardConfigVB config{};
+        service::applet::LibraryAppletMode mode{};
         bool validationPending{};
         std::u16string currentText{};
         CloseResult currentResult{};


### PR DESCRIPTION
This PR changes behavior of emulated swkbd applet, from throwing an error to emitting only a warning.
Along with #2023 (and possibly SetGyroscopeZeroDriftMode and GetGyroscopeZeroDriftMode stubs)
this PR brings Super Mario 3D World from `nothing` to `ingame`