### PR TITLE
Don't load Bitmap already set as Drawable

### DIFF
--- a/app/src/main/java/emu/skyline/AppDialog.kt
+++ b/app/src/main/java/emu/skyline/AppDialog.kt
@@ -63,7 +63,7 @@ class AppDialog : BottomSheetDialogFragment() {
             }
         }
 
-        binding.gameIcon.setImageBitmap(item.bitmapIcon)
+        item.icon?.let { binding.gameIcon.setImageBitmap(it) }
         binding.gameTitle.text = item.title
         binding.gameVersion.text = item.version ?: item.loaderResultString(requireContext())
         binding.gameTitleId.text = item.titleId

--- a/app/src/main/java/emu/skyline/adapter/AppViewItem.kt
+++ b/app/src/main/java/emu/skyline/adapter/AppViewItem.kt
@@ -102,7 +102,7 @@ class AppViewItem(var layoutType : LayoutType, private val item : AppItem, priva
         binding.textVersion.isSelected = true
         binding.textAuthor.isSelected = true
 
-        binding.icon.setImageBitmap(item.bitmapIcon)
+        item.icon?.let { binding.icon.setImageBitmap(it) }
 
         if (layoutType == LayoutType.List) {
             binding.icon.setOnClickListener { showIconDialog(it.context, item) }


### PR DESCRIPTION
I didn't catch this before, but the ImageView for these two layouts already has the default icon. There is no point checking for null and then replacing the default with the default when the load can be skipped altogether.