### PR TITLE
Ignore new layer creations instead of replacing previous ones

### DIFF
--- a/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
+++ b/app/src/main/cpp/skyline/services/hosbinder/IHOSBinderDriver.cpp
@@ -117,13 +117,13 @@ namespace skyline::service::hosbinder {
     u64 IHOSBinderDriver::CreateLayer(DisplayId pDisplayId) {
         if (pDisplayId != displayId)
             throw exception("Creating layer on unopened display: '{}'", ToString(pDisplayId));
-        else if (layer) // Fallback to replacing previous layer
-            Logger::Warn("Creation of multiple layers is not supported");
-
-
-        layerStrongReferenceCount = InitialStrongReferenceCount;
-        layerWeakReferenceCount = 0;
-        layer = std::make_shared<GraphicBufferProducer>(state, nvMap);
+        else if (!layer) {
+            layerStrongReferenceCount = InitialStrongReferenceCount;
+            layerWeakReferenceCount = 0;
+            layer = std::make_shared<GraphicBufferProducer>(state, nvMap);
+        }
+        else // Ignore new layer creations if one already exists
+            Logger::Warn("Creation of multiple layers is not supported. Ignoring creation of new layers.");
 
         return DefaultLayerId;
     }


### PR DESCRIPTION
This allows Portal 1 and 2 to boot and go in game. Instead of replacing the previous layer when a new one is created, we just ignore the new ones, until proper multiple layers support is implemented.
I don't have any other game with multiple layer creations so I can't test if there are regression in other games with this change. If so, please feel free to close this pull request.

Video of Portal 2 in game
https://user-images.githubusercontent.com/10391562/216836835-7dc5a647-cbed-4d2f-a346-ae0526d7f7ae.mp4


Images of Portal 1 in game (credits to Cudzlox on Discord)
![portal_1_01](https://user-images.githubusercontent.com/10391562/216836824-b17a8bff-85d5-46f1-967e-9e62d4b802e2.png)
![portal_1_02](https://user-images.githubusercontent.com/10391562/216836827-ad89d3f6-6025-4649-a793-33b43cc86a14.png)
![portal_1_03](https://user-images.githubusercontent.com/10391562/216836831-7493b1eb-5711-44fe-9c16-4410f73eae52.png)


