### PR TITLE
Add an option to filter valid files for library

### DIFF
--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -305,6 +305,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun populateAdapter() {
         val items = getDataItems()
+        if (appSettings.filterValid) items.removeIf { item -> item is AppItem && item.version.isNullOrEmpty() }
         adapter.setItems(items.map {
             when (it) {
                 is HeaderItem -> HeaderViewItem(it.title)

--- a/app/src/main/java/emu/skyline/settings/AppSettings.kt
+++ b/app/src/main/java/emu/skyline/settings/AppSettings.kt
@@ -25,6 +25,7 @@ class AppSettings @Inject constructor(@ApplicationContext private val context : 
     var layoutType by sharedPreferences(context, 1)
     var sortAppsBy by sharedPreferences(context, 0)
     var groupByFormat by sharedPreferences(context, true)
+    var filterValid by sharedPreferences(context, false)
     var selectAction by sharedPreferences(context, false)
 
     // Input

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="group_by_format">Group Games By Format</string>
     <string name="group_by_format_desc_off">Games will be shown as a single list</string>
     <string name="group_by_format_desc_on">Games will be shown grouped by format</string>
+    <string name="filter_valid">Filter Valid Games</string>
+    <string name="filter_valid_desc_off">All game files will be displayed</string>
+    <string name="filter_valid_desc_on">Only valid games will be displayed</string>
     <string name="select_action">Always Show Game Information</string>
     <string name="select_action_desc_on">Game information will be shown on clicking a game</string>
     <string name="select_action_desc_off">Game information will only be shown on long-clicking a game</string>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -57,6 +57,12 @@
             android:summaryOn="@string/group_by_format_desc_on"
             app:key="group_by_format"
             app:title="@string/group_by_format" />
+        <emu.skyline.preference.RefreshSwitchPreferenceCompat
+            android:defaultValue="false"
+            android:summaryOff="@string/filter_valid_desc_off"
+            android:summaryOn="@string/filter_valid_desc_on"
+            app:key="filter_valid"
+            app:title="@string/filter_valid" />
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:summaryOff="@string/select_action_desc_off"


### PR DESCRIPTION
I don't know if this is the case for everyone, but I store DLC and stuff alongside my games in a folder named after the game. This means that when I load the emulator, my list of items is like 30 long, but only 6 of them are games. Filtering the files shouldn't be enforced, but having the option would be nice. For now, it's based on a version being populated, since none of the DLC are actually assigned versions read by the emulator.