### PR TITLE
Implement various DMA engine features and copy methods

### DIFF
--- a/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.cpp
@@ -44,12 +44,12 @@ namespace skyline::gpu::interconnect {
         });
     }
 
-    void Inline2Memory::Upload(IOVA dst, span<u32> src) {
-        auto dstMappings{channelCtx.asCtx->gmmu.TranslateRange(dst, src.size_bytes())};
+    void Inline2Memory::Upload(IOVA dst, span<u8> src) {
+        auto dstMappings{channelCtx.asCtx->gmmu.TranslateRange(dst, src.size())};
 
         size_t offset{};
         for (auto mapping : dstMappings) {
-            UploadSingleMapping(mapping, src.cast<u8>().subspan(offset, mapping.size()));
+            UploadSingleMapping(mapping, src.subspan(offset, mapping.size()));
             offset += mapping.size();
         }
     }

--- a/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.h
@@ -33,6 +33,6 @@ namespace skyline::gpu::interconnect {
       public:
         Inline2Memory(GPU &gpu, soc::gm20b::ChannelContext &channelCtx);
 
-        void Upload(IOVA dst, span<u32> src);
+        void Upload(IOVA dst, span<u8> src);
     };
 }

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.h
@@ -30,5 +30,7 @@ namespace skyline::gpu::interconnect {
         MaxwellDma(GPU &gpu, soc::gm20b::ChannelContext &channelCtx);
 
         void Copy(span<u8> dstMapping, span<u8> srcMapping);
+
+        void Clear(span<u8> mapping, u32 value);
     };
 }

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.h
@@ -22,8 +22,6 @@ namespace skyline::gpu::interconnect {
      */
     class MaxwellDma {
       private:
-        using IOVA = soc::gm20b::IOVA;
-
         GPU &gpu;
         soc::gm20b::ChannelContext &channelCtx;
         gpu::interconnect::CommandExecutor &executor;
@@ -31,6 +29,6 @@ namespace skyline::gpu::interconnect {
       public:
         MaxwellDma(GPU &gpu, soc::gm20b::ChannelContext &channelCtx);
 
-        void Copy(IOVA dst, IOVA src, size_t size);
+        void Copy(span<u8> dstMapping, span<u8> srcMapping);
     };
 }

--- a/app/src/main/cpp/skyline/gpu/texture/layout.cpp
+++ b/app/src/main/cpp/skyline/gpu/texture/layout.cpp
@@ -177,17 +177,14 @@ namespace skyline::gpu::texture {
 
             if (hasPaddingBlock)
                 deswizzleBlock(pitchRob, [&](u8 *linearSector, size_t xT) __attribute__((always_inline)) {
-                    #pragma clang loop unroll_count(4)
-                    for (size_t pixelOffset{}; pixelOffset < SectorWidth; pixelOffset += formatBpb) {
-                        if (xT < blockPaddingOffset) {
-                            if constexpr (BlockLinearToPitch)
-                                std::memcpy(linearSector + pixelOffset, sector, formatBpb);
-                            else
-                                std::memcpy(sector, linearSector + pixelOffset, formatBpb);
-                        }
-                        xT += formatBpb;
-                    }
+                    if (xT < blockPaddingOffset) {
+                        size_t copyAmount{std::min<size_t>(blockPaddingOffset - xT, SectorWidth)};
 
+                        if constexpr (BlockLinearToPitch)
+                            std::memcpy(linearSector, sector, copyAmount);
+                        else
+                            std::memcpy(sector, linearSector, copyAmount);
+                    }
                     sector += SectorWidth;
                 });
         }};

--- a/app/src/main/cpp/skyline/gpu/texture/layout.h
+++ b/app/src/main/cpp/skyline/gpu/texture/layout.h
@@ -47,6 +47,16 @@ namespace skyline::gpu::texture {
                                 size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb, u32 pitchAmount,
                                 size_t gobBlockHeight, size_t gobBlockDepth,
                                 u8 *blockLinear, u8 *pitch);
+
+    /**
+     * @brief Copies the contents of a part of a blocklinear texture to a pitch texture
+     */
+    void CopyBlockLinearToPitchSubrect(Dimensions pitchDimensions, Dimensions blockLinearDimensions,
+                                       size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb, u32 pitchAmount,
+                                       size_t gobBlockHeight, size_t gobBlockDepth,
+                                       u8 *blockLinear, u8 *pitch,
+                                       u32 originX, u32 originY);
+
     /**
      * @brief Copies the contents of a blocklinear guest texture to a linear output buffer
      */
@@ -69,7 +79,14 @@ namespace skyline::gpu::texture {
                                  u8 *pitch, u8 *blockLinear);
 
     /**
-     * @brief Copies the contents of a blocklinear guest texture to a linear output buffer
+     * @brief Copies the contents of a linear texture to a part of a blocklinear texture
+     */
+    void CopyLinearToBlockLinearSubrect(Dimensions linearDimensions, Dimensions blockLinearDimensions,
+                                       size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb,
+                                       size_t gobBlockHeight, size_t gobBlockDepth,
+                                       u8 *linear, u8 *blockLinear,
+                                        u32 originX, u32 originY);
+
     /**
      * @brief Copies the contents of a pitch texture to a part of a blocklinear texture
      */

--- a/app/src/main/cpp/skyline/gpu/texture/layout.h
+++ b/app/src/main/cpp/skyline/gpu/texture/layout.h
@@ -41,20 +41,46 @@ namespace skyline::gpu::texture {
                                  u8 *blockLinear, u8 *linear);
 
     /**
+     * @brief Copies the contents of a blocklinear texture to a pitch texture
+     */
+    void CopyBlockLinearToPitch(Dimensions dimensions,
+                                size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb, u32 pitchAmount,
+                                size_t gobBlockHeight, size_t gobBlockDepth,
+                                u8 *blockLinear, u8 *pitch);
+    /**
      * @brief Copies the contents of a blocklinear guest texture to a linear output buffer
      */
     void CopyBlockLinearToLinear(const GuestTexture &guest, u8 *blockLinear, u8 *linear);
 
     /**
-     * @brief Copies the contents of a blocklinear texture to a linear output buffer
+     * @brief Copies the contents of a linear buffer to a blocklinear texture
      */
     void CopyLinearToBlockLinear(Dimensions dimensions,
-                                 size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb,
+                                size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb,
+                                size_t gobBlockHeight, size_t gobBlockDepth,
+                                u8 *linear, u8 *blockLinear);
+
+    /**
+     * @brief Copies the contents of a pitch texture to a blocklinear texture
+     */
+    void CopyPitchToBlockLinear(Dimensions dimensions,
+                                 size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb, u32 pitchAmount,
                                  size_t gobBlockHeight, size_t gobBlockDepth,
-                                 u8 *linear, u8 *blockLinear);
+                                 u8 *pitch, u8 *blockLinear);
 
     /**
      * @brief Copies the contents of a blocklinear guest texture to a linear output buffer
+    /**
+     * @brief Copies the contents of a pitch texture to a part of a blocklinear texture
+     */
+    void CopyPitchToBlockLinearSubrect(Dimensions pitchDimensions, Dimensions blockLinearDimensions,
+                                 size_t formatBlockWidth, size_t formatBlockHeight, size_t formatBpb, u32 pitchAmount,
+                                 size_t gobBlockHeight, size_t gobBlockDepth,
+                                 u8 *pitch, u8 *blockLinear,
+                                 u32 originX, u32 originY);
+
+    /**
+     * @brief Copies the contents of a linear guest texture to a blocklinear texture
      */
     void CopyLinearToBlockLinear(const GuestTexture &guest, u8 *linear, u8 *blockLinear);
 

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/inline2memory.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/inline2memory.cpp
@@ -43,14 +43,14 @@ namespace skyline::soc::gm20b::engine {
                 if ((srcDimensions.width != dstDimensions.width) || (srcDimensions.height != dstDimensions.height))
                     gpu::texture::CopyLinearToBlockLinearSubrect(srcDimensions, dstDimensions,
                                                                  1, 1, 1,
-                                                                 1 << static_cast<u8>(state.dstBlockSize.height), 1 << static_cast<u8>(state.dstBlockSize.depth),
+                                                                 state.dstBlockSize.Height(), state.dstBlockSize.Depth(),
                                                                  span{buffer}.cast<u8>().data(), dst,
                                                                  state.originBytesX, state.originSamplesY
                     );
                 else
                     gpu::texture::CopyLinearToBlockLinear(dstDimensions,
                                                           1, 1, 1,
-                                                          1 << static_cast<u8>(state.dstBlockSize.height), 1 << static_cast<u8>(state.dstBlockSize.depth),
+                                                          state.dstBlockSize.Height(), state.dstBlockSize.Depth(),
                                                           span{buffer}.cast<u8>().data(), dst
                     );
             }};

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/inline2memory.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/inline2memory.h
@@ -28,28 +28,6 @@ namespace skyline::soc::gm20b::engine {
          * @url https://github.com/devkitPro/deko3d/blob/master/source/maxwell/engine_inline.def
          */
         struct RegisterState {
-            enum class BlockWidth : u8 {
-                OneGob = 0
-            };
-
-            enum class BlockHeight : u8 {
-                OneGob = 0,
-                TwoGobs = 1,
-                FourGobs = 2,
-                EightGobs = 3,
-                SixteenGobs = 4,
-                ThirtyTwoGobs = 5
-            };
-
-            enum class BlockDepth : u8 {
-                OneGob = 0,
-                TwoGobs = 1,
-                FourGobs = 2,
-                EightGobs = 3,
-                SixteenGobs = 4,
-                ThirtyTwoGobs = 5
-            };
-
             enum class DmaDstMemoryLayout : u8 {
                 BlockLinear = 0,
                 Pitch = 1
@@ -92,10 +70,17 @@ namespace skyline::soc::gm20b::engine {
             Address offsetOut;
             u32 pitchOut;
             struct {
-                BlockWidth width : 4;
-                BlockHeight height : 4;
-                BlockDepth depth : 4;
+                u32 width : 4;
+                u32 height : 4;
+                u32 depth : 4;
                 u32 _pad1_ : 20;
+
+                size_t Height() const {
+                    return 1 << height;
+                }
+                size_t Depth() const {
+                    return 1 << depth;
+                }
             } dstBlockSize;
             u32 dstWidth;
             u32 dstHeight;

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.cpp
@@ -95,8 +95,8 @@ namespace skyline::soc::gm20b::engine {
                     (registers.remapComponents->dstZ == Registers::RemapComponents::Swizzle::ConstA) &&
                     (registers.remapComponents->dstW == Registers::RemapComponents::Swizzle::ConstA) &&
                     (registers.remapComponents->ComponentSize() == 4)) {
-                    for (size_t currMapping{dstMappings.size()}; currMapping; --currMapping)
-                        interconnect.Clear(dstMappings[currMapping], *registers.remapConstA);
+                    for (auto mapping : dstMappings)
+                        interconnect.Clear(mapping, *registers.remapConstA);
                 } else {
                     Logger::Warn("Remapped DMA copies are unimplemented!");
                 }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
@@ -23,16 +23,21 @@ namespace skyline::soc::gm20b::engine {
         host1x::SyncpointSet &syncpoints;
         ChannelContext &channelCtx;
         gpu::interconnect::MaxwellDma interconnect;
+        std::vector<u8> copyCache;
 
         void HandleMethod(u32 method, u32 argument);
+
+        void DmaCopy();
+
+        void HandleCopy(TranslatedAddressRange srcMappings, TranslatedAddressRange dstMappings, size_t srcSize, size_t dstSize, auto copyCallback);
+
+        void CopyBlockLinearToPitch();
+
+        void CopyPitchToBlockLinear();
 
         void LaunchDma();
 
         void ReleaseSemaphore();
-
-        void CopyPitchToBlockLinear();
-
-        void CopyBlockLinearToPitch();
 
       public:
         /**

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
@@ -29,7 +29,9 @@ namespace skyline::soc::gm20b::engine {
 
         void DmaCopy();
 
-        void HandleCopy(TranslatedAddressRange srcMappings, TranslatedAddressRange dstMappings, size_t srcSize, size_t dstSize, auto copyCallback);
+        void HandleSplitCopy(TranslatedAddressRange srcMappings, TranslatedAddressRange dstMappings, size_t srcSize, size_t dstSize, auto copyCallback);
+
+        void CopyPitchToPitch();
 
         void CopyBlockLinearToPitch();
 

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_dma.h
@@ -182,8 +182,6 @@ namespace skyline::soc::gm20b::engine {
                     NoWrite = 6
                 };
 
-                Address address;
-
                 Swizzle dstX : 3;
                 u8 _pad0_ : 1;
                 Swizzle dstY : 3;
@@ -212,7 +210,7 @@ namespace skyline::soc::gm20b::engine {
                     return numDstComponentsMinusOne + 1;
                 }
             };
-            static_assert(sizeof(RemapComponents) == 0xC);
+            static_assert(sizeof(RemapComponents) == 0x4);
 
             Register<0x1C2, RemapComponents> remapComponents;
 


### PR DESCRIPTION
In more detail the following was implemented: Support for pitch copies in the DMA engine (including pitch to pitch), Subrect copies, 3D copy support. and small optimizations to the base copy function. 
These changes were largely untested due to me lacking games that use these features, but I am confident that this code has no issues, however they should be tested either way before being merged.

Edit: The pull request now also includes support for all I2M copy functionality

Closes #1108 