### PR TITLE
Add picture in picture for emulation activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,7 +66,8 @@
 
         <activity
             android:name=".EmulationActivity"
-            android:configChanges="orientation|screenSize|uiMode"
+            android:supportsPictureInPicture="true"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
             android:process="${emulationProcess}"

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -90,9 +90,10 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
      */
     private var desiredRefreshRate = 60f
 
-    private val muteIntentAction = "$packageName.EMULATOR_MUTE"
     private lateinit var pictureInPictureParamsBuilder : PictureInPictureParams.Builder
-    private lateinit var muteReceiver : BroadcastReceiver
+    private val pauseIntentAction = "$packageName.EMULATOR_PAUSE"
+    private val muteIntentAction = "$packageName.EMULATOR_MUTE"
+    private lateinit var pictureInPictureReceiver : BroadcastReceiver
 
     @Inject
     lateinit var appSettings : AppSettings
@@ -103,6 +104,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     lateinit var inputManager : InputManager
 
     lateinit var inputHandler : InputHandler
+
+    private var gameSurface : Surface? = null
 
     /**
      * This is the entry point into the emulation code for libskyline
@@ -273,12 +276,22 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
         pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
 
+        val pictureInPictureActions : MutableList<RemoteAction> = mutableListOf()
+        val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        val pauseIcon = Icon.createWithResource(this, R.drawable.ic_pause)
+        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(pauseIntentAction), pendingFlags)
+        val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause_emulator), pausePendingIntent)
+        pictureInPictureActions.add(pauseRemoteAction)
+
         if (!emulationSettings.isAudioOutputDisabled) {
             val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
-            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), pendingFlags)
             val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
-            pictureInPictureParamsBuilder.setActions(mutableListOf(muteRemoteAction))
+            pictureInPictureActions.add(muteRemoteAction)
         }
+
+        pictureInPictureParamsBuilder.setActions(pictureInPictureActions)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             pictureInPictureParamsBuilder.setAutoEnterEnabled(true)
 
@@ -370,32 +383,37 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         if (isInPictureInPictureMode) {
-            if (!emulationSettings.isAudioOutputDisabled) {
-                muteReceiver = object : BroadcastReceiver() {
-                    override fun onReceive(context : Context?, intent : Intent) {
-                        if (intent.action == muteIntentAction)
-                            changeAudioStatus(false)
-                    }
+            pictureInPictureReceiver = object : BroadcastReceiver() {
+                override fun onReceive(context : Context?, intent : Intent) {
+                    if (intent.action == pauseIntentAction)
+                        setSurface(null)
+                    else if (intent.action == muteIntentAction)
+                        changeAudioStatus(false)
                 }
+            }
 
-                IntentFilter(muteIntentAction).also {
-                    registerReceiver(muteReceiver, it)
-                }
+            IntentFilter().apply {
+                addAction(pauseIntentAction)
+                if (!emulationSettings.isAudioOutputDisabled)
+                    addAction(muteIntentAction)
+            }.also {
+                registerReceiver(pictureInPictureReceiver, it)
             }
 
             binding.onScreenControllerView.isGone = true
             binding.onScreenControllerToggle.isGone = true
         } else {
-            if (!emulationSettings.isAudioOutputDisabled) {
-                changeAudioStatus(true)
-
-                try {
-                    if (this::muteReceiver.isInitialized)
-                        unregisterReceiver(muteReceiver)
-                } catch (ignored : Exception) {
-                    // Perfectly acceptable and should be ignored
-                }
+            try {
+                if (this::pictureInPictureReceiver.isInitialized)
+                    unregisterReceiver(pictureInPictureReceiver)
+            } catch (ignored : Exception) {
+                // Perfectly acceptable and should be ignored
             }
+
+            setSurface(gameSurface)
+
+            if (!emulationSettings.isAudioOutputDisabled)
+                changeAudioStatus(true)
             
             binding.onScreenControllerView.apply {
                 controllerType = inputHandler.getFirstControllerType()
@@ -446,8 +464,10 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             holder.surface.setFrameRate(desiredRefreshRate, if (emulationSettings.maxRefreshRate) Surface.FRAME_RATE_COMPATIBILITY_DEFAULT else Surface.FRAME_RATE_COMPATIBILITY_FIXED_SOURCE)
 
         while (emulationThread!!.isAlive)
-            if (setSurface(holder.surface))
+            if (setSurface(holder.surface)) {
+                gameSurface = holder.surface
                 return
+            }
     }
 
     /**
@@ -463,8 +483,10 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     override fun surfaceDestroyed(holder : SurfaceHolder) {
         Log.d(Tag, "surfaceDestroyed Holder: $holder")
         while (emulationThread!!.isAlive)
-            if (setSurface(null))
+            if (setSurface(null)) {
+                gameSurface = null
                 return
+            }
     }
 
     override fun dispatchKeyEvent(event : KeyEvent) : Boolean {

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -51,6 +51,9 @@ import java.util.concurrent.FutureTask
 import javax.inject.Inject
 import kotlin.math.abs
 
+private const val ActionPause = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_PAUSE"
+private const val ActionMute = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_MUTE"
+
 @AndroidEntryPoint
 class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTouchListener, DisplayManager.DisplayListener {
     companion object {
@@ -94,9 +97,6 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     private var isEmulatorPaused = false
 
     private lateinit var pictureInPictureParamsBuilder : PictureInPictureParams.Builder
-    private val intentActionPause = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_PAUSE"
-    private val intentActionMute = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_MUTE"
-    private lateinit var pictureInPictureReceiver : BroadcastReceiver
 
     @Inject
     lateinit var appSettings : AppSettings
@@ -400,16 +400,14 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
 
         val pauseIcon = Icon.createWithResource(this, R.drawable.ic_pause)
-        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(intentActionPause), pendingFlags)
-        val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause_emulator), pausePendingIntent)
+        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(ActionPause), pendingFlags)
+        val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause), pausePendingIntent)
         pictureInPictureActions.add(pauseRemoteAction)
 
-        if (!emulationSettings.isAudioOutputDisabled) {
-            val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
-            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(intentActionMute), pendingFlags)
-            val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
-            pictureInPictureActions.add(muteRemoteAction)
-        }
+        val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
+        val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(ActionMute), pendingFlags)
+        val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.mute), mutePendingIntent)
+        pictureInPictureActions.add(muteRemoteAction)
 
         pictureInPictureParamsBuilder.setActions(pictureInPictureActions)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
@@ -420,22 +418,22 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         return pictureInPictureParamsBuilder
     }
 
+    private var pictureInPictureReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context : Context?, intent : Intent) {
+            if (intent.action == ActionPause)
+                pauseEmulator()
+            else if (intent.action == ActionMute)
+                changeAudioStatus(false)
+        }
+    }
+
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         if (isInPictureInPictureMode) {
-            pictureInPictureReceiver = object : BroadcastReceiver() {
-                override fun onReceive(context : Context?, intent : Intent) {
-                    if (intent.action == intentActionPause)
-                        pauseEmulator()
-                    else if (intent.action == intentActionMute)
-                        changeAudioStatus(false)
-                }
-            }
 
             IntentFilter().apply {
-                addAction(intentActionPause)
-                if (!emulationSettings.isAudioOutputDisabled)
-                    addAction(intentActionMute)
+                addAction(ActionPause)
+                addAction(ActionMute)
             }.also {
                 registerReceiver(pictureInPictureReceiver, it)
             }
@@ -445,11 +443,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenPauseToggle.isGone = true
         } else {
             try {
-                if (this::pictureInPictureReceiver.isInitialized)
-                    unregisterReceiver(pictureInPictureReceiver)
-            } catch (ignored : Exception) {
-                // Perfectly acceptable and should be ignored
-            }
+                unregisterReceiver(pictureInPictureReceiver)
+            } catch (ignored : Exception) { }
 
             resumeEmulator()
             

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -277,27 +277,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenControllerToggle.setOnApplyWindowInsetsListener(insetsOrMarginHandler)
         }
 
-        pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
-
-        val pictureInPictureActions : MutableList<RemoteAction> = mutableListOf()
-        val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-
-        val pauseIcon = Icon.createWithResource(this, R.drawable.ic_pause)
-        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(intentActionPause), pendingFlags)
-        val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause_emulator), pausePendingIntent)
-        pictureInPictureActions.add(pauseRemoteAction)
-
-        if (!emulationSettings.isAudioOutputDisabled) {
-            val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
-            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(intentActionMute), pendingFlags)
-            val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
-            pictureInPictureActions.add(muteRemoteAction)
-        }
-
-        pictureInPictureParamsBuilder.setActions(pictureInPictureActions)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-            pictureInPictureParamsBuilder.setAutoEnterEnabled(true)
-
+        pictureInPictureParamsBuilder = getPictureInPictureBuilder()
         setPictureInPictureParams(pictureInPictureParamsBuilder.build())
 
         binding.gameView.holder.addCallback(this)
@@ -411,6 +391,33 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                     or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                     or View.SYSTEM_UI_FLAG_FULLSCREEN)
         }
+    }
+
+    private fun getPictureInPictureBuilder() : PictureInPictureParams.Builder {
+        val pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
+
+        val pictureInPictureActions : MutableList<RemoteAction> = mutableListOf()
+        val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        val pauseIcon = Icon.createWithResource(this, R.drawable.ic_pause)
+        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(intentActionPause), pendingFlags)
+        val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause_emulator), pausePendingIntent)
+        pictureInPictureActions.add(pauseRemoteAction)
+
+        if (!emulationSettings.isAudioOutputDisabled) {
+            val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
+            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(intentActionMute), pendingFlags)
+            val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
+            pictureInPictureActions.add(muteRemoteAction)
+        }
+
+        pictureInPictureParamsBuilder.setActions(pictureInPictureActions)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            pictureInPictureParamsBuilder.setAutoEnterEnabled(true)
+
+        setPictureInPictureParams(pictureInPictureParamsBuilder.build())
+
+        return pictureInPictureParamsBuilder
     }
 
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -271,11 +271,14 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenControllerToggle.setOnApplyWindowInsetsListener(insetsOrMarginHandler)
         }
 
-        val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
-        val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-        val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
+        pictureInPictureParamsBuilder = PictureInPictureParams.Builder()
 
-        pictureInPictureParamsBuilder = PictureInPictureParams.Builder().setActions(mutableListOf(muteRemoteAction))
+        if (!emulationSettings.isAudioOutputDisabled) {
+            val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
+            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
+            pictureInPictureParamsBuilder.setActions(mutableListOf(muteRemoteAction))
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             pictureInPictureParamsBuilder.setAutoEnterEnabled(true)
 
@@ -367,33 +370,39 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         if (isInPictureInPictureMode) {
-            muteReceiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context?, intent: Intent) {
-                    if (intent.action == muteIntentAction)
-                        changeAudioStatus(false)
+            if (!emulationSettings.isAudioOutputDisabled) {
+                muteReceiver = object : BroadcastReceiver() {
+                    override fun onReceive(context : Context?, intent : Intent) {
+                        if (intent.action == muteIntentAction)
+                            changeAudioStatus(false)
+                    }
                 }
-            }
 
-            IntentFilter(muteIntentAction).also {
-                registerReceiver(muteReceiver, it)
+                IntentFilter(muteIntentAction).also {
+                    registerReceiver(muteReceiver, it)
+                }
             }
 
             binding.onScreenControllerView.isGone = true
             binding.onScreenControllerToggle.isGone = true
         } else {
+            if (!emulationSettings.isAudioOutputDisabled) {
+                changeAudioStatus(true)
+
+                try {
+                    if (this::muteReceiver.isInitialized)
+                        unregisterReceiver(muteReceiver)
+                } catch (ignored : Exception) {
+                    // Perfectly acceptable and should be ignored
+                }
+            }
+            
             binding.onScreenControllerView.apply {
                 controllerType = inputHandler.getFirstControllerType()
                 isGone = controllerType == ControllerType.None || !appSettings.onScreenControl
             }
             binding.onScreenControllerToggle.apply {
                 isGone = binding.onScreenControllerView.isGone
-            }
-
-            try {
-                if (this::muteReceiver.isInitialized)
-                    unregisterReceiver(muteReceiver)
-            } catch (ignored: Exception) {
-                // Perfectly acceptable and should be ignored
             }
         }
     }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -90,6 +90,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
      */
     private var desiredRefreshRate = 60f
 
+    private var isEmulatorPaused = false
+
     private lateinit var pictureInPictureParamsBuilder : PictureInPictureParams.Builder
     private val pauseIntentAction = "$packageName.EMULATOR_PAUSE"
     private val muteIntentAction = "$packageName.EMULATOR_MUTE"
@@ -342,18 +344,37 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             setOnClickListener { binding.onScreenControllerView.isInvisible = !binding.onScreenControllerView.isInvisible }
         }
 
+        binding.onScreenPauseToggle.apply {
+            isGone = binding.onScreenControllerView.isGone
+            setOnClickListener {
+                if (isEmulatorPaused) {
+                    resumeEmulator()
+                    binding.onScreenPauseToggle.setImageResource(R.drawable.ic_pause)
+                } else {
+                    pauseEmulator()
+                    binding.onScreenPauseToggle.setImageResource(R.drawable.ic_play)
+                }
+            }
+        }
+
         executeApplication(intent!!)
     }
 
+    @SuppressWarnings("WeakerAccess")
     fun pauseEmulator() {
+        if (isEmulatorPaused) return
         setSurface(null)
         changeAudioStatus(false)
+        isEmulatorPaused = true
     }
 
+    @SuppressWarnings("WeakerAccess")
     fun resumeEmulator() {
+        if (!isEmulatorPaused) return
         gameSurface?.let { setSurface(it) }
         if (!emulationSettings.isAudioOutputDisabled)
             changeAudioStatus(true)
+        isEmulatorPaused = false
     }
 
     override fun onPause() {
@@ -413,6 +434,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
             binding.onScreenControllerView.isGone = true
             binding.onScreenControllerToggle.isGone = true
+            binding.onScreenPauseToggle.isGone = true
         } else {
             try {
                 if (this::pictureInPictureReceiver.isInitialized)
@@ -428,6 +450,9 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                 isGone = controllerType == ControllerType.None || !appSettings.onScreenControl
             }
             binding.onScreenControllerToggle.apply {
+                isGone = binding.onScreenControllerView.isGone
+            }
+            binding.onScreenPauseToggle.apply {
                 isGone = binding.onScreenControllerView.isGone
             }
         }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -410,7 +410,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                 // Perfectly acceptable and should be ignored
             }
 
-            setSurface(gameSurface)
+            gameSurface?.let { setSurface(it) }
 
             if (!emulationSettings.isAudioOutputDisabled)
                 changeAudioStatus(true)

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -31,6 +31,7 @@ import androidx.core.view.updateMargins
 import androidx.fragment.app.FragmentTransaction
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import emu.skyline.BuildConfig
 import emu.skyline.applet.swkbd.SoftwareKeyboardConfig
 import emu.skyline.applet.swkbd.SoftwareKeyboardDialog
 import emu.skyline.data.AppItem
@@ -93,8 +94,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     private var isEmulatorPaused = false
 
     private lateinit var pictureInPictureParamsBuilder : PictureInPictureParams.Builder
-    private val pauseIntentAction = "$packageName.EMULATOR_PAUSE"
-    private val muteIntentAction = "$packageName.EMULATOR_MUTE"
+    private val intentActionPause = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_PAUSE"
+    private val intentActionMute = "${BuildConfig.APPLICATION_ID}.ACTION_EMULATOR_MUTE"
     private lateinit var pictureInPictureReceiver : BroadcastReceiver
 
     @Inject
@@ -282,13 +283,13 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
 
         val pauseIcon = Icon.createWithResource(this, R.drawable.ic_pause)
-        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(pauseIntentAction), pendingFlags)
+        val pausePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_pause, Intent(intentActionPause), pendingFlags)
         val pauseRemoteAction = RemoteAction(pauseIcon, getString(R.string.pause), getString(R.string.pause_emulator), pausePendingIntent)
         pictureInPictureActions.add(pauseRemoteAction)
 
         if (!emulationSettings.isAudioOutputDisabled) {
             val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
-            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), pendingFlags)
+            val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(intentActionMute), pendingFlags)
             val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
             pictureInPictureActions.add(muteRemoteAction)
         }
@@ -417,17 +418,17 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         if (isInPictureInPictureMode) {
             pictureInPictureReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context : Context?, intent : Intent) {
-                    if (intent.action == pauseIntentAction)
+                    if (intent.action == intentActionPause)
                         pauseEmulator()
-                    else if (intent.action == muteIntentAction)
+                    else if (intent.action == intentActionMute)
                         changeAudioStatus(false)
                 }
             }
 
             IntentFilter().apply {
-                addAction(pauseIntentAction)
+                addAction(intentActionPause)
                 if (!emulationSettings.isAudioOutputDisabled)
-                    addAction(muteIntentAction)
+                    addAction(intentActionMute)
             }.also {
                 registerReceiver(pictureInPictureReceiver, it)
             }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -6,12 +6,17 @@
 package emu.skyline
 
 import android.annotation.SuppressLint
+import android.app.PendingIntent
 import android.app.PictureInPictureParams
+import android.app.RemoteAction
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.AssetManager
 import android.content.res.Configuration
 import android.graphics.PointF
+import android.graphics.drawable.Icon
 import android.hardware.display.DisplayManager
 import android.os.*
 import android.util.Log
@@ -78,12 +83,16 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     /**
      * If the activity should return to [MainActivity] or just call [finishAffinity]
      */
-    var returnToMain : Boolean = false
+    private var returnToMain : Boolean = false
 
     /**
      * The desired refresh rate to present at in Hz
      */
-    var desiredRefreshRate = 60f
+    private var desiredRefreshRate = 60f
+
+    private val muteIntentAction = "$packageName.EMULATOR_MUTE"
+    private lateinit var pictureInPictureParamsBuilder : PictureInPictureParams.Builder
+    private lateinit var muteReceiver : BroadcastReceiver
 
     @Inject
     lateinit var appSettings : AppSettings
@@ -262,8 +271,15 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenControllerToggle.setOnApplyWindowInsetsListener(insetsOrMarginHandler)
         }
 
+        val muteIcon = Icon.createWithResource(this, R.drawable.ic_volume_mute)
+        val mutePendingIntent = PendingIntent.getBroadcast(this, R.drawable.ic_volume_mute, Intent(muteIntentAction), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val muteRemoteAction = RemoteAction(muteIcon, getString(R.string.mute), getString(R.string.disable_audio_output), mutePendingIntent)
+
+        pictureInPictureParamsBuilder = PictureInPictureParams.Builder().setActions(mutableListOf(muteRemoteAction))
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-            setPictureInPictureParams(PictureInPictureParams.Builder().setAutoEnterEnabled(true).build())
+            pictureInPictureParamsBuilder.setAutoEnterEnabled(true)
+
+        setPictureInPictureParams(pictureInPictureParamsBuilder.build())
 
         binding.gameView.holder.addCallback(this)
 
@@ -351,6 +367,17 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         if (isInPictureInPictureMode) {
+            muteReceiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent) {
+                    if (intent.action == muteIntentAction)
+                        changeAudioStatus(false)
+                }
+            }
+
+            IntentFilter(muteIntentAction).also {
+                registerReceiver(muteReceiver, it)
+            }
+
             binding.onScreenControllerView.isGone = true
             binding.onScreenControllerToggle.isGone = true
         } else {
@@ -361,9 +388,15 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenControllerToggle.apply {
                 isGone = binding.onScreenControllerView.isGone
             }
+
+            try {
+                if (this::muteReceiver.isInitialized)
+                    unregisterReceiver(muteReceiver)
+            } catch (ignored: Exception) {
+                // Perfectly acceptable and should be ignored
+            }
         }
     }
-
 
     /**
      * Stop the currently executing ROM and replace it with the one specified in the new intent
@@ -377,8 +410,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     }
 
     override fun onUserLeaveHint() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
-            enterPictureInPictureMode(PictureInPictureParams.Builder().build())
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && !isInPictureInPictureMode)
+            enterPictureInPictureMode(pictureInPictureParamsBuilder.build())
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -345,13 +345,24 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         executeApplication(intent!!)
     }
 
+    fun pauseEmulator() {
+        setSurface(null)
+        changeAudioStatus(false)
+    }
+
+    fun resumeEmulator() {
+        gameSurface?.let { setSurface(it) }
+        if (!emulationSettings.isAudioOutputDisabled)
+            changeAudioStatus(true)
+    }
+
     override fun onPause() {
         super.onPause()
 
         if (emulationSettings.forceMaxGpuClocks)
             GpuDriverHelper.forceMaxGpuClocks(false)
 
-        changeAudioStatus(false)
+        pauseEmulator()
     }
 
     override fun onStart() {
@@ -367,7 +378,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     override fun onResume() {
         super.onResume()
 
-        changeAudioStatus(true)
+        resumeEmulator()
 
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
             @Suppress("DEPRECATION")
@@ -386,7 +397,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             pictureInPictureReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context : Context?, intent : Intent) {
                     if (intent.action == pauseIntentAction)
-                        setSurface(null)
+                        pauseEmulator()
                     else if (intent.action == muteIntentAction)
                         changeAudioStatus(false)
                 }
@@ -410,10 +421,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                 // Perfectly acceptable and should be ignored
             }
 
-            gameSurface?.let { setSurface(it) }
-
-            if (!emulationSettings.isAudioOutputDisabled)
-                changeAudioStatus(true)
+            resumeEmulator()
             
             binding.onScreenControllerView.apply {
                 controllerType = inputHandler.getFirstControllerType()

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -6,9 +6,11 @@
 package emu.skyline
 
 import android.annotation.SuppressLint
+import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
 import android.content.res.AssetManager
+import android.content.res.Configuration
 import android.graphics.PointF
 import android.hardware.display.DisplayManager
 import android.os.*
@@ -167,6 +169,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     /**
      * Return from emulation to either [MainActivity] or the activity on the back stack
      */
+    @SuppressWarnings("WeakerAccess")
     fun returnFromEmulation() {
         if (shouldFinish) {
             runOnUiThread {
@@ -259,6 +262,9 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             binding.onScreenControllerToggle.setOnApplyWindowInsetsListener(insetsOrMarginHandler)
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            setPictureInPictureParams(PictureInPictureParams.Builder().setAutoEnterEnabled(true).build())
+
         binding.gameView.holder.addCallback(this)
 
         binding.gameView.setAspectRatio(
@@ -342,6 +348,23 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         }
     }
 
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        if (isInPictureInPictureMode) {
+            binding.onScreenControllerView.isGone = true
+            binding.onScreenControllerToggle.isGone = true
+        } else {
+            binding.onScreenControllerView.apply {
+                controllerType = inputHandler.getFirstControllerType()
+                isGone = controllerType == ControllerType.None || !appSettings.onScreenControl
+            }
+            binding.onScreenControllerToggle.apply {
+                isGone = binding.onScreenControllerView.isGone
+            }
+        }
+    }
+
+
     /**
      * Stop the currently executing ROM and replace it with the one specified in the new intent
      */
@@ -351,6 +374,11 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             setIntent(intent)
             executeApplication(intent)
         }
+    }
+
+    override fun onUserLeaveHint() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
+            enterPictureInPictureMode(PictureInPictureParams.Builder().build())
     }
 
     override fun onDestroy() {
@@ -518,7 +546,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         return ((major shl 22) or (minor shl 12) or (patch)).toInt()
     }
 
-    val insetsOrMarginHandler = View.OnApplyWindowInsetsListener { view, insets ->
+    private val insetsOrMarginHandler = View.OnApplyWindowInsetsListener { view, insets ->
         insets.displayCutout?.let {
             val defaultHorizontalMargin = view.resources.getDimensionPixelSize(R.dimen.onScreenItemHorizontalMargin)
             val left = if (it.safeInsetLeft == 0) defaultHorizontalMargin else it.safeInsetLeft

--- a/app/src/main/res/drawable/ic_pause.xml
+++ b/app/src/main/res/drawable/ic_pause.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_volume_mute.xml
+++ b/app/src/main/res/drawable/ic_volume_mute.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7,9v6h4l5,5V4l-5,5H7z"/>
+</vector>

--- a/app/src/main/res/layout/emu_activity.xml
+++ b/app/src/main/res/layout/emu_activity.xml
@@ -31,6 +31,18 @@
         android:textColor="@color/colorPerfStatsPrimary" />
 
     <ImageButton
+        android:id="@+id/on_screen_pause_toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|right"
+        android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
+        android:background="?android:attr/actionBarItemBackground"
+        android:padding="8dp"
+        android:src="@drawable/ic_pause"
+        app:tint="#40FFFFFF"
+        tools:ignore="ContentDescription" />
+
+    <ImageButton
         android:id="@+id/on_screen_controller_toggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,6 @@
     <string name="incomplete_prod_keys">Incomplete production keys</string>
     <!-- Picture-In-Picture -->
     <string name="pause">Pause</string>
-    <string name="pause_emulator">Pause emulator process</string>
     <string name="mute">Mute</string>
     <!-- Settings - Content -->
     <string name="content">Content</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="respect_display_cutout_disabled">Allow UI elements to be drawn in the cutout area</string>
     <!-- Settings - Audio -->
     <string name="audio">Audio</string>
+    <string name="mute">Mute</string>
     <string name="disable_audio_output">Disable Audio Output</string>
     <string name="disable_audio_output_enabled">Audio output is disabled</string>
     <string name="disable_audio_output_disabled">Audio output is enabled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,10 @@
     <string name="invalid_file">Invalid file</string>
     <string name="missing_title_key">Missing title key</string>
     <string name="incomplete_prod_keys">Incomplete production keys</string>
+    <!-- Picture-In-Picture -->
+    <string name="pause">Pause</string>
+    <string name="pause_emulator">Pause emulator process</string>
+    <string name="mute">Mute</string>
     <!-- Settings - Content -->
     <string name="content">Content</string>
     <string name="open_data_directory">View Internal Directory</string>
@@ -85,7 +89,6 @@
     <string name="respect_display_cutout_disabled">Allow UI elements to be drawn in the cutout area</string>
     <!-- Settings - Audio -->
     <string name="audio">Audio</string>
-    <string name="mute">Mute</string>
     <string name="disable_audio_output">Disable Audio Output</string>
     <string name="disable_audio_output_enabled">Audio output is disabled</string>
     <string name="disable_audio_output_disabled">Audio output is enabled</string>


### PR DESCRIPTION
When you launch a game and hit the home or recents button, the emulation activity does picture-in-picture similar to the YouTube app. This one is good for when you have to send a text or something else you need to launch from the home screen and want to make sure the game isn't killed off in the background. The onscreen controls are currently hidden in PiP mode and restored when returning.

It can be completely disabled by either going into PiP and pressing the gear, which opens the PiP settings or (on Samsung and potentially on most Android devices) by opening the Settings app and going to Apps -> Overflow menu (3 dots, top right) -> Special access -> Picture-in-picture.

Not sure if this is something desirable, but I had fun with it.

<details>
  <summary>Screenshot</summary>
  
![signal-2023-02-14-112817_002](https://user-images.githubusercontent.com/1173913/218798088-aed4cb26-87e3-4644-b237-3735b174cfa1.png)
</details>
