### PR TITLE
Support  deprecation of `getSerializableExtra`

### DIFF
--- a/app/src/main/java/emu/skyline/AppDialog.kt
+++ b/app/src/main/java/emu/skyline/AppDialog.kt
@@ -25,6 +25,7 @@ import emu.skyline.data.AppItemTag
 import emu.skyline.databinding.AppDialogBinding
 import emu.skyline.loader.LoaderResult
 import emu.skyline.settings.SettingsActivity
+import emu.skyline.utils.serializable
 
 /**
  * This dialog is used to show extra game metadata and provide extra options such as pinning the game to the home screen
@@ -46,7 +47,7 @@ class AppDialog : BottomSheetDialogFragment() {
 
     private lateinit var binding : AppDialogBinding
 
-    private val item by lazy { requireArguments().getSerializable(AppItemTag)!! as AppItem }
+    private val item by lazy { requireArguments().serializable<AppItem>(AppItemTag)!! }
 
     /**
      * This inflates the layout of the dialog after initial view creation

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -37,6 +37,7 @@ import emu.skyline.settings.EmulationSettings
 import emu.skyline.settings.NativeSettings
 import emu.skyline.utils.ByteBufferSerializable
 import emu.skyline.utils.GpuDriverHelper
+import emu.skyline.utils.serializable
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.FutureTask
@@ -218,7 +219,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
      * Populates the [item] member with data from the intent
      */
     private fun populateAppItem() {
-        val intentItem = intent.getSerializableExtra(AppItemTag) as AppItem?
+        val intentItem = intent.serializable(AppItemTag) as AppItem?
         if (intentItem != null) {
             item = intentItem
             return

--- a/app/src/main/java/emu/skyline/preference/GpuDriverActivity.kt
+++ b/app/src/main/java/emu/skyline/preference/GpuDriverActivity.kt
@@ -29,6 +29,7 @@ import emu.skyline.settings.EmulationSettings
 import emu.skyline.utils.GpuDriverHelper
 import emu.skyline.utils.GpuDriverInstallResult
 import emu.skyline.utils.WindowInsetsHelper
+import emu.skyline.utils.serializable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -40,7 +41,7 @@ import kotlinx.coroutines.launch
 class GpuDriverActivity : AppCompatActivity() {
     private val binding by lazy { GpuDriverActivityBinding.inflate(layoutInflater) }
 
-    private val item by lazy { intent.extras?.getSerializable(AppItemTag) as AppItem? }
+    private val item by lazy { intent.extras?.serializable(AppItemTag) as AppItem? }
 
     private val adapter = SelectableGenericAdapter(0)
 

--- a/app/src/main/java/emu/skyline/settings/GameSettingsFragment.kt
+++ b/app/src/main/java/emu/skyline/settings/GameSettingsFragment.kt
@@ -17,6 +17,7 @@ import emu.skyline.preference.GpuDriverPreference
 import emu.skyline.preference.IntegerListPreference
 import emu.skyline.utils.GpuDriverHelper
 import emu.skyline.utils.WindowInsetsHelper
+import emu.skyline.utils.serializable
 
 /**
  * This fragment is used to display custom game preferences
@@ -26,7 +27,7 @@ class GameSettingsFragment : PreferenceFragmentCompat() {
         private const val DIALOG_FRAGMENT_TAG = "androidx.preference.PreferenceFragment.DIALOG"
     }
 
-    private val item by lazy { requireArguments().getSerializable(AppItemTag)!! as AppItem }
+    private val item by lazy { requireArguments().serializable<AppItem>(AppItemTag)!! }
 
     override fun onViewCreated(view : View, savedInstanceState : Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/emu/skyline/utils/SerializationHelper.kt
+++ b/app/src/main/java/emu/skyline/utils/SerializationHelper.kt
@@ -5,10 +5,22 @@
 
 package emu.skyline.utils
 
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
 import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
+
+inline fun <reified T : Serializable> Bundle.serializable(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getSerializable(key) as? T
+}
+inline fun <reified T : Serializable> Intent.serializable(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getSerializableExtra(key) as? T
+}
 
 fun <T : Serializable> T.toFile(file : File) {
     ObjectOutputStream(file.outputStream()).use { it.writeObject(this) }


### PR DESCRIPTION
Split this out from #2199 because of the merge conflict it would have with #2246 since it has nothing to do with picture in picture and is easier to fix alone.