### PR TITLE
Stub `GyroscopeZeroDriftMode`

### DIFF
--- a/app/src/main/cpp/skyline/input/npad_device.cpp
+++ b/app/src/main/cpp/skyline/input/npad_device.cpp
@@ -10,7 +10,8 @@ namespace skyline::input {
         : manager(manager),
           section(section),
           id(id),
-          updateEvent(std::make_shared<kernel::type::KEvent>(manager.state, false)) {
+          updateEvent(std::make_shared<kernel::type::KEvent>(manager.state, false)),
+          gyroZeroDriftMode(GyroscopeZeroDriftMode::Standard) {
         constexpr std::size_t InitializeEntryCount{19}; //!< HW initializes the first 19 entries
 
         ResetDeviceProperties();

--- a/app/src/main/cpp/skyline/input/npad_device.h
+++ b/app/src/main/cpp/skyline/input/npad_device.h
@@ -70,6 +70,8 @@ namespace skyline::input {
     /**
      * @brief A handle to a specific device addressed by its ID and type
      * @note This is used by both Six-Axis and Vibration
+     * @url https://switchbrew.org/wiki/HID_services#SixAxisSensorHandle
+     * @url https://switchbrew.org/wiki/HID_services#VibrationDeviceHandle
      */
     union __attribute__((__packed__)) NpadDeviceHandle {
         u32 raw;
@@ -125,6 +127,15 @@ namespace skyline::input {
     };
     static_assert(sizeof(NpadVibrationValue) == 0x10);
 
+    /**
+     * @url https://switchbrew.org/wiki/HID_services#GyroscopeZeroDriftMode
+     */
+    enum class GyroscopeZeroDriftMode : u32 {
+        Loose = 0,
+        Standard = 1,
+        Tight = 2,
+    };
+
     class NpadManager;
 
     /**
@@ -170,6 +181,7 @@ namespace skyline::input {
         NpadControllerType type{};
         NpadConnectionState connectionState{};
         std::shared_ptr<kernel::type::KEvent> updateEvent; //!< This event is triggered on the controller's style changing
+        GyroscopeZeroDriftMode gyroZeroDriftMode;
 
         NpadDevice(NpadManager &manager, NpadSection &section, NpadId id);
 

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.cpp
@@ -41,6 +41,28 @@ namespace skyline::service::hid {
         return {};
     }
 
+    Result IHidServer::SetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto npadHandle{request.Pop<NpadDeviceHandle>()};
+        auto mode{request.Pop<GyroscopeZeroDriftMode>()};
+
+        state.input->npad[npadHandle.id].gyroZeroDriftMode = mode;
+        return {};
+    }
+
+    Result IHidServer::GetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto npadHandle{request.Pop<NpadDeviceHandle>()};
+
+        response.Push(state.input->npad[npadHandle.id].gyroZeroDriftMode);
+        return {};
+    }
+
+    Result IHidServer::ResetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto npadHandle{request.Pop<NpadDeviceHandle>()};
+
+        state.input->npad[npadHandle.id].gyroZeroDriftMode = GyroscopeZeroDriftMode::Standard;
+        return {};
+    }
+
     Result IHidServer::IsSixAxisSensorAtRest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         response.Push<u8>(1);
         return {};

--- a/app/src/main/cpp/skyline/services/hid/IHidServer.h
+++ b/app/src/main/cpp/skyline/services/hid/IHidServer.h
@@ -58,6 +58,24 @@ namespace skyline::service::hid {
         Result StopSixAxisSensor(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Sets the gyroscope zero drift mode
+         * @url https://switchbrew.org/wiki/HID_services#SetGyroscopeZeroDriftMode
+         */
+        Result SetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Returns the gyroscope zero drift mode
+         * @url https://switchbrew.org/wiki/HID_services#GetGyroscopeZeroDriftMode
+         */
+        Result GetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Rsets the gyroscope zero drift mode to Standard
+         * @url https://switchbrew.org/wiki/HID_services#ResetGyroscopeZeroDriftMode
+         */
+        Result ResetGyroscopeZeroDriftMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @url https://switchbrew.org/wiki/HID_services#IsSixAxisSensorAtRest
          */
         Result IsSixAxisSensorAtRest(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -197,6 +215,9 @@ namespace skyline::service::hid {
             SFUNC(0x1F, IHidServer, ActivateKeyboard),
             SFUNC(0x42, IHidServer, StartSixAxisSensor),
             SFUNC(0x43, IHidServer, StopSixAxisSensor),
+            SFUNC(0x4F, IHidServer, SetGyroscopeZeroDriftMode),
+            SFUNC(0x50, IHidServer, GetGyroscopeZeroDriftMode),
+            SFUNC(0x51, IHidServer, ResetGyroscopeZeroDriftMode),
             SFUNC(0x52, IHidServer, IsSixAxisSensorAtRest),
             SFUNC(0x64, IHidServer, SetSupportedNpadStyleSet),
             SFUNC(0x65, IHidServer, GetSupportedNpadStyleSet),


### PR DESCRIPTION
Related service calls are called in a loop by SM3DW. A variable tracking zero drift mode has been added to `npad_device`, but it's unused at the moment.