### PR TITLE
`onBackPressed` -> `onBackPressedDispatcher`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
     <application
         android:name=".SkylineApplication"
+        android:enableOnBackInvokedCallback="true"
         android:allowBackup="true"
         android:extractNativeLibs="true"
         android:fullBackupContent="@xml/backup_descriptor"

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -15,6 +15,7 @@ import android.os.*
 import android.util.Log
 import android.util.Rational
 import android.view.*
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
 import androidx.core.view.isGone
@@ -202,10 +203,6 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         emulationThread!!.start()
     }
 
-    override fun onBackPressed() {
-        returnFromEmulation()
-    }
-
     @SuppressLint("SetTextI18n", "ClickableViewAccessibility")
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
@@ -285,6 +282,16 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             GpuDriverHelper.forceMaxGpuClocks(false)
 
         changeAudioStatus(false)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                returnFromEmulation()
+            }
+        })
     }
 
     override fun onResume() {

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -308,6 +309,23 @@ class MainActivity : AppCompatActivity() {
         if (items.isEmpty()) adapter.setItems(listOf(HeaderViewItem(getString(R.string.no_rom))))
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                binding.searchBar.apply {
+                    if (hasFocus() && text.isNotEmpty()) {
+                        text = ""
+                        clearFocus()
+                    } else {
+                        finish()
+                    }
+                }
+            }
+        })
+    }
+
     override fun onResume() {
         super.onResume()
 
@@ -328,17 +346,6 @@ class MainActivity : AppCompatActivity() {
         if (layoutTypeChanged) {
             setAppListDecoration()
             adapter.notifyItemRangeChanged(0, adapter.currentItems.size)
-        }
-    }
-
-    override fun onBackPressed() {
-        binding.searchBar.apply {
-            if (hasFocus() && text.isNotEmpty()) {
-                text = ""
-                clearFocus()
-            } else {
-                super.onBackPressed()
-            }
         }
     }
 }

--- a/app/src/main/java/emu/skyline/SettingsActivity.kt
+++ b/app/src/main/java/emu/skyline/SettingsActivity.kt
@@ -145,7 +145,7 @@ class SettingsActivity : AppCompatActivity() {
      */
     override fun onKeyUp(keyCode : Int, event : KeyEvent?) : Boolean {
         if (keyCode == KeyEvent.KEYCODE_BUTTON_B) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
 

--- a/app/src/main/java/emu/skyline/input/ControllerActivity.kt
+++ b/app/src/main/java/emu/skyline/input/ControllerActivity.kt
@@ -342,7 +342,7 @@ class ControllerActivity : AppCompatActivity() {
      */
     override fun onKeyUp(keyCode : Int, event : KeyEvent?) : Boolean {
         if (keyCode == KeyEvent.KEYCODE_BUTTON_B) {
-            onBackPressed()
+            onBackPressedDispatcher.onBackPressed()
             return true
         }
 


### PR DESCRIPTION
Not a strictly necessary change at the the moment, but Android is removing support for the `onBackPressed` callback to implement perhaps one of their sillier design changes where you can preview where you are going back to before inevitably going back there regardless. 

The way it's explained and the way it functions are the difference between seeing an artist rendering of a new console and then seeing the release product. Ironically, this is the change required for API 13+ and then the actual change to make the new transitions work is a separate condition for API 33 + (that is not currently included in this PR). It almost makes this seem pointless, but I guess it keeps it from colliding with the new handling.
