### PR TITLE
Fix out-of-bound access to textures during deswizzling

### DIFF
--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.cpp
@@ -85,7 +85,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
 
     /* Depth Render Target */
     void DepthRenderTargetState::EngineRegisters::DirtyBind(DirtyManager &manager, dirty::Handle handle) const {
-        manager.Bind(handle, ztSize, ztOffset, ztFormat, ztBlockSize, ztArrayPitch, ztSelect, ztLayer, surfaceClip);
+        manager.Bind(handle, ztSize, ztOffset, ztFormat, ztBlockSize, ztArrayPitchLsr2, ztSelect, ztLayer, surfaceClip);
     }
 
     DepthRenderTargetState::DepthRenderTargetState(dirty::Handle dirtyHandle, DirtyManager &manager, const EngineRegisters &engine) : engine{manager, dirtyHandle, engine} {}
@@ -119,7 +119,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
             .blockDepth = engine->ztBlockSize.BlockDepth(),
         };
 
-        guest.layerStride = (guest.baseArrayLayer > 1 || guest.layerCount > 1) ? engine->ztArrayPitch : 0;
+        guest.layerStride = (guest.baseArrayLayer > 1 || guest.layerCount > 1) ? engine->ZtArrayPitch() : 0;
 
         auto mappings{ctx.channelCtx.asCtx->gmmu.TranslateRange(engine->ztOffset, guest.GetSize())};
         guest.mappings.assign(mappings.begin(), mappings.end());

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.h
@@ -39,12 +39,16 @@ namespace skyline::gpu::interconnect::maxwell3d {
             const soc::gm20b::engine::Address &ztOffset;
             const engine::ZtFormat &ztFormat;
             const engine::ZtBlockSize &ztBlockSize;
-            const u32 &ztArrayPitch;
+            const u32 &ztArrayPitchLsr2;
             const engine::ZtSelect &ztSelect;
             const engine::ZtLayer &ztLayer;
             const engine::SurfaceClip &surfaceClip;
 
             void DirtyBind(DirtyManager &manager, dirty::Handle handle) const;
+
+            u32 ZtArrayPitch() const {
+                return ztArrayPitchLsr2 << 2;
+            }
         };
 
       private:

--- a/app/src/main/cpp/skyline/gpu/texture/layout.cpp
+++ b/app/src/main/cpp/skyline/gpu/texture/layout.cpp
@@ -42,10 +42,10 @@ namespace skyline::gpu::texture {
             // Iterate over every level, adding the size of the current level to the total size
             totalSize += (GobWidth * gobsWidth) * (GobHeight * util::AlignUp(gobsHeight, gobBlockHeight)) * util::AlignUp(gobsDepth, gobBlockDepth);
 
-            // Successively divide every dimension by 2 until the final level is reached
-            gobsWidth = std::max(gobsWidth / 2, 1UL);
-            gobsHeight = std::max(gobsHeight / 2, 1UL);
-            gobsDepth = std::max(gobsDepth / 2, 1UL);
+            // Successively divide every dimension by 2 until the final level is reached, the division is rounded up to contain the padding GOBs
+            gobsWidth = std::max(util::DivideCeil(gobsWidth, 2UL), 1UL);
+            gobsHeight = std::max(util::DivideCeil(gobsHeight, 2UL), 1UL);
+            gobsDepth = std::max(gobsDepth / 2, 1UL); // The GOB depth is the same as the depth dimension and needs to be rounded down during the division
 
             gobBlockHeight = CalculateBlockGobs(gobBlockHeight, gobsHeight);
             gobBlockDepth = CalculateBlockGobs(gobBlockDepth, gobsDepth);
@@ -74,8 +74,8 @@ namespace skyline::gpu::texture {
                 gobBlockHeight, gobBlockDepth
             );
 
-            gobsWidth = std::max(gobsWidth / 2, 1UL);
-            gobsHeight = std::max(gobsHeight / 2, 1UL);
+            gobsWidth = std::max(util::DivideCeil(gobsWidth, 2UL), 1UL);
+            gobsHeight = std::max(util::DivideCeil(gobsHeight, 2UL), 1UL);
 
             dimensions.width = std::max(dimensions.width / 2, 1U);
             dimensions.height = std::max(dimensions.height / 2, 1U);


### PR DESCRIPTION
A large amount of titles suffered from having corrupted textures (such as on Nier Automata) or arbitrary crashes (such as on SMO) due to OOB access to textures during deswizzling due to various reasons, this PR aims to fix those broken textures and significantly improve stability across the board.

**Note:** This does not fix all broken textures as they may be broken due to the current `TextureManager` implementation being incomplete.

**No more pink textures on Nier: Automata**
![Nier Automata](https://user-images.githubusercontent.com/17637537/215523142-cca13b62-5d3b-4187-99ec-5f9e1da40d78.png)
