### PR TITLE
Suppress a linear configuration warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,10 @@ android {
         targetCompatibility javaVersion
     }
 
+    packagingOptions {
+        jniLibs.useLegacyPackaging = true
+    }
+
     signingConfigs {
         ci {
             storeFile file(System.getenv("SIGNING_STORE_PATH") ?: "${System.getenv("user.home")}/keystore.jks")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,13 +51,13 @@ android {
 
     /* JVM Bytecode Options */
     def javaVersion = JavaVersion.VERSION_1_8
-    compileOptions {
-        sourceCompatibility javaVersion
-        targetCompatibility javaVersion
-    }
     kotlinOptions {
         jvmTarget = javaVersion.toString()
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+    }
+    compileOptions {
+        sourceCompatibility javaVersion
+        targetCompatibility javaVersion
     }
 
     signingConfigs {


### PR DESCRIPTION
I kept wondering why the Java version was identical and still complaining they were not set to the same value on half of my projects. This seems to avoid the warning, which isn't consistent.

Also addressed the CI warning "PackagingOptions.jniLibs.useLegacyPackaging should be set to true because android:extractNativeLibs is set to "true" in AndroidManifest.xml"