### PR TITLE
Add TIC format `0x78D24952`

### DIFF
--- a/app/src/main/cpp/skyline/gpu/interconnect/common/textures.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/textures.cpp
@@ -121,6 +121,8 @@ namespace skyline::gpu::interconnect {
             TIC_FORMAT_CASE_ST_SRGB(Astc5x5, Astc5x5, Unorm);
             TIC_FORMAT_CASE_ST(Astc6x6, Astc6x6, Unorm);
             TIC_FORMAT_CASE_ST_SRGB(Astc6x6, Astc6x6, Unorm);
+            TIC_FORMAT_CASE_ST(Astc8x6, Astc8x6, Unorm);
+            TIC_FORMAT_CASE_ST_SRGB(Astc8x6, Astc8x6, Unorm);
             TIC_FORMAT_CASE_ST(Astc8x8, Astc8x8, Unorm);
             TIC_FORMAT_CASE_ST_SRGB(Astc8x8, Astc8x8, Unorm);
             TIC_FORMAT_CASE_ST(Astc10x8, Astc10x8, Unorm);

--- a/app/src/main/cpp/skyline/gpu/texture/format.h
+++ b/app/src/main/cpp/skyline/gpu/texture/format.h
@@ -141,6 +141,10 @@ namespace skyline::gpu::format {
                            .blockWidth = 6,
                            .blockHeight = 6
     );
+    FORMAT_SUFF_UNORM_SRGB(Astc8x6, 128, eAstc8x6, Block,
+                           .blockWidth = 8,
+                           .blockHeight = 6
+    );
     FORMAT_SUFF_UNORM_SRGB(Astc8x8, 128, eAstc8x8, Block,
                            .blockWidth = 8,
                            .blockHeight = 8


### PR DESCRIPTION
Changes the flickering color in Doom Eternal from green to pink.