### PR TITLE
Implement usage tracker and basic indirect draw HLE

### DIFF
--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -95,6 +95,7 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
     // Initialize tracing
     perfetto::TracingInitArgs args;
     args.backends |= perfetto::kSystemBackend;
+    args.shmem_size_hint_kb = 0x200000;
     perfetto::Tracing::Initialize(args);
     perfetto::TrackEvent::Register();
 

--- a/app/src/main/cpp/skyline/common/interval_list.h
+++ b/app/src/main/cpp/skyline/common/interval_list.h
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2022 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include "base.h"
+#include "span.h"
+
+namespace skyline {
+    /**
+     * @brief Stores a list of non-overlapping intervals
+     */
+    template<typename SizeType>
+    class IntervalList {
+      public:
+        using DifferenceType = decltype(std::declval<SizeType>() - std::declval<SizeType>());
+
+        struct Interval {
+            SizeType offset;
+            SizeType end;
+
+            Interval() = default;
+
+            Interval(SizeType offset, SizeType end) : offset{offset}, end{end} {}
+
+            Interval(span<u8> interval) : offset{interval.data()}, end{interval.data() + interval.size()} {}
+        };
+
+      private:
+        std::vector<Interval> intervals; //!< A list of intervals sorted by their end offset
+
+      public:
+        struct QueryResult {
+            bool enclosed; //!< If the given offset was enclosed by an interval
+            DifferenceType size; //!< Size of the interval starting from the query offset, or distance to the next interval if `enclosed` is false (if there is no next interval size is 0)
+        };
+
+        /**
+         * @brief Clears all inserted intervals from the map
+         */
+        void Clear() {
+            intervals.clear();
+        }
+
+        /**
+         * @brief Forces future accesses to the given interval to use the shadow copy
+        */
+        void Insert(Interval entry) {
+            auto firstIt{std::lower_bound(intervals.begin(), intervals.end(), entry, [](const auto &lhs, const auto &rhs) {
+                return lhs.end < rhs.offset;
+            })}; // Lowest offset entry that (maybe) overlaps with the new entry
+
+            if (firstIt == intervals.end() || firstIt->offset >= entry.end) {
+                intervals.insert(firstIt, entry);
+                return;
+            }
+            // Now firstIt will always overlap
+
+            auto lastIt{firstIt}; // Highest offset entry that overlaps with the new entry
+            while (std::next(lastIt) != intervals.end() && std::next(lastIt)->offset < entry.end)
+                lastIt++;
+
+            // Since firstIt and lastIt both are guaranteed to overlap, max them to get the new entry's end
+            SizeType end{std::max(std::max(firstIt->end, entry.end), lastIt->end)};
+
+            // Erase all overlapping entries but the first
+            auto eraseStartIt{std::next(firstIt)};
+            auto eraseEndIt{std::next(lastIt)};
+            if (eraseStartIt != eraseEndIt) {
+                lastIt = intervals.erase(eraseStartIt, eraseEndIt);
+                firstIt = std::prev(lastIt);
+            }
+
+            firstIt->offset = std::min(entry.offset, firstIt->offset);
+            firstIt->end = end;
+        }
+
+        /**
+         * @brief Merge the given interval into the list
+         */
+        void Merge(const IntervalList<SizeType> &list) {
+            for (auto &entry : list.intervals)
+                Insert(entry);
+        }
+
+        /**
+         * @return A struct describing the interval containing `offset`
+         */
+        QueryResult Query(SizeType offset) {
+            auto it{std::lower_bound(intervals.begin(), intervals.end(), offset, [](const auto &lhs, const auto &rhs) {
+                return lhs.end < rhs;
+            })}; // Lowest offset entry that (maybe) overlaps with the new entry
+
+            if (it == intervals.end()) // No overlaps past offset
+                return {false, {}};
+            else if (it->offset > offset) // No overlap, return the distance to the next possible overlap
+                return {false, it->offset - offset};
+            else // Overlap, return the distance to the end of the overlap
+                return {true, it->end - offset};
+        }
+
+        /**
+         * @return If the given interval intersects with any of the intervals in the list
+         */
+        bool Intersect(Interval interval) {
+            SizeType offset{interval.offset};
+            while (offset < interval.end) {
+                if (auto result{Query(offset)}; result.enclosed)
+                    return true;
+                else if (result.size)
+                    offset += result.size;
+                else
+                    return false;
+            }
+
+            return false;
+        }
+    };
+}

--- a/app/src/main/cpp/skyline/gpu.cpp
+++ b/app/src/main/cpp/skyline/gpu.cpp
@@ -402,7 +402,8 @@ namespace skyline::gpu {
           descriptor(*this),
           helperShaders(*this, state.os->assetFileSystem),
           renderPassCache(*this),
-          framebufferCache(*this) {}
+          framebufferCache(*this),
+          debugTracingBuffer(memory.AllocateBuffer(DebugTracingBufferSize)) {}
 
     void GPU::Initialise() {
         std::string titleId{state.loader->nacp->GetSaveDataOwnerId()};

--- a/app/src/main/cpp/skyline/gpu.h
+++ b/app/src/main/cpp/skyline/gpu.h
@@ -68,6 +68,9 @@ namespace skyline::gpu {
         std::optional<interconnect::maxwell3d::PipelineManager> graphicsPipelineManager;
         interconnect::kepler_compute::PipelineManager computePipelineManager;
 
+        static constexpr size_t DebugTracingBufferSize{0x80000}; //!< 512KiB
+        memory::Buffer debugTracingBuffer; //!< General use buffer for debug tracing, first 4 bytes are allocated for checkpoints
+
         GPU(const DeviceState &state);
 
         /**

--- a/app/src/main/cpp/skyline/gpu/buffer.h
+++ b/app/src/main/cpp/skyline/gpu/buffer.h
@@ -31,6 +31,8 @@ namespace skyline::gpu {
 
         BufferBinding(vk::Buffer buffer, vk::DeviceSize offset = 0, vk::DeviceSize size = 0) : buffer{buffer}, offset{offset}, size{size} {}
 
+        BufferBinding(MegaBufferAllocator::Allocation allocation) : buffer{allocation.buffer}, offset{allocation.offset}, size{allocation.region.size()} {}
+
         operator bool() const {
             return buffer;
         }

--- a/app/src/main/cpp/skyline/gpu/buffer.h
+++ b/app/src/main/cpp/skyline/gpu/buffer.h
@@ -49,14 +49,7 @@ namespace skyline::gpu {
         size_t id;
         bool isDirect{}; //!< Indicates if a buffer is directly mapped from the guest
 
-        /**
-         * @brief Interval struct used to track which part of the buffer should be accessed through the shadow
-         */
-        struct WriteTrackingInterval {
-            size_t offset;
-            size_t end;
-        };
-        std::vector<WriteTrackingInterval> directTrackedWrites; //!< (Direct) A vector of write tracking intervals for the buffer, this is used to determine when to read from `directTrackedShadow`
+        IntervalList<size_t> directTrackedWrites; //!< (Direct) A list of tracking intervals for the buffer, this is used to determine when to read from `directTrackedShadow`
         std::vector<u8> directTrackedShadow; //!< (Direct) Temporary mirror used to track any CPU-side writes to the buffer while it's being read by the GPU
         bool directTrackedShadowActive{}; //!< (Direct) If `directTrackedShadow` is currently being used to track writes
 
@@ -116,27 +109,12 @@ namespace skyline::gpu {
         void ResetMegabufferState();
 
       private:
-        struct QueryIntervalResult {
-            bool useShadow; //!< If the shadow should be used for buffer accesses within the interval
-            u64 size; //!< Size of the interval starting from the query offset
-        };
-
         BufferDelegate *delegate;
 
         friend BufferView;
         friend BufferManager;
 
         void SetupStagedTraps();
-
-        /**
-         * @brief Forces future accesses to the given interval to use the shadow copy
-         */
-        void InsertWriteIntervalDirect(WriteTrackingInterval interval);
-
-        /**
-         * @return A struct describing the interval containing `offset`
-         */
-        QueryIntervalResult QueryWriteIntervalDirect(u64 offset);
 
         /**
          * @brief Enables the shadow buffer used for sequencing buffer contents independently of the GPU on the CPU

--- a/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
@@ -53,6 +53,7 @@ namespace skyline::gpu {
     }
 
     BufferManager::LockedBuffer BufferManager::CoalesceBuffers(span<u8> range, const LockedBuffers &srcBuffers, ContextTag tag) {
+        TRACE_EVENT("gpu", "BufferManager::CoalesceBuffers");
         std::shared_ptr<FenceCycle> newBufferCycle{};
         for (auto &srcBuffer : srcBuffers) {
             // Since new direct buffers will share the underlying backing of source buffers we don't need to wait for the GPU if they're dirty, for non direct buffers we do though as otherwise we won't be able to migrate their contents to the new backing

--- a/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
@@ -130,8 +130,7 @@ namespace skyline::gpu {
                 } else if (srcBuffer->directTrackedShadowActive) {
                     newBuffer->EnableTrackedShadowDirect();
                     copyBuffer(*newBuffer->guest, *srcBuffer->guest, newBuffer->directTrackedShadow.data(), srcBuffer->directTrackedShadow.data());
-                    for (const auto &interval : srcBuffer->directTrackedWrites)
-                        newBuffer->InsertWriteIntervalDirect(interval);
+                    newBuffer->directTrackedWrites.Merge(srcBuffer->directTrackedWrites);
                 }
             }
 

--- a/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
@@ -126,7 +126,7 @@ namespace skyline::gpu {
                     copyBuffer(*newBuffer->guest, *srcBuffer->guest, newBuffer->backing->data(), srcBuffer->backing->data());
                 }
             } else {
-                if (srcBuffer->directGpuWritesActive) {
+                if (srcBuffer->RefreshGpuWritesActiveDirect(false, {})) {
                     newBuffer->MarkGpuDirtyImpl();
                 } else if (srcBuffer->directTrackedShadowActive) {
                     newBuffer->EnableTrackedShadowDirect();

--- a/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/buffer_manager.cpp
@@ -113,7 +113,7 @@ namespace skyline::gpu {
                     if (srcBuffer.lock.IsFirstUsage() && newBuffer->dirtyState != Buffer::DirtyState::GpuDirty)
                         copyBuffer(*newBuffer->guest, *srcBuffer->guest, newBuffer->mirror.data(), srcBuffer->backing->data());
                     else
-                        newBuffer->MarkGpuDirty();
+                        newBuffer->MarkGpuDirtyImpl();
 
                     // Since we don't synchost source buffers and the source buffers here are GPU dirty their mirrors will be out of date, meaning the backing contents of this source buffer's region in the new buffer from the initial synchost call will be incorrect. By copying backings directly here we can ensure that no writes are lost and that if the newly created buffer needs to turn GPU dirty during recreation no copies need to be done since the backing is as up to date as the mirror at a minimum.
                     copyBuffer(*newBuffer->guest, *srcBuffer->guest, newBuffer->backing->data(), srcBuffer->backing->data());
@@ -126,7 +126,7 @@ namespace skyline::gpu {
                 }
             } else {
                 if (srcBuffer->directGpuWritesActive) {
-                    newBuffer->MarkGpuDirty();
+                    newBuffer->MarkGpuDirtyImpl();
                 } else if (srcBuffer->directTrackedShadowActive) {
                     newBuffer->EnableTrackedShadowDirect();
                     copyBuffer(*newBuffer->guest, *srcBuffer->guest, newBuffer->directTrackedShadow.data(), srcBuffer->directTrackedShadow.data());

--- a/app/src/main/cpp/skyline/gpu/buffer_manager.h
+++ b/app/src/main/cpp/skyline/gpu/buffer_manager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <common/trace.h>
 #include <common/linear_allocator.h>
 #include <common/segment_table.h>
 #include <common/spin_lock.h>
@@ -99,6 +100,7 @@ namespace skyline::gpu {
         BufferView FindOrCreateImpl(GuestBuffer guestMapping, ContextTag tag, const std::function<void(std::shared_ptr<Buffer>, ContextLock<Buffer> &&)> &attachBuffer);
 
         BufferView FindOrCreate(GuestBuffer guestMapping, ContextTag tag = {}, const std::function<void(std::shared_ptr<Buffer>, ContextLock<Buffer> &&)> &attachBuffer = {}) {
+            TRACE_EVENT("gpu", "BufferManager::FindOrCreate");
             auto lookupBuffer{bufferTable[guestMapping.begin().base()]};
             if (lookupBuffer != nullptr)
                 if (auto view{lookupBuffer->TryGetView(guestMapping)}; view)

--- a/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
@@ -100,7 +100,6 @@ namespace skyline::gpu::interconnect {
     void CommandRecordThread::ProcessSlot(Slot *slot) {
         TRACE_EVENT_FMT("gpu", "ProcessSlot: 0x{:X}, execution: {}", slot, u64{slot->executionTag});
         auto &gpu{*state.gpu};
-        std::scoped_lock lock{gpu.buffer.recreationMutex};
 
         vk::RenderPass lRenderPass;
         u32 subpassIndex;

--- a/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
@@ -562,6 +562,7 @@ namespace skyline::gpu::interconnect {
         attachedBuffers.clear();
         allocator->Reset();
         renderPassIndex = 0;
+        usageTracker.sequencedIntervals.Clear();
 
         // Periodically clear preserve attachments just in case there are new waiters which would otherwise end up waiting forever
         if ((submissionNumber % (2U << *state.settings->executorSlotCountScale)) == 0) {
@@ -586,7 +587,6 @@ namespace skyline::gpu::interconnect {
 
             SubmitInternal();
             submissionNumber++;
-
         } else {
             if (callback && *state.settings->useDirectMemoryImport)
                 waiterThread.Queue(nullptr, std::move(callback));
@@ -598,6 +598,8 @@ namespace skyline::gpu::interconnect {
         ResetInternal();
 
         if (wait) {
+            usageTracker.dirtyIntervals.Clear();
+
             std::condition_variable cv;
             std::mutex mutex;
             bool gpuDone{};

--- a/app/src/main/cpp/skyline/gpu/interconnect/command_executor.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/command_executor.h
@@ -6,6 +6,7 @@
 #include <boost/container/stable_vector.hpp>
 #include <renderdoc_app.h>
 #include <common/linear_allocator.h>
+#include <gpu/usage_tracker.h>
 #include <gpu/megabuffer.h>
 #include "command_nodes.h"
 #include "common/spin_lock.h"
@@ -217,6 +218,7 @@ namespace skyline::gpu::interconnect {
         size_t submissionNumber{};
         ContextTag executionTag{};
         bool captureNextExecution{};
+        UsageTracker usageTracker;
 
         CommandExecutor(const DeviceState &state);
 

--- a/app/src/main/cpp/skyline/gpu/interconnect/command_nodes.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/command_nodes.h
@@ -122,5 +122,13 @@ namespace skyline::gpu::interconnect::node {
         }
     };
 
-    using NodeVariant = std::variant<FunctionNode, RenderPassNode, NextSubpassNode, SubpassFunctionNode, NextSubpassFunctionNode, RenderPassEndNode>; //!< A variant encompassing all command nodes types
+    /**
+     * @brief A node which copies the contained ID value to the debug tracking buffer
+     */
+    struct CheckpointNode {
+        BufferBinding binding; //!< Binding for a GPU-side buffer containing the checkpoint ID
+        u32 id;
+    };
+
+    using NodeVariant = std::variant<FunctionNode, CheckpointNode, RenderPassNode, NextSubpassNode, SubpassFunctionNode, NextSubpassFunctionNode, RenderPassEndNode>; //!< A variant encompassing all command nodes types
 }

--- a/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
@@ -62,7 +62,7 @@ namespace skyline::gpu::interconnect {
                 dstStageMask |= dstStage;
             }
 
-            view.GetBuffer()->MarkGpuDirty();
+            view.GetBuffer()->MarkGpuDirty(ctx.executor.usageTracker);
         } else {
             if (auto megaBufferBinding{view.TryMegaBuffer(ctx.executor.cycle, ctx.gpu.megaBufferAllocator, ctx.executor.executionTag)})
                 return megaBufferBinding;

--- a/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
@@ -77,6 +77,9 @@ namespace skyline::gpu::interconnect {
 
     static BindlessHandle ReadBindlessHandle(InterconnectContext &ctx, auto &constantBuffers, const auto &desc, size_t arrayIdx) {
         ConstantBuffer &primaryCbuf{constantBuffers[desc.cbuf_index]};
+        if (!primaryCbuf.view)
+            return { .raw = 0 };
+
         size_t elemOffset{arrayIdx << desc.size_shift};
         size_t primaryCbufOffset{desc.cbuf_offset + elemOffset};
         u32 primaryVal{primaryCbuf.Read<u32>(ctx.executor, primaryCbufOffset)};

--- a/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/pipeline.inc
@@ -51,6 +51,8 @@ namespace skyline::gpu::interconnect {
 
         size_t padding{ssbo.address & (ctx.gpu.traits.minimumStorageBufferAlignment - 1)};
         cachedView.Update(ctx, ssbo.address - padding, util::AlignUp(ssbo.size + padding, ctx.gpu.traits.minimumStorageBufferAlignment));
+        if (!cachedView.view) // Return a dummy buffer if the SSBO isn't bound
+            return BufferBinding{ctx.gpu.megaBufferAllocator.Allocate(ctx.executor.cycle, PAGE_SIZE).buffer, 0, PAGE_SIZE};
 
         auto view{cachedView.view};
         ctx.executor.AttachBuffer(view);

--- a/app/src/main/cpp/skyline/gpu/interconnect/common/shader_cache.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/shader_cache.cpp
@@ -53,13 +53,13 @@ namespace skyline::gpu::interconnect {
             mirrorBlock = blockMapping;
         }
 
-        if (entry->trapCount > MirrorEntry::SkipTrapThreshold && entry->channelSequenceNumber != ctx.channelCtx.channelSequenceNumber) {
-            entry->channelSequenceNumber = ctx.channelCtx.channelSequenceNumber;
+        if (entry->trapCount > MirrorEntry::SkipTrapThreshold && entry->executionTag != ctx.executor.executionTag) {
+            entry->executionTag = ctx.executor.executionTag;
             entry->dirty = true;
         }
 
         // If the mirror entry has been written to, clear its shader binary cache and retrap to catch any future writes
-        if (entry->dirty) {
+        if (entry->dirty || ctx.executor.usageTracker.sequencedIntervals.Intersect(blockMapping.subspan(blockOffset))) {
             entry->cache.clear();
             entry->dirty = false;
 
@@ -129,7 +129,7 @@ namespace skyline::gpu::interconnect {
         if (programBase != lastProgramBase || programOffset != lastProgramOffset)
             return true;
 
-        if (entry && entry->trapCount > MirrorEntry::SkipTrapThreshold && entry->channelSequenceNumber != ctx.channelCtx.channelSequenceNumber)
+        if (entry && entry->trapCount > MirrorEntry::SkipTrapThreshold && entry->executionTag != ctx.executor.executionTag)
             return true;
         else if (entry && entry->dirty)
             return true;

--- a/app/src/main/cpp/skyline/gpu/interconnect/common/shader_cache.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/shader_cache.h
@@ -22,7 +22,7 @@ namespace skyline::gpu::interconnect {
 
             static constexpr u32 SkipTrapThreshold{20}; //!< Threshold for the number of times a mirror trap needs to be hit before we fallback to always hashing
             u32 trapCount{}; //!< The number of times the trap has been hit, used to avoid trapping in cases where the constant retraps would harm performance
-            size_t channelSequenceNumber{}; //!< For the case where `trapCount > SkipTrapThreshold`, the memory sequence number number used to clear the cache after every access
+            ContextTag executionTag{}; //!< For the case where `trapCount > SkipTrapThreshold`, the memory sequence number number used to clear the cache after every access
             bool dirty{}; //!< If the trap has been hit and the cache needs to be cleared
 
             MirrorEntry(span<u8> alignedMirror) : mirror{alignedMirror} {}

--- a/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
@@ -158,6 +158,8 @@ namespace skyline::gpu::interconnect {
                                     vk::PipelineStageFlagBits::eAllGraphics, vk::PipelineStageFlagBits::eAllGraphics);
             }
         );
+        executor.AddCheckpoint("After blit");
+
 
         executor.NotifyPipelineChange();
     }

--- a/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
@@ -112,6 +112,8 @@ namespace skyline::gpu::interconnect {
           executor{channelCtx.executor} {}
 
     void Fermi2D::Blit(const Surface &srcSurface, const Surface &dstSurface, float srcRectX, float srcRectY, u32 dstRectWidth, u32 dstRectHeight, u32 dstRectX, u32 dstRectY, float duDx, float dvDy, SampleModeOrigin sampleOrigin, bool resolve, SampleModeFilter filter) {
+        TRACE_EVENT("gpu", "Fermi2D::Blit");
+
         // TODO: When we support MSAA perform a resolve operation rather than blit when the `resolve` flag is set.
         auto srcGuestTexture{GetGuestTexture(srcSurface)};
         auto dstGuestTexture{GetGuestTexture(dstSurface)};
@@ -129,6 +131,7 @@ namespace skyline::gpu::interconnect {
         float centredSrcRectX{sampleOrigin == SampleModeOrigin::Corner ? srcRectX - 0.5f : srcRectX};
         float centredSrcRectY{sampleOrigin == SampleModeOrigin::Corner ? srcRectY - 0.5f : srcRectY};
 
+        executor.AddCheckpoint("Before blit");
         gpu.helperShaders.blitHelperShader.Blit(
             gpu,
             {

--- a/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/fermi_2d.cpp
@@ -123,6 +123,7 @@ namespace skyline::gpu::interconnect {
         auto dstTextureView{gpu.texture.FindOrCreate(dstGuestTexture, executor.tag)};
         executor.AttachDependency(dstTextureView);
         executor.AttachTexture(dstTextureView.get());
+        dstTextureView->texture->MarkGpuDirty(executor.usageTracker);
 
         // Blit shader always samples from centre so adjust if necessary
         float centredSrcRectX{sampleOrigin == SampleModeOrigin::Corner ? srcRectX - 0.5f : srcRectX};

--- a/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/inline2memory.cpp
@@ -22,7 +22,7 @@ namespace skyline::gpu::interconnect {
         ContextLock dstBufLock{executor.tag, dstBuf};
 
 
-        dstBuf.Write(src, 0, [&]() {
+        dstBuf.Write(src, 0, executor.usageTracker, [&]() {
             executor.AttachLockedBufferView(dstBuf, std::move(dstBufLock));
             // This will prevent any CPU accesses to backing for the duration of the usage
             dstBuf.GetBuffer()->BlockAllCpuBackingWrites();

--- a/app/src/main/cpp/skyline/gpu/interconnect/kepler_compute/kepler_compute.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/kepler_compute/kepler_compute.cpp
@@ -65,6 +65,7 @@ namespace skyline::gpu::interconnect::kepler_compute {
         auto *drawParams{ctx.executor.allocator->EmplaceUntracked<DrawParams>(DrawParams{stateUpdater, {qmd.ctaRasterWidth, qmd.ctaRasterHeight, qmd.ctaRasterDepth}, srcStageMask, dstStageMask})};
 
 
+        ctx.executor.AddCheckpoint("Before dispatch");
         ctx.executor.AddOutsideRpCommand([drawParams](vk::raii::CommandBuffer &commandBuffer, const std::shared_ptr<FenceCycle> &, GPU &gpu) {
             drawParams->stateUpdater.RecordAll(gpu, commandBuffer);
 
@@ -76,5 +77,6 @@ namespace skyline::gpu::interconnect::kepler_compute {
 
             commandBuffer.dispatch(drawParams->dimensions[0], drawParams->dimensions[1], drawParams->dimensions[2]);
         });
+        ctx.executor.AddCheckpoint("After dispatch");
     }
 }

--- a/app/src/main/cpp/skyline/gpu/interconnect/kepler_compute/kepler_compute.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/kepler_compute/kepler_compute.cpp
@@ -31,6 +31,8 @@ namespace skyline::gpu::interconnect::kepler_compute {
         if (ctx.gpu.traits.quirks.brokenComputeShaders)
             return;
 
+        TRACE_EVENT("gpu", "KeplerCompute::Dispatch");
+
         StateUpdateBuilder builder{*ctx.executor.allocator};
 
         constantBuffers.Update(ctx, qmd);

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.cpp
@@ -435,6 +435,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
     void ActiveState::Update(InterconnectContext &ctx, Textures &textures, ConstantBufferSet &constantBuffers, StateUpdateBuilder &builder,
                              bool indexed, engine::DrawTopology topology, bool estimateIndexBufferSize, u32 drawFirstIndex, u32 drawElementCount,
                              vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask) {
+        TRACE_EVENT("gpu", "ActiveState::Update");
         if (topology != directState.inputAssembly.GetPrimitiveTopology()) {
             directState.inputAssembly.SetPrimitiveTopology(topology);
             pipeline.MarkDirty(false);

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.cpp
@@ -206,7 +206,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
                         dstStageMask |=  vk::PipelineStageFlagBits::eTransformFeedbackEXT;
                     }
 
-                    view->GetBuffer()->MarkGpuDirty();
+                    view->GetBuffer()->MarkGpuDirty(ctx.executor.usageTracker);
                     builder.SetTransformFeedbackBuffer(index, *view);
                     return;
                 } else {

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/active_state.h
@@ -47,6 +47,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
         CachedMappedBufferView view{};
         BufferBinding megaBufferBinding{};
         vk::IndexType indexType{};
+        bool didEstimateSize{};
         u32 usedElementCount{};
         u32 usedFirstIndex{};
         bool usedQuadConversion{};
@@ -54,9 +55,9 @@ namespace skyline::gpu::interconnect::maxwell3d {
       public:
         IndexBufferState(dirty::Handle dirtyHandle, DirtyManager &manager, const EngineRegisters &engine);
 
-        void Flush(InterconnectContext &ctx, StateUpdateBuilder &builder, vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask, bool quadConversion, u32 firstIndex, u32 elementCount);
+        void Flush(InterconnectContext &ctx, StateUpdateBuilder &builder, vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask, bool quadConversion, bool estimateSize, u32 firstIndex, u32 elementCount);
 
-        bool Refresh(InterconnectContext &ctx, StateUpdateBuilder &builder, vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask, bool quadConversion, u32 firstIndex, u32 elementCount);
+        bool Refresh(InterconnectContext &ctx, StateUpdateBuilder &builder, vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask, bool quadConversion, bool estimateSize, u32 firstIndex, u32 elementCount);
 
         void PurgeCaches();
     };
@@ -259,9 +260,10 @@ namespace skyline::gpu::interconnect::maxwell3d {
 
         /**
          * @brief Updates the active state for a given draw operation, removing the dirtiness of all member states
+         * @note If `extimateIndexBufferSize` is false and `indexed` is true the `drawFirstIndex` and `drawElementCount` arguments must be populated
          */
         void Update(InterconnectContext &ctx, Textures &textures, ConstantBufferSet &constantBuffers, StateUpdateBuilder &builder,
-                    bool indexed, engine::DrawTopology topology, u32 drawFirstIndex, u32 drawElementCount,
+                    bool indexed, engine::DrawTopology topology, bool estimateIndexBufferSize, u32 drawFirstIndex, u32 drawElementCount,
                     vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask);
 
         Pipeline *GetPipeline();

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/constant_buffers.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/constant_buffers.cpp
@@ -40,6 +40,8 @@ namespace skyline::gpu::interconnect::maxwell3d {
     }
 
     void ConstantBuffers::Load(InterconnectContext &ctx, span<u32> data, u32 offset) {
+        TRACE_EVENT("gpu", "ConstantBuffers::Load");
+
         auto &view{*selectorState.UpdateGet(ctx, data.size_bytes()).view};
         auto srcCpuBuf{data.cast<u8>()};
 

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/constant_buffers.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/constant_buffers.cpp
@@ -64,6 +64,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
                 callbackData.view.GetBuffer()->BlockAllCpuBackingWrites();
 
                 auto srcGpuAllocation{callbackData.ctx.gpu.megaBufferAllocator.Push(callbackData.ctx.executor.cycle, callbackData.srcCpuBuf)};
+                callbackData.ctx.executor.AddCheckpoint("Before constant buffer load");
                 callbackData.ctx.executor.AddOutsideRpCommand([=, srcCpuBuf = callbackData.srcCpuBuf, view = callbackData.view, offset = callbackData.offset](vk::raii::CommandBuffer &commandBuffer, const std::shared_ptr<FenceCycle> &, GPU &gpu) {
                     auto binding{view.GetBinding(gpu)};
                     vk::BufferCopy copyRegion{
@@ -77,6 +78,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
                         .dstAccessMask = vk::AccessFlagBits::eMemoryRead | vk::AccessFlagBits::eMemoryWrite
                     }, {}, {});
                 });
+                callbackData.ctx.executor.AddCheckpoint("After constant buffer load");
             });
         }
     }

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.cpp
@@ -132,6 +132,8 @@ namespace skyline::gpu::interconnect::maxwell3d {
         if (scissor.extent.width == 0 || scissor.extent.height == 0)
             return;
 
+        TRACE_EVENT("gpu", "Maxwell3D::Clear");
+
         auto needsAttachmentClearCmd{[&](auto &view) {
             return scissor.offset.x != 0 || scissor.offset.y != 0 ||
                 scissor.extent != vk::Extent2D{view->texture->dimensions} ||
@@ -215,6 +217,8 @@ namespace skyline::gpu::interconnect::maxwell3d {
     }
 
     void Maxwell3D::Draw(engine::DrawTopology topology, bool transformFeedbackEnable, bool indexed, u32 count, u32 first, u32 instanceCount, u32 vertexOffset, u32 firstInstance) {
+        TRACE_EVENT("gpu", "Draw", "indexed", indexed, "count", count, "instanceCount", instanceCount);
+
         StateUpdateBuilder builder{*ctx.executor.allocator};
         vk::PipelineStageFlags srcStageMask{}, dstStageMask{};
 

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.h
@@ -49,6 +49,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
         Textures textures;
         std::shared_ptr<memory::Buffer> quadConversionBuffer{};
         bool quadConversionBufferAttached{};
+        BufferView indirectBufferView;
 
         static constexpr size_t DescriptorBatchSize{0x100};
         std::shared_ptr<boost::container::static_vector<DescriptorAllocator::ActiveDescriptorSet, DescriptorBatchSize>> attachedDescriptorSets;
@@ -102,5 +103,7 @@ namespace skyline::gpu::interconnect::maxwell3d {
         void Clear(engine::ClearSurface &clearSurface);
 
         void Draw(engine::DrawTopology topology, bool transformFeedbackEnable, bool indexed, u32 count, u32 first, u32 instanceCount, u32 vertexOffset, u32 firstInstance);
+
+        void DrawIndirect(engine::DrawTopology topology, bool transformFeedbackEnable, bool indexed, span<u8> indirectBuffer, u32 count, u32 stride);
     };
 }

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.h
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/maxwell_3d.h
@@ -57,7 +57,22 @@ namespace skyline::gpu::interconnect::maxwell3d {
 
         size_t UpdateQuadConversionBuffer(u32 count, u32 firstVertex);
 
+        /**
+         * @brief A scissor derived from the current clear register state
+         */
         vk::Rect2D GetClearScissor();
+
+        /**
+         * @brief A scissor derived from the current draw register state and bound RTs
+         */
+        vk::Rect2D GetDrawScissor();
+
+        /**
+         * @brief Performs operations common across indirect and regular draws
+         */
+        void PrepareDraw(StateUpdateBuilder &builder,
+                         engine::DrawTopology topology, bool indexed, bool estimateIndexBufferSize, u32 firstIndex, u32 count,
+                         vk::PipelineStageFlags &srcStageMask, vk::PipelineStageFlags &dstStageMask);
 
       public:
         DirectPipelineState &directState;

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_3d/pipeline_state.cpp
@@ -385,6 +385,8 @@ namespace skyline::gpu::interconnect::maxwell3d {
           ctSelect{engine.ctSelect} {}
 
     void PipelineState::Flush(InterconnectContext &ctx, Textures &textures, ConstantBufferSet &constantBuffers, StateUpdateBuilder &builder) {
+        TRACE_EVENT("gpu", "PipelineState::Flush");
+
         packedState.dynamicStateActive = ctx.gpu.traits.supportsExtendedDynamicState;
         packedState.ctSelect = ctSelect;
 

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.cpp
@@ -24,7 +24,7 @@ namespace skyline::gpu::interconnect {
         })};
         ContextLock dstBufLock{executor.tag, dstBuf};
 
-        dstBuf.CopyFrom(srcBuf, [&]() {
+        dstBuf.CopyFrom(srcBuf, executor.usageTracker, [&]() {
             executor.AttachLockedBufferView(srcBuf, std::move(srcBufLock));
             executor.AttachLockedBufferView(dstBuf, std::move(dstBufLock));
             // This will prevent any CPU accesses to backing for the duration of the usage

--- a/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/maxwell_dma.cpp
@@ -63,7 +63,7 @@ namespace skyline::gpu::interconnect {
         executor.AttachBuffer(clearBuf);
 
         clearBuf.GetBuffer()->BlockSequencedCpuBackingWrites();
-        clearBuf.GetBuffer()->MarkGpuDirty();
+        clearBuf.GetBuffer()->MarkGpuDirty(executor.usageTracker);
 
         executor.AddOutsideRpCommand([clearBuf, value](vk::raii::CommandBuffer &commandBuffer, const std::shared_ptr<FenceCycle> &, GPU &gpu) {
             commandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eTransfer, {}, vk::MemoryBarrier{

--- a/app/src/main/cpp/skyline/gpu/texture/texture.cpp
+++ b/app/src/main/cpp/skyline/gpu/texture/texture.cpp
@@ -725,6 +725,12 @@ namespace skyline::gpu {
         }
     }
 
+    void Texture::MarkGpuDirty(UsageTracker &usageTracker) {
+        for (auto mapping : guest->mappings)
+            if (mapping.valid())
+                usageTracker.dirtyIntervals.Insert(mapping);
+    }
+
     void Texture::SynchronizeHost(bool gpuDirty) {
         if (!guest)
             return;

--- a/app/src/main/cpp/skyline/gpu/texture/texture.h
+++ b/app/src/main/cpp/skyline/gpu/texture/texture.h
@@ -10,6 +10,7 @@
 #include <nce.h>
 #include <gpu/tag_allocator.h>
 #include <gpu/memory_manager.h>
+#include <gpu/usage_tracker.h>
 
 namespace skyline::gpu {
     namespace texture {
@@ -559,6 +560,11 @@ namespace skyline::gpu {
          * @note The texture **must** be locked prior to calling this
          */
         void TransitionLayout(vk::ImageLayout layout);
+
+        /**
+         * @brief Marks the texture as being GPU dirty
+         */
+        void MarkGpuDirty(UsageTracker &usageTracker);
 
         /**
          * @brief Synchronizes the host texture with the guest after it has been modified

--- a/app/src/main/cpp/skyline/gpu/texture_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/texture_manager.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include <common/trace.h>
 #include "texture_manager.h"
 
 namespace skyline::gpu {
     TextureManager::TextureManager(GPU &gpu) : gpu(gpu) {}
 
     std::shared_ptr<TextureView> TextureManager::FindOrCreate(const GuestTexture &guestTexture, ContextTag tag) {
+        TRACE_EVENT("gpu", "TextureManager::FindOrCreate");
+
         auto guestMapping{guestTexture.mappings.front()};
 
         /*

--- a/app/src/main/cpp/skyline/gpu/usage_tracker.h
+++ b/app/src/main/cpp/skyline/gpu/usage_tracker.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright © 2022 Skyline Team and Contributors (https://github.com/skyline-emu/)
+
+#pragma once
+
+#include <common/interval_list.h>
+
+namespace skyline::gpu {
+    /**
+     * @brief Tracks the usage of GPU memory and buffers to allow for fine-grained flushing
+     */
+    struct UsageTracker {
+        IntervalList<u8 *> dirtyIntervals; //!< Intervals of GPU-dirty contents that requires a flush before accessing
+        IntervalList<u8 *> sequencedIntervals; //!< Intervals of GPFIFO-sequenced writes that occur within an execution
+    };
+}

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/engine.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/engine.cpp
@@ -18,7 +18,7 @@ namespace skyline::soc::gm20b::engine {
 
     MacroEngineBase::MacroEngineBase(MacroState &macroState) : macroState(macroState) {}
 
-    void MacroEngineBase::HandleMacroCall(u32 macroMethodOffset, u32 argument, bool lastCall) {
+    void MacroEngineBase::HandleMacroCall(u32 macroMethodOffset, u32 argument, u32 *argumentPtr, bool lastCall) {
         // Starting a new macro at index 'macroMethodOffset / 2'
         if (!(macroMethodOffset & 1)) {
             // Flush the current macro as we are switching to another one
@@ -31,7 +31,7 @@ namespace skyline::soc::gm20b::engine {
             macroInvocation.index = (macroMethodOffset / 2) % macroState.macroPositions.size();
         }
 
-        macroInvocation.arguments.emplace_back(argument);
+        macroInvocation.arguments.emplace_back(argument, argumentPtr);
 
         // Flush macro after all of the data in the method call has been sent
         if (lastCall && macroInvocation.Valid()) {

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
@@ -80,7 +80,7 @@ namespace skyline::soc::gm20b::engine {
 
         struct {
             u32 index{std::numeric_limits<u32>::max()};
-            std::vector<u32> arguments;
+            std::vector<MacroArgument> arguments;
 
             bool Valid() {
                 return index != std::numeric_limits<u32>::max();
@@ -114,10 +114,14 @@ namespace skyline::soc::gm20b::engine {
             throw exception("DrawIndexedInstanced is not implemented for this engine");
         }
 
+        virtual void DrawIndexedIndirect(u32 drawTopology, span<u8> indirectBuffer, u32 count, u32 stride) {
+            throw exception("DrawIndexedIndirect is not implemented for this engine");
+        }
+
         /**
          * @brief Handles a call to a method in the MME space
          * @param macroMethodOffset The target offset from EngineMethodsEnd
          */
-        void HandleMacroCall(u32 macroMethodOffset, u32 value, bool lastCall);
+        void HandleMacroCall(u32 macroMethodOffset, u32 argument, u32 *argumentPtr, bool lastCall);
     };
 }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
@@ -80,7 +80,7 @@ namespace skyline::soc::gm20b::engine {
 
         struct {
             u32 index{std::numeric_limits<u32>::max()};
-            std::vector<MacroArgument> arguments;
+            std::vector<GpfifoArgument> arguments;
 
             bool Valid() {
                 return index != std::numeric_limits<u32>::max();
@@ -121,7 +121,8 @@ namespace skyline::soc::gm20b::engine {
         /**
          * @brief Handles a call to a method in the MME space
          * @param macroMethodOffset The target offset from EngineMethodsEnd
+         * @return If flushes should be skipped for subsequent GPFIFO argument fetches
          */
-        void HandleMacroCall(u32 macroMethodOffset, u32 argument, u32 *argumentPtr, bool lastCall);
+        bool HandleMacroCall(u32 macroMethodOffset, GpfifoArgument argument, bool lastCall, const std::function<void(void)> &flushCallback);
     };
 }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/engine.h
@@ -106,11 +106,11 @@ namespace skyline::soc::gm20b::engine {
          */
         virtual u32 ReadMethodFromMacro(u32 method) = 0;
 
-        virtual void DrawInstanced(bool setRegs, u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) {
+        virtual void DrawInstanced(u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) {
             throw exception("DrawInstanced is not implemented for this engine");
         }
 
-        virtual void DrawIndexedInstanced(bool setRegs, u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) {
+        virtual void DrawIndexedInstanced(u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) {
             throw exception("DrawIndexedInstanced is not implemented for this engine");
         }
 

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
@@ -499,4 +499,10 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
 
         interconnect.Draw(topology, *registers.streamOutputEnable, true, indexBufferCount, indexBufferFirst, instanceCount, globalBaseVertexIndex, globalBaseInstanceIndex);
     }
+
+    void Maxwell3D::DrawIndexedIndirect(u32 drawTopology, span<u8> indirectBuffer, u32 count, u32 stride) {
+        auto topology{static_cast<type::DrawTopology>(drawTopology)};
+        interconnect.DrawIndirect(topology, *registers.streamOutputEnable, true, indirectBuffer, count, stride);
+    }
+
 }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.cpp
@@ -475,32 +475,27 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
         return registers.raw[method];
     }
 
-    void Maxwell3D::DrawInstanced(bool setRegs, u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) {
+    void Maxwell3D::DrawInstanced(u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) {
+        FlushEngineState();
+
         auto topology{static_cast<type::DrawTopology>(drawTopology)};
-        if (setRegs) {
-            registers.begin->op = topology;
-            registers.drawVertexArray->count = vertexArrayCount;
-            registers.vertexArrayStart = vertexArrayStart;
-            registers.globalBaseInstanceIndex = globalBaseInstanceIndex;
-        }
+        registers.globalBaseInstanceIndex = globalBaseInstanceIndex;
+        registers.vertexArrayStart = vertexArrayStart;
 
         interconnect.Draw(topology, *registers.streamOutputEnable, false, vertexArrayCount, vertexArrayStart, instanceCount, 0, globalBaseInstanceIndex);
+        registers.globalBaseInstanceIndex = 0;
     }
 
-    void Maxwell3D::DrawIndexedInstanced(bool setRegs, u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) {
-        auto topology{static_cast<type::DrawTopology>(drawTopology)};
-        if (setRegs) {
-            registers.begin->op = topology;
-            registers.drawIndexBuffer->count = indexBufferCount;
-            registers.indexBuffer->first = indexBufferFirst;
-            registers.globalBaseVertexIndex = globalBaseVertexIndex;
-            registers.globalBaseInstanceIndex = globalBaseInstanceIndex;
-        }
+    void Maxwell3D::DrawIndexedInstanced(u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) {
+        FlushEngineState();
 
+        auto topology{static_cast<type::DrawTopology>(drawTopology)};
         interconnect.Draw(topology, *registers.streamOutputEnable, true, indexBufferCount, indexBufferFirst, instanceCount, globalBaseVertexIndex, globalBaseInstanceIndex);
     }
 
     void Maxwell3D::DrawIndexedIndirect(u32 drawTopology, span<u8> indirectBuffer, u32 count, u32 stride) {
+        FlushEngineState();
+
         auto topology{static_cast<type::DrawTopology>(drawTopology)};
         interconnect.DrawIndirect(topology, *registers.streamOutputEnable, true, indirectBuffer, count, stride);
     }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.h
@@ -456,5 +456,7 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
         void DrawInstanced(bool setRegs, u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) override;
 
         void DrawIndexedInstanced(bool setRegs, u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) override;
+
+        void DrawIndexedIndirect(u32 drawTopology, span<u8> indirectBuffer, u32 count, u32 stride) override;
     };
 }

--- a/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/engines/maxwell_3d.h
@@ -453,9 +453,9 @@ namespace skyline::soc::gm20b::engine::maxwell3d {
 
         u32 ReadMethodFromMacro(u32 method) override;
 
-        void DrawInstanced(bool setRegs, u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) override;
+        void DrawInstanced(u32 drawTopology, u32 vertexArrayCount, u32 instanceCount, u32 vertexArrayStart, u32 globalBaseInstanceIndex) override;
 
-        void DrawIndexedInstanced(bool setRegs, u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) override;
+        void DrawIndexedInstanced(u32 drawTopology, u32 indexBufferCount, u32 instanceCount, u32 globalBaseVertexIndex, u32 indexBufferFirst, u32 globalBaseInstanceIndex) override;
 
         void DrawIndexedIndirect(u32 drawTopology, span<u8> indirectBuffer, u32 count, u32 stride) override;
     };

--- a/app/src/main/cpp/skyline/soc/gm20b/gpfifo.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/gpfifo.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <common/circular_queue.h>
+#include <soc/gm20b/macro/macro_state.h>
 #include "engines/gpfifo.h"
 
 namespace skyline::soc::gm20b {
@@ -107,6 +108,7 @@ namespace skyline::soc::gm20b {
         engine::GPFIFO gpfifoEngine; //!< The engine for processing GPFIFO method calls
         CircularQueue<GpEntry> gpEntries;
         std::vector<u32> pushBufferData; //!< Persistent vector storing pushbuffer data to avoid constant reallocations
+        bool skipDirtyFlushes{}; //!< If GPU flushing should be skipped when fetching pushbuffer contents
 
         /**
          * @brief Holds the required state in order to resume a method started from one call to `Process` in another
@@ -132,7 +134,7 @@ namespace skyline::soc::gm20b {
         /**
          * @brief Sends a method call to the appropriate subchannel and handles macro and GPFIFO methods
          */
-        void SendFull(u32 method, u32 argument, u32 *argumentPtr, SubchannelId subchannel, bool lastCall);
+        void SendFull(u32 method, GpfifoArgument argument, SubchannelId subchannel, bool lastCall);
 
         /**
          * @brief Sends a method call to the appropriate subchannel, macro and GPFIFO methods are not handled

--- a/app/src/main/cpp/skyline/soc/gm20b/gpfifo.h
+++ b/app/src/main/cpp/skyline/soc/gm20b/gpfifo.h
@@ -132,7 +132,7 @@ namespace skyline::soc::gm20b {
         /**
          * @brief Sends a method call to the appropriate subchannel and handles macro and GPFIFO methods
          */
-        void SendFull(u32 method, u32 argument, SubchannelId subchannel, bool lastCall);
+        void SendFull(u32 method, u32 argument, u32 *argumentPtr, SubchannelId subchannel, bool lastCall);
 
         /**
          * @brief Sends a method call to the appropriate subchannel, macro and GPFIFO methods are not handled

--- a/app/src/main/cpp/skyline/soc/gm20b/macro/macro_interpreter.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/macro/macro_interpreter.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright © 2020 Skyline Team and Contributors (https://github.com/skyline-emu/)
 
+#include "macro_state.h"
 #include "soc/gm20b/engines/engine.h"
 #include "macro_interpreter.h"
 
 namespace skyline::soc::gm20b::engine {
-    MacroInterpreter::MacroInterpreter(span<u32> macroCode) : macroCode(macroCode) {}
+    MacroInterpreter::MacroInterpreter(span<u32> macroCode) : macroCode{macroCode} {}
 
     void MacroInterpreter::Execute(size_t offset, span<u32> args, MacroEngineBase *targetEngine) {
         // Reset the interpreter state

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -22,6 +22,7 @@ import android.os.*
 import android.util.Log
 import android.util.Rational
 import android.view.*
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
@@ -308,6 +309,9 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
         force60HzRefreshRate(!emulationSettings.maxRefreshRate)
         getSystemService<DisplayManager>()?.registerDisplayListener(this, null)
+
+        if (!emulationSettings.isGlobal && emulationSettings.useCustomSettings)
+            Toast.makeText(this, getString(R.string.per_game_settings_active_message), Toast.LENGTH_SHORT).show()
 
         binding.gameView.setOnTouchListener(this)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,4 +257,5 @@
     <!--suppress AndroidLintUnusedResources -->
     <string name="expand_button_title" tools:override="true">Expand</string>
     <string name="undo">Undo</string>
+    <string name="per_game_settings_active_message">Per-game settings are active</string>
 </resources>


### PR DESCRIPTION
- Introduces a lot of new gpu debugging infra
- Doubles performance in nier automata thanks to indirect HLE
- Avoids many redundant waits that happened with DMI before due to not being able to tell if resources are dirty
- Fixes DMI on 8 gen 2