### PR TITLE
Add options to group and sort games

### DIFF
--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -257,7 +257,7 @@ class MainActivity : AppCompatActivity() {
             SortingOrder.AlphabeticalAsc.ordinal -> sortedApps.sortBy { it.name }
             SortingOrder.AlphabeticalDesc.ordinal -> sortedApps.sortByDescending { it.name }
         }
-        return sortedApps.toList()
+        return sortedApps
     }
 
     private fun handleState(state : MainState) = when (state) {

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -64,6 +64,11 @@ class MainActivity : AppCompatActivity() {
     private var formatFilter : RomFormat? = null
     private var appEntries : Map<RomFormat, List<AppEntry>>? = null
 
+    enum class SortingOrder {
+        AlphabeticalAsc,
+        AlphabeticalDesc
+    }
+
     private var refreshIconVisible = false
         set(visible) {
             field = visible
@@ -245,14 +250,14 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun sortGameList(gameList : List<AppEntry>) : MutableList<AppEntry> {
+    private fun sortGameList(gameList : List<AppEntry>) : List<AppEntry> {
         val sortedApps : MutableList<AppEntry> = mutableListOf<AppEntry>()
         gameList.forEach { entry -> sortedApps.add(entry) }
         when (preferenceSettings.sortAppsBy) {
-            1 -> sortedApps.sortByDescending { it.name }
-            else -> sortedApps.sortBy { it.name }
+            SortingOrder.AlphabeticalAsc.ordinal -> sortedApps.sortBy { it.name }
+            SortingOrder.AlphabeticalDesc.ordinal -> sortedApps.sortByDescending { it.name }
         }
-        return sortedApps
+        return sortedApps.toList()
     }
 
     private fun handleState(state : MainState) = when (state) {

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -217,15 +217,42 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun getDataItems() = mutableListOf<DataItem>().apply {
-        appEntries?.let { entries ->
-            val formats = formatFilter?.let { listOf(it) } ?: formatOrder
-            for (format in formats) {
-                entries[format]?.let {
-                    add(HeaderItem(format.name))
-                    it.forEach { entry -> add(AppItem(entry)) }
+        if (preferenceSettings.groupByFormat) {
+            appEntries?.let { entries ->
+                val formats = formatFilter?.let { listOf(it) } ?: formatOrder
+                for (format in formats) {
+                    entries[format]?.let {
+                        add(HeaderItem(format.name))
+                        for (entry in sortGameList(it)) {
+                            add(AppItem(entry))
+                        }
+                    }
                 }
             }
+        } else {
+            val gameList = mutableListOf<AppEntry>()
+            appEntries?.let { entries ->
+                val formats = formatFilter?.let { listOf(it) } ?: formatOrder
+                for (format in formats) {
+                    entries[format]?.let {
+                        it.forEach { entry -> gameList.add(entry) }
+                    }
+                }
+            }
+            for (entry in sortGameList(gameList.toList())) {
+                add(AppItem(entry))
+            }
         }
+    }
+
+    private fun sortGameList(gameList : List<AppEntry>) : MutableList<AppEntry> {
+        val sortedApps : MutableList<AppEntry> = mutableListOf<AppEntry>()
+        gameList.forEach { entry -> sortedApps.add(entry) }
+        when (preferenceSettings.sortAppsBy) {
+            1 -> sortedApps.sortByDescending { it.name }
+            else -> sortedApps.sortBy { it.name }
+        }
+        return sortedApps
     }
 
     private fun handleState(state : MainState) = when (state) {

--- a/app/src/main/java/emu/skyline/preference/ChkBoxPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/ChkBoxPreference.kt
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ */
+
+package emu.skyline.preference
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.CheckBoxPreference
+import androidx.preference.R
+import emu.skyline.di.getSettings
+
+/**
+ * This preference is used with checkboxes that need to refresh the main activity when changed
+ */
+class ChkBoxPreference @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = R.attr.checkBoxPreferenceStyle) : CheckBoxPreference(context, attrs, defStyleAttr) {
+
+    override fun onClick() {
+        context?.getSettings()?.refreshRequired = true
+        super.onClick()
+    }
+}

--- a/app/src/main/java/emu/skyline/preference/RefreshCheckBoxPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/RefreshCheckBoxPreference.kt
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MPL-2.0
- * Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ * Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
  */
 
 package emu.skyline.preference
@@ -14,8 +14,7 @@ import emu.skyline.di.getSettings
 /**
  * This preference is used with checkboxes that need to refresh the main activity when changed
  */
-class ChkBoxPreference @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = R.attr.checkBoxPreferenceStyle) : CheckBoxPreference(context, attrs, defStyleAttr) {
-
+class RefreshCheckBoxPreference @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = R.attr.checkBoxPreferenceStyle) : CheckBoxPreference(context, attrs, defStyleAttr) {
     override fun onClick() {
         context?.getSettings()?.refreshRequired = true
         super.onClick()

--- a/app/src/main/java/emu/skyline/utils/PreferenceSettings.kt
+++ b/app/src/main/java/emu/skyline/utils/PreferenceSettings.kt
@@ -18,6 +18,8 @@ class PreferenceSettings @Inject constructor(@ApplicationContext private val con
     var searchLocation by sharedPreferences(context, "")
     var appTheme by sharedPreferences(context, 2)
     var layoutType by sharedPreferences(context, 1)
+    var groupByFormat by sharedPreferences(context, true)
+    var sortAppsBy by sharedPreferences(context, 0)
     var selectAction by sharedPreferences(context, false)
     var perfStats by sharedPreferences(context, false)
     var logLevel by sharedPreferences(context, 3)

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -12,6 +12,10 @@
         <item>Grid</item>
         <item>Grid Compact</item>
     </string-array>
+    <string-array name="sort_apps_by">
+        <item>A-Z</item>
+        <item>Z-A</item>
+    </string-array>
     <string-array name="app_theme">
         <item>Light</item>
         <item>Dark</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="failed_open_directory">Cannot find an external file manager to open Skyline\'s internal directory</string>
     <string name="theme">Theme</string>
     <string name="layout_type">Game Display Layout</string>
+    <string name="group_by_format">Group Games By Format</string>
+    <string name="group_by_format_desc_off">Games will be shown as a single list</string>
+    <string name="group_by_format_desc_on">Games will be shown grouped by format</string>
+    <string name="sort_apps_by">Games Sorting Order</string>
     <string name="select_action">Always Show Game Information</string>
     <string name="select_action_desc_on">Game information will be shown on clicking a game</string>
     <string name="select_action_desc_off">Game information will only be shown on long-clicking a game</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -23,6 +23,20 @@
             app:title="@string/layout_type"
             app:useSimpleSummaryProvider="true" />
         <CheckBoxPreference
+            android:defaultValue="true"
+            android:summaryOff="@string/group_by_format_desc_off"
+            android:summaryOn="@string/group_by_format_desc_on"
+            app:key="group_by_format"
+            app:refreshRequired="true"
+            app:title="@string/group_by_format" />
+        <emu.skyline.preference.IntegerListPreference
+            android:defaultValue="0"
+            android:entries="@array/sort_apps_by"
+            app:key="sort_apps_by"
+            app:refreshRequired="true"
+            app:title="@string/sort_apps_by"
+            app:useSimpleSummaryProvider="true" />
+        <CheckBoxPreference
             android:defaultValue="false"
             android:summaryOff="@string/select_action_desc_off"
             android:summaryOn="@string/select_action_desc_on"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,7 +22,7 @@
             app:key="layout_type"
             app:title="@string/layout_type"
             app:useSimpleSummaryProvider="true" />
-        <CheckBoxPreference
+        <emu.skyline.preference.ChkBoxPreference
             android:defaultValue="true"
             android:summaryOff="@string/group_by_format_desc_off"
             android:summaryOn="@string/group_by_format_desc_on"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,7 +22,7 @@
             app:key="layout_type"
             app:title="@string/layout_type"
             app:useSimpleSummaryProvider="true" />
-        <emu.skyline.preference.ChkBoxPreference
+        <emu.skyline.preference.RefreshCheckBoxPreference
             android:defaultValue="true"
             android:summaryOff="@string/group_by_format_desc_off"
             android:summaryOn="@string/group_by_format_desc_on"


### PR DESCRIPTION
Functionality is added to the game list on the main screen, adding and option to disable grouping the games by format, and adding an additional option to sort games by alphabetical order, from A-Z or Z-A at the moment, thinking of adding options for sorting by favorites, and played count.