### PR TITLE
Stub indirect layer VI service functions

### DIFF
--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
@@ -89,6 +89,18 @@ namespace skyline::service::visrv {
         Result SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Draws an indirect layer into the supplied buffer
+         * @url https://switchbrew.org/wiki/Display_services#GetIndirectLayerImageMap
+         */
+        Result GetIndirectLayerImageMap(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Gets the amount of memory required for an indirect layer
+         * @url https://switchbrew.org/wiki/Display_services#GetIndirectLayerImageRequiredMemoryInfo
+         */
+        Result GetIndirectLayerImageRequiredMemoryInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Converts an arbitrary scaling mode to a VI scaling mode
          */
         Result ConvertScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -113,6 +125,8 @@ namespace skyline::service::visrv {
           SFUNC_BASE(0x7EF, IApplicationDisplayService, IDisplayService, DestroyStrayLayer),
           SFUNC(0x835, IApplicationDisplayService, SetLayerScalingMode),
           SFUNC(0x836, IApplicationDisplayService, ConvertScalingMode),
+          SFUNC(0x992, IApplicationDisplayService, GetIndirectLayerImageMap),
+          SFUNC(0x99C, IApplicationDisplayService, GetIndirectLayerImageRequiredMemoryInfo),
           SFUNC(0x1452, IApplicationDisplayService, GetDisplayVsyncEvent)
       )
     };

--- a/app/src/main/cpp/skyline/services/visrv/results.h
+++ b/app/src/main/cpp/skyline/services/visrv/results.h
@@ -7,5 +7,6 @@
 
 namespace skyline::service::visrv::result {
     constexpr Result InvalidArgument(114, 1);
+    constexpr Result InvalidDimensions(114, 4);
     constexpr Result IllegalOperation(114, 6);
 }


### PR DESCRIPTION
Indirect layers are used by the game to render layer on its own, the game allocates a buffer with the size from `GetIndirectLayerImageRequiredMemoryInfo` and uses `GetIndirectLayerImageMap` to draw the applet contents into the buffer. 

As we don't LLE applet implementations nor do our HLE implementations draw equivalent applets, we cannot submit this to the guest. As a result, these functions are stubbed with the framebuffer being cleared to red. 

Stubbing these functions allows titles such as Dark Souls to proceed further.