### PR TITLE
Toggle DisableFrameThrottling setting by clicking on FPS display

### DIFF
--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -27,7 +27,7 @@ std::weak_ptr<skyline::kernel::OS> OsWeak;
 std::weak_ptr<skyline::gpu::GPU> GpuWeak;
 std::weak_ptr<skyline::audio::Audio> AudioWeak;
 std::weak_ptr<skyline::input::Input> InputWeak;
-std::weak_ptr<skyline::Settings> SettingsWeak;
+std::weak_ptr<skyline::AndroidSettings> SettingsWeak;
 
 // https://cs.android.com/android/platform/superproject/+/master:bionic/libc/tzcode/bionic.cpp;l=43;drc=master;bpv=1;bpt=1
 static std::string GetTimeZoneName() {
@@ -85,7 +85,8 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
 
     auto jvmManager{std::make_shared<skyline::JvmManager>(env, instance)};
 
-    std::shared_ptr<skyline::Settings> settings{std::make_shared<skyline::AndroidSettings>(env, settingsInstance)};
+    auto androidSettings{std::make_shared<skyline::AndroidSettings>(env, settingsInstance)};
+    std::shared_ptr<skyline::Settings> settings{androidSettings};
 
     skyline::JniString publicAppFilesPath(env, publicAppFilesPathJstring);
     skyline::Logger::EmulationContext.Initialize(publicAppFilesPath + "logs/emulation.sklog");
@@ -115,7 +116,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
         GpuWeak = os->state.gpu;
         AudioWeak = os->state.audio;
         InputWeak = os->state.input;
-        SettingsWeak = settings;
+        SettingsWeak = androidSettings;
         jvmManager->InitializeControllers();
 
         skyline::Logger::DebugNoPrefix("Launching ROM {}", skyline::JniString(env, romUriJstring));
@@ -235,6 +236,7 @@ extern "C" JNIEXPORT void JNICALL Java_emu_skyline_utils_NativeSettings_updateNa
     auto settings{SettingsWeak.lock()};
     if (!settings)
         return; // We don't mind if we miss settings updates while settings haven't been initialized
+    settings->BeginTransaction(env);
     settings->Update();
 }
 

--- a/app/src/main/cpp/skyline/common/android_settings.h
+++ b/app/src/main/cpp/skyline/common/android_settings.h
@@ -20,14 +20,12 @@ namespace skyline {
          * @note Will construct the underlying KtSettings object in-place
          */
         AndroidSettings(JNIEnv *env, jobject settingsInstance) : ktSettings(env, settingsInstance) {
+            ktSettings.BeginTransaction(env);
             Update();
         }
 
-        /**
-         * @note Will take ownership of the passed KtSettings object
-         */
-        AndroidSettings(KtSettings &&ktSettings) : ktSettings(std::move(ktSettings)) {
-            Update();
+        void BeginTransaction(JNIEnv *env) {
+            ktSettings.BeginTransaction(env);
         }
 
         void Update() override {
@@ -49,6 +47,6 @@ namespace skyline {
             disableSubgroupShuffle = ktSettings.GetBool("disableSubgroupShuffle");
             isAudioOutputDisabled = ktSettings.GetBool("isAudioOutputDisabled");
             validationLayer = ktSettings.GetBool("validationLayer");
-        };
+        }
     };
 }

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -33,7 +33,7 @@ namespace skyline::gpu {
         auto desc{presentationTrack.Serialize()};
         desc.set_name("Presentation");
         perfetto::TrackEvent::SetTrackDescriptor(presentationTrack, desc);
-        state.settings->disableFrameThrottling.AddCallback(std::bind(&PresentationEngine::OnDisableFrameThrottlingChanged, this, std::placeholders::_1));
+        state.settings->disableFrameThrottling.AddCallback([this](auto && value) { OnDisableFrameThrottlingChanged(value); });
     }
 
     PresentationEngine::~PresentationEngine() {

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -29,7 +29,9 @@ namespace skyline::gpu {
           presentationTrack{static_cast<u64>(trace::TrackIds::Presentation), perfetto::ProcessTrack::Current()},
           vsyncEvent{std::make_shared<kernel::type::KEvent>(state, true)},
           choreographerThread{&PresentationEngine::ChoreographerThread, this},
-          presentationThread{&PresentationEngine::PresentationThread, this} {
+          presentationThread{&PresentationEngine::PresentationThread, this},
+          forceTripleBuffering{*state.settings->forceTripleBuffering},
+          disableFrameThrottling{*state.settings->disableFrameThrottling} {
         auto desc{presentationTrack.Serialize()};
         desc.set_name("Presentation");
         perfetto::TrackEvent::SetTrackDescriptor(presentationTrack, desc);
@@ -203,7 +205,7 @@ namespace skyline::gpu {
             }); // We don't care about suboptimal images as they are caused by not respecting the transform hint, we handle transformations externally
         }
 
-        timestamp = (timestamp && !*state.settings->disableFrameThrottling) ? timestamp : getMonotonicNsNow(); // We tie FPS to the submission time rather than presentation timestamp, if we don't have the presentation timestamp available or if frame throttling is disabled as we want the maximum measured FPS to not be restricted to the refresh rate
+        timestamp = (timestamp && !disableFrameThrottling) ? timestamp : getMonotonicNsNow(); // We tie FPS to the submission time rather than presentation timestamp, if we don't have the presentation timestamp available or if frame throttling is disabled as we want the maximum measured FPS to not be restricted to the refresh rate
         if (frameTimestamp) {
             i64 sampleWeight{Fps ? Fps : 1}; //!< The weight of each sample in calculating the average, we want to roughly average the past second
 
@@ -281,7 +283,7 @@ namespace skyline::gpu {
     }
 
     void PresentationEngine::UpdateSwapchain(texture::Format format, texture::Dimensions extent) {
-        auto minImageCount{std::max(vkSurfaceCapabilities.minImageCount, *state.settings->forceTripleBuffering ? 3U : 2U)};
+        auto minImageCount{std::max(vkSurfaceCapabilities.minImageCount, forceTripleBuffering ? 3U : 2U)};
         if (minImageCount > MaxSwapchainImageCount)
             throw exception("Requesting swapchain with higher image count ({}) than maximum slot count ({})", minImageCount, MaxSwapchainImageCount);
 
@@ -305,7 +307,7 @@ namespace skyline::gpu {
         if ((capabilities.supportedUsageFlags & presentUsage) != presentUsage)
             throw exception("Swapchain doesn't support image usage '{}': {}", vk::to_string(presentUsage), vk::to_string(capabilities.supportedUsageFlags));
 
-        auto requestedMode{*state.settings->disableFrameThrottling ? vk::PresentModeKHR::eMailbox : vk::PresentModeKHR::eFifo};
+        auto requestedMode{disableFrameThrottling ? vk::PresentModeKHR::eMailbox : vk::PresentModeKHR::eFifo};
         auto modes{gpu.vkPhysicalDevice.getSurfacePresentModesKHR(**vkSurface)};
         if (std::find(modes.begin(), modes.end(), requestedMode) == modes.end())
             throw exception("Swapchain doesn't support present mode: {}", vk::to_string(requestedMode));
@@ -342,8 +344,10 @@ namespace skyline::gpu {
         swapchainImageCount = vkImages.size();
     }
 
-    void PresentationEngine::OnDisableFrameThrottlingChanged(const bool &value) {
+    void PresentationEngine::OnDisableFrameThrottlingChanged(const bool value) {
         std::scoped_lock guard{mutex};
+
+        disableFrameThrottling = value;
 
         if (vkSurface && swapchainExtent && swapchainFormat)
             UpdateSwapchain(swapchainFormat, swapchainExtent);

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -33,6 +33,7 @@ namespace skyline::gpu {
         auto desc{presentationTrack.Serialize()};
         desc.set_name("Presentation");
         perfetto::TrackEvent::SetTrackDescriptor(presentationTrack, desc);
+        state.settings->disableFrameThrottling.AddCallback(std::bind(&PresentationEngine::OnDisableFrameThrottlingChanged, this, std::placeholders::_1));
     }
 
     PresentationEngine::~PresentationEngine() {
@@ -339,6 +340,13 @@ namespace skyline::gpu {
         swapchainFormat = format;
         swapchainExtent = extent;
         swapchainImageCount = vkImages.size();
+    }
+
+    void PresentationEngine::OnDisableFrameThrottlingChanged(const bool &value) {
+        std::scoped_lock guard{mutex};
+
+        if (vkSurface && swapchainExtent && swapchainFormat)
+            UpdateSwapchain(swapchainFormat, swapchainExtent);
     }
 
     void PresentationEngine::UpdateSurface(jobject newSurface) {

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.h
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.h
@@ -105,6 +105,11 @@ namespace skyline::gpu {
          */
         void UpdateSwapchain(texture::Format format, texture::Dimensions extent);
 
+        /**
+         * @brief Handles DisableFrameThrottling setting changed event
+        */
+        void OnDisableFrameThrottlingChanged(const bool &value);
+
       public:
         PresentationEngine(const DeviceState &state, GPU &gpu);
 

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.h
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.h
@@ -46,6 +46,9 @@ namespace skyline::gpu {
         size_t frameIndex{}; //!< The index of the next semaphore/fence to be used for acquiring swapchain images
         size_t swapchainImageCount{}; //!< The number of images in the current swapchain
 
+        bool forceTripleBuffering{}; //!< If the presentation engine should always triple buffer even if the swapchain supports double buffering
+        bool disableFrameThrottling{}; //!< Allow the guest to submit frames without any blocking calls
+
         i64 frameTimestamp{}; //!< The timestamp of the last frame being shown in nanoseconds
         i64 averageFrametimeNs{}; //!< The average time between frames in nanoseconds
         i64 averageFrametimeDeviationNs{}; //!< The average deviation of frametimes in nanoseconds
@@ -108,7 +111,7 @@ namespace skyline::gpu {
         /**
          * @brief Handles DisableFrameThrottling setting changed event
         */
-        void OnDisableFrameThrottlingChanged(const bool &value);
+        void OnDisableFrameThrottlingChanged(const bool value);
 
       public:
         PresentationEngine(const DeviceState &state, GPU &gpu);

--- a/app/src/main/cpp/skyline/jvm.h
+++ b/app/src/main/cpp/skyline/jvm.h
@@ -25,18 +25,22 @@ namespace skyline {
      */
     class KtSettings {
       private:
-        JNIEnv *env; //!< A pointer to the current jni environment
+        JNIEnv *env{}; //!< The JNI environment
         jclass settingsClass; //!< The settings class
         jobject settingsInstance; //!< The settings instance
 
       public:
-        KtSettings(JNIEnv *env, jobject settingsInstance) : env(env), settingsInstance(settingsInstance), settingsClass(env->GetObjectClass(settingsInstance)) {}
+        KtSettings(JNIEnv *env, jobject settingsInstance) : settingsInstance(env->NewGlobalRef(settingsInstance)), settingsClass(reinterpret_cast<jclass>(env->NewGlobalRef(env->GetObjectClass(settingsInstance)))) {}
 
         KtSettings(const KtSettings &) = delete;
 
         void operator=(const KtSettings &) = delete;
 
         KtSettings(KtSettings &&) = default;
+
+        void BeginTransaction(JNIEnv *pEnv) {
+            this->env = pEnv;
+        }
 
         /**
          * @param key A null terminated string containing the key of the setting to get

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -76,6 +76,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     @Inject
     lateinit var preferenceSettings : PreferenceSettings
 
+    lateinit var nativeSettings : NativeSettings
+
     @Inject
     lateinit var inputManager : InputManager
 
@@ -194,7 +196,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
         GpuDriverHelper.ensureFileRedirectDir(this)
         emulationThread = Thread {
-            executeApplication(rom.toString(), romType, romFd.detachFd(), NativeSettings(this, preferenceSettings), applicationContext.getPublicFilesDir().canonicalPath + "/", applicationContext.filesDir.canonicalPath + "/", applicationInfo.nativeLibraryDir + "/", assets)
+            executeApplication(rom.toString(), romType, romFd.detachFd(), nativeSettings, applicationContext.getPublicFilesDir().canonicalPath + "/", applicationContext.filesDir.canonicalPath + "/", applicationInfo.nativeLibraryDir + "/", assets)
             returnFromEmulation()
         }
 
@@ -210,7 +212,10 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         super.onCreate(savedInstanceState)
         requestedOrientation = preferenceSettings.orientation
         window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+
         inputHandler = InputHandler(inputManager, preferenceSettings)
+        nativeSettings = NativeSettings(this, preferenceSettings)
+
         setContentView(binding.root)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -252,9 +257,13 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                     }
                 }, 250)
                 setOnClickListener {
-                    preferenceSettings.disableFrameThrottling = !preferenceSettings.disableFrameThrottling
-                    var color = if (preferenceSettings.disableFrameThrottling) getColor(R.color.colorPerfStatsSecondary) else getColor(R.color.colorPerfStatsPrimary)
+                    val newValue = !preferenceSettings.disableFrameThrottling
+                    preferenceSettings.disableFrameThrottling = newValue
+                    nativeSettings.disableFrameThrottling = newValue
+
+                    var color = if (newValue) getColor(R.color.colorPerfStatsSecondary) else getColor(R.color.colorPerfStatsPrimary)
                     binding.perfStats.setTextColor(color)
+                    nativeSettings.updateNative()
                 }
             }
         }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -251,6 +251,11 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                         postDelayed(this, 250)
                     }
                 }, 250)
+                setOnClickListener {
+                    preferenceSettings.disableFrameThrottling = !preferenceSettings.disableFrameThrottling
+                    var color = if (preferenceSettings.disableFrameThrottling) getColor(R.color.colorPerfStatsSecondary) else getColor(R.color.colorPerfStatsPrimary)
+                    binding.perfStats.setTextColor(color)
+                }
             }
         }
 


### PR DESCRIPTION
I made a suggestion few days ago about adding a toggle button for enabling/disabling frame throttling.
At first I thought about adding special button but it was easier to do it by clicking on FPS counter.
Not sure if I did it right, it was not working until I updated the setting inside presentation engine and updated the swapchain.
Tested on my phone and it seems to be working.