### PR TITLE
Add a delete button to the game dialog

### DIFF
--- a/app/src/main/java/emu/skyline/AppDialog.kt
+++ b/app/src/main/java/emu/skyline/AppDialog.kt
@@ -105,6 +105,11 @@ class AppDialog : BottomSheetDialogFragment() {
             shortcutManager.requestPinShortcut(info.build(), null)
         }
 
+        binding.gameDelete.setOnClickListener {
+            dialog?.onBackPressed()
+            (activity as MainActivity).requestAppItemDelete(item)
+        }
+
         binding.gameTitleId.setOnLongClickListener {
             val clipboard = requireActivity().getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
             clipboard.setPrimaryClip(android.content.ClipData.newPlainText("Title ID", item.titleId))

--- a/app/src/main/java/emu/skyline/AppDialog.kt
+++ b/app/src/main/java/emu/skyline/AppDialog.kt
@@ -107,7 +107,7 @@ class AppDialog : BottomSheetDialogFragment() {
 
         binding.gameDelete.setOnClickListener {
             dialog?.onBackPressed()
-            (activity as MainActivity).requestAppItemDelete(item)
+            (activity as MainActivity).requestDeleteAppItem(item)
         }
 
         binding.gameTitleId.setOnLongClickListener {

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -6,6 +6,7 @@
 package emu.skyline
 
 import android.content.Intent
+import android.content.pm.ShortcutManager
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
@@ -302,7 +303,7 @@ class MainActivity : AppCompatActivity() {
         AppDialog.newInstance(appItem).show(supportFragmentManager, "game")
     }
 
-    fun requestAppItemDelete(appItem : AppItem) {
+    fun requestDeleteAppItem(appItem : AppItem) {
         var prompt = Snackbar.make(binding.root, getString(R.string.delete_failed, appItem.title), Snackbar.LENGTH_SHORT)
         DocumentFile.fromTreeUri(this, appItem.uri)?.let { file ->
             if (file.canWrite()) {
@@ -311,6 +312,14 @@ class MainActivity : AppCompatActivity() {
                 builder.setPositiveButton(getString(android.R.string.cancel)) { _, _ -> }
                 builder.setNegativeButton(getString(R.string.delete)) { _, _ ->
                     if (file.delete()) {
+                        val shortcutManager = getSystemService(ShortcutManager::class.java)
+                        val shortcutIds = arrayListOf<String>()
+                        shortcutManager.pinnedShortcuts.forEach {
+                            if (it.intent?.data?.path == appItem.uri.path)
+                                shortcutIds.add(it.id)
+                        }
+                        if (shortcutIds.isNotEmpty())
+                            shortcutManager.disableShortcuts(shortcutIds.toMutableList())
                         loadRoms(false)
                     } else {
                         prompt.show()

--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import emu.skyline.adapter.*
@@ -87,6 +88,7 @@ class MainActivity : AppCompatActivity() {
     private val documentPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) {
         it?.let { uri ->
             contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             appSettings.searchLocation = uri.toString()
 
             loadRoms(false)
@@ -298,6 +300,32 @@ class MainActivity : AppCompatActivity() {
         if (binding.swipeRefreshLayout.isRefreshing) return
 
         AppDialog.newInstance(appItem).show(supportFragmentManager, "game")
+    }
+
+    fun requestAppItemDelete(appItem : AppItem) {
+        var prompt = Snackbar.make(binding.root, getString(R.string.delete_failed, appItem.title), Snackbar.LENGTH_SHORT)
+        DocumentFile.fromTreeUri(this, appItem.uri)?.let { file ->
+            if (file.canWrite()) {
+                val builder = MaterialAlertDialogBuilder(this)
+                builder.setMessage(getString(R.string.delete_confirm, appItem.title))
+                builder.setPositiveButton(getString(android.R.string.cancel)) { _, _ -> }
+                builder.setNegativeButton(getString(R.string.delete)) { _, _ ->
+                    if (file.delete()) {
+                        loadRoms(false)
+                    } else {
+                        prompt.show()
+                    }
+                }
+                builder.show()
+            } else {
+                prompt = Snackbar.make(binding.root, getString(R.string.delete_permission), Snackbar.LENGTH_LONG)
+                prompt.setAction(R.string.grant) {
+                    if (prompt.isShown) prompt.dismiss()
+                    documentPicker.launch(null)
+                }
+                prompt.show()
+            }
+        } ?: prompt.show()
     }
 
     private fun loadRoms(loadFromFile : Boolean) {

--- a/app/src/main/res/layout/app_dialog.xml
+++ b/app/src/main/res/layout/app_dialog.xml
@@ -138,6 +138,16 @@
                 app:iconGravity="textStart"
                 app:iconPadding="0dp" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/game_delete"
+                style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:contentDescription="@string/pin"
+                app:icon="@drawable/ic_delete"
+                app:iconGravity="textStart" />
+
         </com.google.android.flexbox.FlexboxLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,12 @@
     <string name="validation_layer">Enable Validation Layer</string>
     <string name="validation_layer_enabled">The Vulkan validation layer is enabled, major slowdowns are to be expected</string>
     <string name="validation_layer_disabled">The Vulkan validation layer is disabled</string>
+    <!-- App Dialog - Delete -->
+    <string name="delete">Delete</string>
+    <string name="delete_confirm">Are you sure you want to delete %1$s</string>
+    <string name="delete_permission">Delete requires write permission</string>
+    <string name="delete_failed">Failed to delete %1$s</string>
+    <string name="grant">Grant</string>
     <!-- Gpu Driver Activity -->
     <string name="gpu_driver">GPU Driver</string>
     <string name="add_gpu_driver">Add a GPU driver</string>


### PR DESCRIPTION
Bear with me because there is some stuff that would normally be unnecessary, but needs to be included because of timing.

This adds the ability to delete a file through the game dialog. The problem, as you may already know, is that write permission is not being requested to display the game list. That is why this has to check for write permission to be present and then call a new instance of selecting your root folder to add it. By doing it this way and not simply trying to shoehorn write permission on top of the existing request, it prevents ever having to request it again for subsequent files. As for new requests (ie. new installs), the permission will be requested as part of the initial setup. I'm sure there are 100 prettier ways to go about this, but most would involve having requested the write permission up front, despite not needing it yet.

Oh, and the delete button is intentionally the negative button to prevent accidental presses. Anyone rushing through dialogs should end up cancelling, not deleting files.