### PR TITLE
Align ChipGroup to center when space exists

### DIFF
--- a/app/src/main/res/layout/header_rom_filter.xml
+++ b/app/src/main/res/layout/header_rom_filter.xml
@@ -1,29 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:scrollbars="none">
-
-    <com.google.android.material.chip.ChipGroup
-        android:id="@+id/chip_group"
+    android:layout_height="wrap_content">
+    <HorizontalScrollView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="4dp"
-        app:checkedChip="@id/all_chip"
-        app:chipSpacingHorizontal="16dp"
-        app:selectionRequired="true"
-        app:singleLine="true"
-        app:singleSelection="true">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:scrollbars="none"
+        tools:ignore="MissingConstraints">
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/all_chip"
-            style="?attr/chipChoiceStyle"
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chip_group"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/all" />
-    </com.google.android.material.chip.ChipGroup>
-</HorizontalScrollView>
+            android:paddingStart="16dp"
+            android:paddingTop="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="4dp"
+            app:checkedChip="@id/all_chip"
+            app:chipSpacingHorizontal="16dp"
+            app:selectionRequired="true"
+            app:singleLine="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/all_chip"
+                style="?attr/chipChoiceStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/all" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This is aimed at tablets and users with a modified density. With "Minimum width" being part of Developer options and the adb `wm` command being available without root, this targets a much larger audience. Wrapping the ChipGroup in a ConstraintLayout allows centering it non-destructively for those with a previously large right margin. For anyone that couldn't fit them all before, everything should look the same as always.

![signal-2023-02-27-181531_002](https://user-images.githubusercontent.com/1173913/221710903-5f594bcb-3ac8-48a4-a444-880449ce2b05.png)
