### PR TITLE
Stub `notif:a` and some other services

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -332,6 +332,7 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/glue/IStaticService.cpp
         ${source_DIR}/skyline/services/glue/ITimeZoneService.cpp
         ${source_DIR}/skyline/services/glue/IWriterForSystem.cpp
+        ${source_DIR}/skyline/services/glue/INotificationServicesForApplication.cpp
         ${source_DIR}/skyline/services/fssrv/IFileSystemProxy.cpp
         ${source_DIR}/skyline/services/fssrv/IFileSystem.cpp
         ${source_DIR}/skyline/services/fssrv/IFile.cpp

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -296,6 +296,8 @@ add_library(skyline SHARED
         ${source_DIR}/skyline/services/am/applet/IApplet.cpp
         ${source_DIR}/skyline/services/bcat/IBcatService.cpp
         ${source_DIR}/skyline/services/bcat/IDeliveryCacheStorageService.cpp
+        ${source_DIR}/skyline/services/bcat/IDeliveryCacheFileService.cpp
+        ${source_DIR}/skyline/services/bcat/IDeliveryCacheDirectoryService.cpp
         ${source_DIR}/skyline/services/bcat/IServiceCreator.cpp
         ${source_DIR}/skyline/services/bt/IBluetoothUser.cpp
         ${source_DIR}/skyline/services/btm/IBtmUser.cpp

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.cpp
@@ -14,7 +14,8 @@ namespace skyline::service::am {
     IApplicationFunctions::IApplicationFunctions(const DeviceState &state, ServiceManager &manager)
         : BaseService(state, manager),
           gpuErrorEvent(std::make_shared<type::KEvent>(state, false)),
-          friendInvitationStorageChannelEvent(std::make_shared<type::KEvent>(state, false)) {}
+          friendInvitationStorageChannelEvent(std::make_shared<type::KEvent>(state, false)),
+          notificationStorageChannelEvent(std::make_shared<type::KEvent>(state, false)) {}
 
     Result IApplicationFunctions::PopLaunchParameter(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         constexpr u32 LaunchParameterMagic{0xC79497CA}; //!< The magic of the application launch parameters
@@ -181,5 +182,12 @@ namespace skyline::service::am {
 
     Result IApplicationFunctions::TryPopFromFriendInvitationStorageChannel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         return result::NotAvailable;
+    }
+
+    Result IApplicationFunctions::GetNotificationStorageChannelEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto handle{state.process->InsertItem(notificationStorageChannelEvent)};
+        Logger::Warn("Notification Storage Channel Event Handle: 0x{:X}", handle);
+        response.copyHandles.push_back(handle);
+        return {};
     }
 }

--- a/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
+++ b/app/src/main/cpp/skyline/services/am/controller/IApplicationFunctions.h
@@ -21,6 +21,7 @@ namespace skyline::service::am {
       private:
         std::shared_ptr<type::KEvent> gpuErrorEvent; //!< The event signalled on GPU errors
         std::shared_ptr<type::KEvent> friendInvitationStorageChannelEvent; //!< The event signalled on friend invitations
+        std::shared_ptr<type::KEvent> notificationStorageChannelEvent;
         i32 previousProgramIndex{-1}; //!< There was no previous title
 
       public:
@@ -131,6 +132,12 @@ namespace skyline::service::am {
 
         Result TryPopFromFriendInvitationStorageChannel(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        /**
+         * @brief Obtains a handle to the Notification StorageChannel KEvent
+         * @url https://switchbrew.org/wiki/Applet_Manager_services#GetNotificationStorageChannelEvent
+         */
+        Result GetNotificationStorageChannelEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         SERVICE_DECL(
             SFUNC(0x1, IApplicationFunctions, PopLaunchParameter),
             SFUNC(0x14, IApplicationFunctions, EnsureSaveData),
@@ -150,7 +157,8 @@ namespace skyline::service::am {
             SFUNC(0x7B, IApplicationFunctions, GetPreviousProgramIndex),
             SFUNC(0x82, IApplicationFunctions, GetGpuErrorDetectedSystemEvent),
             SFUNC(0x8C, IApplicationFunctions, GetFriendInvitationStorageChannelEvent),
-            SFUNC(0x8D, IApplicationFunctions, TryPopFromFriendInvitationStorageChannel)
+            SFUNC(0x8D, IApplicationFunctions, TryPopFromFriendInvitationStorageChannel),
+            SFUNC(0x96, IApplicationFunctions, GetNotificationStorageChannelEvent)
         )
 
     };

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheDirectoryService.cpp
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheDirectoryService.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "IDeliveryCacheDirectoryService.h"
+
+namespace skyline::service::bcat {
+    IDeliveryCacheDirectoryService::IDeliveryCacheDirectoryService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
+
+    Result IDeliveryCacheDirectoryService::Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        const auto dir_name{request.PopString(0x20)};
+
+        Logger::Debug("Directory name = {}", dir_name);
+        return {};
+    }
+
+    Result IDeliveryCacheDirectoryService::GetCount(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push(static_cast<u32>(0));
+        return {};
+    }
+}

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheDirectoryService.h
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheDirectoryService.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/serviceman.h>
+
+namespace skyline::service::bcat {
+    /**
+     * @brief IDeliveryCacheDirectoryService is used to access BCAT directories
+     * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheDirectoryService
+     */
+    class IDeliveryCacheDirectoryService : public BaseService {
+      public:
+        IDeliveryCacheDirectoryService(const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief Given a DirectoryName, opens that directory
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheDirectoryService
+         */
+        Result Open (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Returns the number (u32) of elements inside the directory (u64)
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheDirectoryService
+         */
+        Result GetCount (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        SERVICE_DECL(
+          SFUNC(0x0, IDeliveryCacheDirectoryService, Open),
+          SFUNC(0x2, IDeliveryCacheDirectoryService, GetCount)
+        )
+    };
+}

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheFileService.cpp
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheFileService.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "IDeliveryCacheFileService.h"
+
+namespace skyline::service::bcat {
+    IDeliveryCacheFileService::IDeliveryCacheFileService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
+
+    Result IDeliveryCacheFileService::Open(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        const auto dir_name{request.PopString(0x20)};
+        const auto file_name{request.PopString(0x20)};
+
+        Logger::Debug("Directory name = {}, File name = {}", dir_name, file_name);
+        return {};
+    }
+
+    Result IDeliveryCacheFileService::GetSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push(static_cast<u64>(0));
+        return {};
+    }
+}

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheFileService.h
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheFileService.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/serviceman.h>
+
+namespace skyline::service::bcat {
+    /**
+     * @brief IDeliveryCacheFileService is used to access BCAT files
+     * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheFileService
+     */
+    class IDeliveryCacheFileService : public BaseService {
+      public:
+        IDeliveryCacheFileService(const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief Given a DirectoryName and a FileName, opens the desired file
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheFileService
+         */
+        Result Open (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Returns the size (u64) of the file
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheFileService
+         */
+        Result GetSize (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+      SERVICE_DECL(
+        SFUNC(0x0, IDeliveryCacheFileService, Open),
+        SFUNC(0x2, IDeliveryCacheFileService, GetSize)
+      )
+    };
+}

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheStorageService.cpp
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheStorageService.cpp
@@ -2,7 +2,24 @@
 // Copyright © 2022 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
 #include "IDeliveryCacheStorageService.h"
+#include "IDeliveryCacheFileService.h"
+#include "IDeliveryCacheDirectoryService.h"
 
 namespace skyline::service::bcat {
     IDeliveryCacheStorageService::IDeliveryCacheStorageService(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
+
+    Result IDeliveryCacheStorageService::CreateFileService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        manager.RegisterService(SRVREG(IDeliveryCacheFileService), session, response);
+        return {};
+    }
+
+    Result IDeliveryCacheStorageService::CreateDirectoryService(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        manager.RegisterService(SRVREG(IDeliveryCacheDirectoryService), session, response);
+        return {};
+    }
+
+    Result IDeliveryCacheStorageService::EnumerateDeliveryCacheDirectory(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push(static_cast<u32>(0));
+        return {};
+    }
 }

--- a/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheStorageService.h
+++ b/app/src/main/cpp/skyline/services/bcat/IDeliveryCacheStorageService.h
@@ -13,5 +13,25 @@ namespace skyline::service::bcat {
     class IDeliveryCacheStorageService : public BaseService {
       public:
         IDeliveryCacheStorageService(const DeviceState &state, ServiceManager &manager);
+
+        /**
+         * @brief Returns #IDeliveryCacheFileService
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheStorageService
+         */
+        Result CreateFileService (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Returns #IDeliveryCacheDirectoryService
+         * @url https://switchbrew.org/wiki/BCAT_services#IDeliveryCacheStorageService
+         */
+        Result CreateDirectoryService (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        Result EnumerateDeliveryCacheDirectory (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        SERVICE_DECL(
+            SFUNC(0x0, IDeliveryCacheStorageService, CreateFileService),
+            SFUNC(0x1, IDeliveryCacheStorageService, CreateDirectoryService),
+            SFUNC(0xA, IDeliveryCacheStorageService, EnumerateDeliveryCacheDirectory)
+        )
     };
 }

--- a/app/src/main/cpp/skyline/services/glue/INotificationServicesForApplication.cpp
+++ b/app/src/main/cpp/skyline/services/glue/INotificationServicesForApplication.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#include "INotificationServicesForApplication.h"
+
+namespace skyline::service::glue {
+    INotificationServicesForApplication::INotificationServicesForApplication(const DeviceState &state, ServiceManager &manager) : BaseService(state, manager) {}
+}

--- a/app/src/main/cpp/skyline/services/glue/INotificationServicesForApplication.h
+++ b/app/src/main/cpp/skyline/services/glue/INotificationServicesForApplication.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <services/base_service.h>
+
+namespace skyline::service::glue {
+    /**
+     * @brief Stub implementation for INotificationServicesForApplication
+     * @url https://switchbrew.org/wiki/Glue_services#notif:a
+     */
+    class INotificationServicesForApplication : public BaseService {
+      public:
+        INotificationServicesForApplication(const DeviceState &state, ServiceManager &manager);
+    };
+}

--- a/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
+++ b/app/src/main/cpp/skyline/services/prepo/IPrepoService.cpp
@@ -10,6 +10,10 @@ namespace skyline::service::prepo {
         return {};
     }
 
+    Result IPrepoService::SaveReportWithUserOld2 (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        return {};
+    }
+
     Result IPrepoService::SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         return {};
     }

--- a/app/src/main/cpp/skyline/services/prepo/IPrepoService.h
+++ b/app/src/main/cpp/skyline/services/prepo/IPrepoService.h
@@ -19,12 +19,15 @@ namespace skyline::service::prepo {
          */
         Result SaveReportWithUserOld (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
+        Result SaveReportWithUserOld2 (type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
         Result SaveReportWithUser(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         Result RequestImmediateTransmission(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         SERVICE_DECL(
             SFUNC(0x2775, IPrepoService, SaveReportWithUserOld),
+            SFUNC(0x2777, IPrepoService, SaveReportWithUserOld2),
             SFUNC(0x2779, IPrepoService, SaveReportWithUser),
             SFUNC(0x27D8, IPrepoService, RequestImmediateTransmission)
         )

--- a/app/src/main/cpp/skyline/services/serviceman.cpp
+++ b/app/src/main/cpp/skyline/services/serviceman.cpp
@@ -21,6 +21,7 @@
 #include "timesrv/IStaticService.h"
 #include "glue/IStaticService.h"
 #include "glue/IWriterForSystem.h"
+#include "glue/INotificationServicesForApplication.h"
 #include "services/timesrv/core.h"
 #include "fssrv/IFileSystemProxy.h"
 #include "nvdrv/INvDrvServices.h"
@@ -99,6 +100,7 @@ namespace skyline::service {
             SERVICE_CASE(glue::IStaticService, "time:a", globalServiceState->timesrv.managerServer.GetStaticServiceAsAdmin(state, *this), globalServiceState->timesrv, timesrv::constant::StaticServiceAdminPermissions)
             SERVICE_CASE(glue::IStaticService, "time:r", globalServiceState->timesrv.managerServer.GetStaticServiceAsRepair(state, *this), globalServiceState->timesrv, timesrv::constant::StaticServiceRepairPermissions)
             SERVICE_CASE(glue::IStaticService, "time:u", globalServiceState->timesrv.managerServer.GetStaticServiceAsUser(state, *this), globalServiceState->timesrv, timesrv::constant::StaticServiceUserPermissions)
+            SERVICE_CASE(glue::INotificationServicesForApplication, "notif:a")
             SERVICE_CASE(glue::IWriterForSystem, "ectx:w")
             SERVICE_CASE(glue::IWriterForSystem, "ectx:aw")
             SERVICE_CASE(fssrv::IFileSystemProxy, "fsp-srv")


### PR DESCRIPTION
Services related to BCAT allow Super Kirby Clash to go ingame.
Services related to notifications will allow Brain Training to be playable once the crash preventing it from booting is fixed.