### PR TITLE
Stub some `IPurchaseEventManager` functions

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -356,6 +356,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/visrv/ISystemDisplayService.cpp
         ${source_DIR}/skyline/services/pl/IPlatformServiceManager.cpp
         ${source_DIR}/skyline/services/aocsrv/IAddOnContentManager.cpp
+        ${source_DIR}/skyline/services/aocsrv/IPurchaseEventManager.cpp
         ${source_DIR}/skyline/services/pctl/IParentalControlServiceFactory.cpp
         ${source_DIR}/skyline/services/pctl/IParentalControlService.cpp
         ${source_DIR}/skyline/services/lm/ILogService.cpp

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.cpp
@@ -3,6 +3,7 @@
 
 #include <kernel/types/KProcess.h>
 #include "IAddOnContentManager.h"
+#include "IPurchaseEventManager.h"
 
 namespace skyline::service::aocsrv {
     IAddOnContentManager::IAddOnContentManager(const DeviceState &state, ServiceManager &manager)
@@ -36,6 +37,11 @@ namespace skyline::service::aocsrv {
     }
 
     Result IAddOnContentManager::CheckAddOnContentMountStatus(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
+
+    Result IAddOnContentManager::CreateEcPurchasedEventManager(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        manager.RegisterService(SRVREG(IPurchaseEventManager), session, response);
         return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
+++ b/app/src/main/cpp/skyline/services/aocsrv/IAddOnContentManager.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <kernel/types/KEvent.h>
-#include <services/base_service.h>
+#include <services/serviceman.h>
 
 namespace skyline::service::aocsrv {
     /**
@@ -28,12 +28,15 @@ namespace skyline::service::aocsrv {
 
         Result CheckAddOnContentMountStatus(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result CreateEcPurchasedEventManager(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x2, IAddOnContentManager, CountAddOnContent),
             SFUNC(0x3, IAddOnContentManager, ListAddOnContent),
             SFUNC(0x8, IAddOnContentManager, GetAddOnContentListChangedEvent),
             SFUNC(0xA, IAddOnContentManager, GetAddOnContentListChangedEventWithProcessId),
-            SFUNC(0x32, IAddOnContentManager, CheckAddOnContentMountStatus)
+            SFUNC(0x32, IAddOnContentManager, CheckAddOnContentMountStatus),
+            SFUNC(0x64, IAddOnContentManager, CreateEcPurchasedEventManager)
         )
     };
 }

--- a/app/src/main/cpp/skyline/services/aocsrv/IPurchaseEventManager.cpp
+++ b/app/src/main/cpp/skyline/services/aocsrv/IPurchaseEventManager.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include <kernel/types/KProcess.h>
+#include "IPurchaseEventManager.h"
+
+namespace skyline::service::aocsrv {
+    IPurchaseEventManager::IPurchaseEventManager(const DeviceState &state, ServiceManager &manager)
+        : BaseService(state, manager),
+          purchasedEvent(std::make_shared<type::KEvent>(state, false)) {}
+
+    Result IPurchaseEventManager::SetDefaultDeliveryTarget(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
+
+    Result IPurchaseEventManager::GetPurchasedEventReadableHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto handle{state.process->InsertItem(purchasedEvent)};
+        Logger::Debug("Purchased Event Readable Handle: 0x{:X}", handle);
+
+        response.copyHandles.push_back(handle);
+        return {};
+    }
+}

--- a/app/src/main/cpp/skyline/services/aocsrv/IPurchaseEventManager.h
+++ b/app/src/main/cpp/skyline/services/aocsrv/IPurchaseEventManager.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <kernel/types/KEvent.h>
+#include <services/base_service.h>
+
+namespace skyline::service::aocsrv {
+    /**
+     * @url https://switchbrew.org/wiki/NS_Services#IPurchaseEventManager
+     */
+    class IPurchaseEventManager : public BaseService {
+      private:
+        std::shared_ptr<kernel::type::KEvent> purchasedEvent;
+
+      public:
+        IPurchaseEventManager(const DeviceState &state, ServiceManager &manager);
+
+        Result SetDefaultDeliveryTarget(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        Result GetPurchasedEventReadableHandle(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        SERVICE_DECL(
+            SFUNC(0x0, IPurchaseEventManager, SetDefaultDeliveryTarget),
+            SFUNC(0x2, IPurchaseEventManager, GetPurchasedEventReadableHandle)
+        )
+    };
+}


### PR DESCRIPTION
Allows Dying Light: Platinum Edition, Doom Eternal and Super Kirby Clash to boot, though they still needs other fixes to get past the Start Screen.
Makes Pokémon Café Mix playable.