### PR TITLE
On-Screen Controls Improvements Part 1

### DIFF
--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -557,7 +557,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         return inputHandler.handleTouchEvent(view, event)
     }
 
-    private fun onButtonStateChanged(buttonId : ButtonId, state : ButtonState) = InputHandler.setButtonState(0, buttonId.value(), state.state)
+    private fun onButtonStateChanged(buttonId : ButtonId, state : ButtonState) = InputHandler.setButtonState(0, buttonId.value, state.state)
 
     private fun onStickStateChanged(stickId : StickId, position : PointF) {
         InputHandler.setAxisValue(0, stickId.xAxis.ordinal, (position.x * Short.MAX_VALUE).toInt())

--- a/app/src/main/java/emu/skyline/input/Controller.kt
+++ b/app/src/main/java/emu/skyline/input/Controller.kt
@@ -13,13 +13,56 @@ import java.io.Serializable
  *
  * @param stringRes The string resource of the controller's name
  * @param firstController If the type only applies to the first controller
+ * @param optionalButtons Optional buttons that are allowed to be displayed on screen, but shouldn't be included in the controller mapping activity
  */
-enum class ControllerType(val stringRes : Int, val firstController : Boolean, val sticks : Array<StickId> = arrayOf(), val buttons : Array<ButtonId> = arrayOf(), val id : Int) {
+enum class ControllerType(val stringRes : Int, val firstController : Boolean, val sticks : Array<StickId> = arrayOf(), val buttons : Array<ButtonId> = arrayOf(), val optionalButtons : Array<ButtonId> = arrayOf(), val id : Int) {
     None(R.string.none, false, id = 0b0),
-    ProController(R.string.procon, false, arrayOf(StickId.Left, StickId.Right), arrayOf(ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y, ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus), 0b1),
-    HandheldProController(R.string.handheld_procon, true, arrayOf(StickId.Left, StickId.Right), arrayOf(ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y, ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus), 0b10),
-    JoyConLeft(R.string.ljoycon, false, arrayOf(StickId.Left), arrayOf(ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight, ButtonId.L, ButtonId.ZL, ButtonId.Minus, ButtonId.LeftSL, ButtonId.LeftSR), 0b1000),
-    JoyConRight(R.string.rjoycon, false, arrayOf(StickId.Right), arrayOf(ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y, ButtonId.R, ButtonId.ZR, ButtonId.Plus, ButtonId.RightSL, ButtonId.RightSR), 0b10000),
+    ProController(
+        R.string.procon,
+        false,
+        arrayOf(StickId.Left, StickId.Right),
+        arrayOf(
+            ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y,
+            ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight,
+            ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus
+        ),
+        arrayOf(ButtonId.L3, ButtonId.R3),
+        0b1
+    ),
+    HandheldProController(
+        R.string.handheld_procon,
+        true,
+        arrayOf(StickId.Left, StickId.Right),
+        arrayOf(
+            ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y,
+            ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight,
+            ButtonId.L, ButtonId.R, ButtonId.ZL, ButtonId.ZR, ButtonId.Plus, ButtonId.Minus
+        ),
+        arrayOf(ButtonId.L3, ButtonId.R3),
+        0b10
+    ),
+    JoyConLeft(
+        R.string.ljoycon,
+        false,
+        arrayOf(StickId.Left),
+        arrayOf(
+            ButtonId.DpadUp, ButtonId.DpadDown, ButtonId.DpadLeft, ButtonId.DpadRight,
+            ButtonId.L, ButtonId.ZL, ButtonId.Minus, ButtonId.LeftSL, ButtonId.LeftSR
+        ),
+        arrayOf(ButtonId.L3),
+        0b1000
+    ),
+    JoyConRight(
+        R.string.rjoycon,
+        false,
+        arrayOf(StickId.Right),
+        arrayOf(
+            ButtonId.A, ButtonId.B, ButtonId.X, ButtonId.Y,
+            ButtonId.R, ButtonId.ZR, ButtonId.Plus, ButtonId.RightSL, ButtonId.RightSR
+        ),
+        arrayOf(ButtonId.R3),
+        0b10000
+    ),
 }
 
 /**

--- a/app/src/main/java/emu/skyline/input/GuestEvent.kt
+++ b/app/src/main/java/emu/skyline/input/GuestEvent.kt
@@ -7,49 +7,44 @@ package emu.skyline.input
 
 import emu.skyline.R.string
 import java.io.Serializable
-import java.util.*
+import java.util.Objects
 import kotlin.math.abs
 
 /**
  * This enumerates all of the buttons that the emulator recognizes
  */
-enum class ButtonId(val short : String? = null, val long : Int? = null) {
-    A("A", string.a_button),
-    B("B", string.b_button),
-    X("X", string.x_button),
-    Y("Y", string.y_button),
-    LeftStick("L", string.left_stick),
-    RightStick("R", string.right_stick),
-    L("L", string.left_shoulder),
-    R("R", string.right_shoulder),
-    ZL("ZL", string.left_trigger),
-    ZR("ZR", string.right_trigger),
-    Plus("+", string.plus_button),
-    Minus("-", string.minus_button),
-    DpadLeft("◀︎", string.left),
-    DpadUp("▲︎", string.up),
-    DpadRight("▶︎", string.right),
-    DpadDown("▼︎", string.down),
-    LeftStickLeft,
-    LeftStickUp,
-    LeftStickRight,
-    LeftStickDown,
-    RightStickLeft,
-    RightStickUp,
-    RightStickRight,
-    RightStickDown,
-    LeftSL("SL", string.left_shoulder),
-    LeftSR("SR", string.right_shoulder),
-    RightSL("SL", string.left_shoulder),
-    RightSR("SR", string.right_shoulder),
-    Menu("⌂︎", string.emu_menu_button);
-
-    /**
-     * This returns the value as setting the [ordinal]-th bit in a [Long]
-     */
-    fun value() : Long {
-        return (1.toLong()) shl ordinal
-    }
+enum class ButtonId(val value : Long, val short : String? = null, val long : Int? = null) {
+    A(1 shl 0, "A", string.a_button),
+    B(1 shl 1, "B", string.b_button),
+    X(1 shl 2, "X", string.x_button),
+    Y(1 shl 3, "Y", string.y_button),
+    LeftStick(1 shl 4, "L", string.left_stick),
+    RightStick(1 shl 5, "R", string.right_stick),
+    L3(1 shl 4, "L3", string.left_stick_button),
+    R3(1 shl 5, "R3", string.right_stick_button),
+    L(1 shl 6, "L", string.left_shoulder),
+    R(1 shl 7, "R", string.right_shoulder),
+    ZL(1 shl 8, "ZL", string.left_trigger),
+    ZR(1 shl 9, "ZR", string.right_trigger),
+    Plus(1 shl 10, "+", string.plus_button),
+    Minus(1 shl 11, "-", string.minus_button),
+    DpadLeft(1 shl 12, "◀︎", string.left),
+    DpadUp(1 shl 13, "▲︎", string.up),
+    DpadRight(1 shl 14, "▶︎", string.right),
+    DpadDown(1 shl 15, "▼︎", string.down),
+    LeftStickLeft(1 shl 16),
+    LeftStickUp(1 shl 17),
+    LeftStickRight(1 shl 18),
+    LeftStickDown(1 shl 19),
+    RightStickLeft(1 shl 20),
+    RightStickUp(1 shl 21),
+    RightStickRight(1 shl 22),
+    RightStickDown(1 shl 23),
+    LeftSL(1 shl 24, "SL", string.left_shoulder),
+    LeftSR(1 shl 25, "SR", string.right_shoulder),
+    RightSL(1 shl 26, "SL", string.left_shoulder),
+    RightSR(1 shl 27, "SR", string.right_shoulder),
+    Menu(1 shl 28, "⌂︎", string.emu_menu_button);
 }
 
 /**

--- a/app/src/main/java/emu/skyline/input/InputHandler.kt
+++ b/app/src/main/java/emu/skyline/input/InputHandler.kt
@@ -221,7 +221,7 @@ class InputHandler(private val inputManager : InputManager, private val emulatio
         return when (val guestEvent = inputManager.eventMap[KeyHostEvent(event.device.descriptor, event.keyCode)]) {
             is ButtonGuestEvent -> {
                 if (guestEvent.button != ButtonId.Menu)
-                    setButtonState(guestEvent.id, guestEvent.button.value(), action.state)
+                    setButtonState(guestEvent.id, guestEvent.button.value, action.state)
                 true
             }
 
@@ -274,7 +274,7 @@ class InputHandler(private val inputManager : InputManager, private val emulatio
                         is ButtonGuestEvent -> {
                             val action = if (abs(value) >= guestEvent.threshold) ButtonState.Pressed.state else ButtonState.Released.state
                             if (guestEvent.button != ButtonId.Menu)
-                                setButtonState(guestEvent.id, guestEvent.button.value(), action)
+                                setButtonState(guestEvent.id, guestEvent.button.value, action)
                         }
 
                         is AxisGuestEvent -> {

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -179,8 +179,40 @@ abstract class OnScreenButton(
      * Moves this button to the given coordinates
      */
     open fun move(x : Float, y : Float) {
-        relativeX = x / width
-        relativeY = (y - heightDiff) / adjustedHeight
+        var adjustedX = x
+        var adjustedY = y
+
+        if (editInfo.snapToGrid) {
+            val centerX = width / 2f
+            val centerY = height / 2f
+            val gridSize = editInfo.gridSize
+            // The coordinates of the first grid line for each axis, because the grid is centered and might not start at [0,0]
+            val startX = centerX % gridSize
+            val startY = centerY % gridSize
+
+            /**
+             * The offset to apply to a coordinate to snap it to the grid is the remainder of
+             * the coordinate divided by the grid size.
+             * Since the grid is centered on the screen and might not start at [0,0] we need to
+             * subtract the grid start offset, otherwise we'd be calculating the offset for a grid that starts at [0,0].
+             *
+             * Example: Touch event X: 158 | Grid size: 50 | Grid start X: 40 -> Grid lines at 40, 90, 140, 190, ...
+             * Snap offset: 158 - 40 = 118 -> 118 % 50 = 18
+             * Apply offset to X: 158 - 18 = 140 which is a grid line
+             *
+             * If we didn't subtract the grid start offset:
+             * Snap offset: 158 % 50 = 8
+             * Apply offset to X: 158 - 8 = 150 which is not a grid line
+             */
+            val snapOffsetX = (x - startX) % gridSize
+            val snapOffsetY = (y - startY) % gridSize
+
+            adjustedX = x - snapOffsetX
+            adjustedY = y - snapOffsetY
+        }
+
+        relativeX = adjustedX / width
+        relativeY = (adjustedY - heightDiff) / adjustedHeight
     }
 
     /**

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -51,13 +51,24 @@ abstract class OnScreenButton(
     private val relativeWidth get() = defaultRelativeWidth * config.globalScale
     private val relativeHeight get() = defaultRelativeHeight * config.globalScale
 
+    /**
+     * The width of the view this button is in, populated by the view during draw
+     */
     var width = 0
+
+    /**
+     * The height of the view this button is in, populated by the view during draw
+     */
     var height = 0
 
+    /**
+     * The height of the view this button is in, adjusted to an arbitrary aspect ratio used during configuration
+     */
     protected val adjustedHeight get() = width / CONFIGURED_ASPECT_RATIO
 
     /**
-     * Buttons should be at bottom when device have large height than [adjustedHeight]
+     * The difference between the view height and the adjusted view height.
+     * This is used to offset the buttons to the bottom of the screen when the view height is larger than [adjustedHeight]
      */
     protected val heightDiff get() = (height - adjustedHeight).coerceAtLeast(0f)
 

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -243,6 +243,6 @@ abstract class OnScreenButton(
     open fun resetConfig() {
         resetRelativeValues()
         config.enabled = true
-        config.scale = 0f
+        config.scale = OnScreenConfiguration.DefaultScale
     }
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -82,8 +82,10 @@ abstract class OnScreenButton(
 
     var hapticFeedback = false
 
-    var isEditing = false
-        private set
+    /**
+     * The edit session information, populated by the view
+     */
+    protected var editInfo = onScreenControllerView.editInfo
 
     protected open fun renderCenteredText(canvas : Canvas, text : String, size : Float, x : Float, y : Float, alpha : Int) {
         buttonSymbolPaint.apply {
@@ -133,19 +135,35 @@ abstract class OnScreenButton(
         relativeY = config.relativeY
     }
 
-    fun startEdit() {
-        isEditing = true
+    /**
+     * Starts an edit session
+     * @param x The x coordinate of the initial touch
+     * @param y The y coordinate of the initial touch
+     */
+    open fun startEdit(x : Float, y : Float) {
     }
 
     open fun edit(x : Float, y : Float) {
+        when (editInfo.editMode) {
+            EditMode.Move -> move(x, y)
+            else -> return
+        }
+    }
+
+    /**
+     * Moves this button to the given coordinates
+     */
+    open fun move(x : Float, y : Float) {
         relativeX = x / width
         relativeY = (y - heightDiff) / adjustedHeight
     }
 
-    fun endEdit() {
+    /**
+     * Ends the current edit session
+     */
+    open fun endEdit() {
         config.relativeX = relativeX
         config.relativeY = relativeY
-        isEditing = false
     }
 
     open fun resetRelativeValues() {

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -27,7 +27,8 @@ abstract class OnScreenButton(
     private val defaultRelativeY : Float,
     private val defaultRelativeWidth : Float,
     private val defaultRelativeHeight : Float,
-    drawableId : Int
+    drawableId : Int,
+    private val defaultEnabled : Boolean
 ) {
     companion object {
         /**
@@ -36,7 +37,7 @@ abstract class OnScreenButton(
         const val CONFIGURED_ASPECT_RATIO = 2074f / 874f
     }
 
-    val config = OnScreenConfiguration(onScreenControllerView.context, buttonId, defaultRelativeX, defaultRelativeY)
+    val config = OnScreenConfiguration(onScreenControllerView.context, buttonId, defaultRelativeX, defaultRelativeY, defaultEnabled)
 
     protected val drawable = ContextCompat.getDrawable(onScreenControllerView.context, drawableId)!!
 
@@ -242,7 +243,7 @@ abstract class OnScreenButton(
 
     open fun resetConfig() {
         resetRelativeValues()
-        config.enabled = true
+        config.enabled = defaultEnabled
         config.scale = OnScreenConfiguration.DefaultScale
     }
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -35,12 +35,11 @@ abstract class OnScreenButton(
         const val CONFIGURED_ASPECT_RATIO = 2074f / 874f
     }
 
-    val config = if (onScreenControllerView.isInEditMode) ControllerConfigurationDummy(defaultRelativeX, defaultRelativeY)
-    else ControllerConfigurationImpl(onScreenControllerView.context, buttonId, defaultRelativeX, defaultRelativeY)
+    val config = OnScreenConfiguration(onScreenControllerView.context, buttonId, defaultRelativeX, defaultRelativeY)
 
     protected val drawable = ContextCompat.getDrawable(onScreenControllerView.context, drawableId)!!
 
-    internal val buttonSymbolPaint = Paint().apply {
+    private val buttonSymbolPaint = Paint().apply {
         color = config.textColor
         typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
         isAntiAlias = true

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenButton.kt
@@ -184,4 +184,9 @@ abstract class OnScreenButton(
         relativeX = defaultRelativeX
         relativeY = defaultRelativeY
     }
+
+    open fun resetConfig() {
+        resetRelativeValues()
+        config.enabled = true
+    }
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
@@ -13,11 +13,23 @@ import emu.skyline.utils.sharedPreferences
 class OnScreenConfiguration(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float) {
     private inline fun <reified T> config(default : T, prefix : String = "${buttonId.name}_") = sharedPreferences(context, default, prefix, "controller_config")
 
+    var enabled by config(true)
+
     var alpha by config(155, "")
     var textColor by config(SwitchColors.BLACK.color)
     var backgroundColor by config(SwitchColors.WHITE.color)
-    var enabled by config(true)
+
+    /**
+     * The global scale applied to all buttons
+     */
     var globalScale by config(1.15f, "")
+
+    /**
+     * The scale of each button, this is added to the global scale
+     * Allows buttons to have their own size, while still be controlled by the global scale
+     */
+    var scale by config(0.0f)
+
     var relativeX by config(defaultRelativeX)
     var relativeY by config(defaultRelativeY)
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
@@ -11,24 +11,30 @@ import emu.skyline.utils.SwitchColors
 import emu.skyline.utils.sharedPreferences
 
 class OnScreenConfiguration(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float) {
+    companion object {
+        const val DefaultAlpha = 130
+        const val DefaultGlobalScale = 1.15f
+        const val DefaultScale = 0.0f
+    }
+
     private inline fun <reified T> config(default : T, prefix : String = "${buttonId.name}_") = sharedPreferences(context, default, prefix, "controller_config")
 
     var enabled by config(true)
 
-    var alpha by config(155, "")
+    var alpha by config(DefaultAlpha, "")
     var textColor by config(SwitchColors.BLACK.color)
     var backgroundColor by config(SwitchColors.WHITE.color)
 
     /**
      * The global scale applied to all buttons
      */
-    var globalScale by config(1.15f, "")
+    var globalScale by config(DefaultGlobalScale, "")
 
     /**
      * The scale of each button, this is added to the global scale
      * Allows buttons to have their own size, while still be controlled by the global scale
      */
-    var scale by config(0.0f)
+    var scale by config(DefaultScale)
 
     var relativeX by config(defaultRelativeX)
     var relativeY by config(defaultRelativeY)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
@@ -10,7 +10,7 @@ import emu.skyline.input.ButtonId
 import emu.skyline.utils.SwitchColors
 import emu.skyline.utils.sharedPreferences
 
-class OnScreenConfiguration(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float) {
+class OnScreenConfiguration(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float, defaultEnabled : Boolean) {
     companion object {
         const val DefaultAlpha = 130
         const val DefaultGlobalScale = 1.15f
@@ -19,7 +19,7 @@ class OnScreenConfiguration(private val context : Context, private val buttonId 
 
     private inline fun <reified T> config(default : T, prefix : String = "${buttonId.name}_") = sharedPreferences(context, default, prefix, "controller_config")
 
-    var enabled by config(true)
+    var enabled by config(defaultEnabled)
 
     var alpha by config(DefaultAlpha, "")
     var textColor by config(SwitchColors.BLACK.color)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenConfiguration.kt
@@ -10,37 +10,14 @@ import emu.skyline.input.ButtonId
 import emu.skyline.utils.SwitchColors
 import emu.skyline.utils.sharedPreferences
 
-interface ControllerConfiguration {
-    var alpha : Int
-    var textColor : Int
-    var backgroundColor : Int
-    var enabled : Boolean
-    var globalScale : Float
-    var relativeX : Float
-    var relativeY : Float
-}
-
-/**
- * Dummy implementation so layout editor is able to render [OnScreenControllerView] when [android.view.View.isInEditMode] is true
- */
-class ControllerConfigurationDummy(defaultRelativeX : Float, defaultRelativeY : Float) : ControllerConfiguration {
-    override var alpha : Int = 155
-    override var textColor = SwitchColors.BLACK.color
-    override var backgroundColor = SwitchColors.WHITE.color
-    override var enabled = true
-    override var globalScale = 1f
-    override var relativeX = defaultRelativeX
-    override var relativeY = defaultRelativeY
-}
-
-class ControllerConfigurationImpl(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float) : ControllerConfiguration {
+class OnScreenConfiguration(private val context : Context, private val buttonId : ButtonId, defaultRelativeX : Float, defaultRelativeY : Float) {
     private inline fun <reified T> config(default : T, prefix : String = "${buttonId.name}_") = sharedPreferences(context, default, prefix, "controller_config")
 
-    override var alpha by config(155, "")
-    override var textColor by config(SwitchColors.BLACK.color)
-    override var backgroundColor by config(SwitchColors.WHITE.color)
-    override var enabled by config(true)
-    override var globalScale by config(1.15f, "")
-    override var relativeX by config(defaultRelativeX)
-    override var relativeY by config(defaultRelativeY)
+    var alpha by config(155, "")
+    var textColor by config(SwitchColors.BLACK.color)
+    var backgroundColor by config(SwitchColors.WHITE.color)
+    var enabled by config(true)
+    var globalScale by config(1.15f, "")
+    var relativeX by config(defaultRelativeX)
+    var relativeY by config(defaultRelativeY)
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -9,14 +9,10 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.content.Context
-import android.content.Context.VIBRATOR_MANAGER_SERVICE
-import android.content.Context.VIBRATOR_SERVICE
 import android.graphics.Canvas
 import android.graphics.PointF
-import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
-import android.os.VibratorManager
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -66,12 +62,9 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
             field = value
             (controls.circularButtons + controls.rectangularButtons + controls.triggerButtons).forEach { it.hapticFeedback = hapticFeedback }
         }
-    private val vibrator: Vibrator =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            (context.getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
-        } else {
-            @Suppress("DEPRECATION") (context.getSystemService(VIBRATOR_SERVICE) as Vibrator)
-        }
+
+    // Populated externally by the activity, as retrieving the vibrator service inside the view crashes the layout editor
+    lateinit var vibrator : Vibrator
     private val effectClick = VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
 
     override fun onDraw(canvas : Canvas) {

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -69,6 +69,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
     lateinit var vibrator : Vibrator
     private val effectClick = VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
 
+    // Ensure controls init happens after editInfo is initialized so that the buttons have a valid reference to it
     private val controls = Controls(this)
 
     override fun onDraw(canvas : Canvas) {
@@ -263,8 +264,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
 
     fun setEditMode(editMode : EditMode) {
         editInfo.editMode = editMode
-        setOnTouchListener(if (editMode == EditMode.None) playingTouchHandler else editingTouchHandler)
-        invalidate()
+        setOnTouchListener(if (isEditing) editingTouchHandler else playingTouchHandler )
     }
 
     fun resetControls() {
@@ -284,6 +284,10 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
     fun decreaseScale() {
         controls.globalScale -= SCALE_STEP
         invalidate()
+    }
+
+    fun setSnapToGrid(snap : Boolean) {
+        editInfo.snapToGrid = snap
     }
 
     fun increaseOpacity() {

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -35,7 +35,7 @@ typealias OnStickStateChangedListener = (stickId : StickId, position : PointF) -
 class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = 0, defStyleRes : Int = 0) : View(context, attrs, defStyleAttr, defStyleRes) {
     companion object {
         private val controllerTypeMappings = mapOf(*ControllerType.values().map {
-            it to (setOf(*it.buttons) to setOf(*it.sticks))
+            it to (setOf(*it.buttons) + setOf(*it.optionalButtons) to setOf(*it.sticks))
         }.toTypedArray())
 
         private const val SCALE_STEP = 0.05f

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -67,7 +67,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
 
     // Populated externally by the activity, as retrieving the vibrator service inside the view crashes the layout editor
     lateinit var vibrator : Vibrator
-    private val effectClick = VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
+    private val effectClick = VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK)
 
     // Ensure controls init happens after editInfo is initialized so that the buttons have a valid reference to it
     private val controls = Controls(this)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -269,8 +269,7 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
 
     fun resetControls() {
         controls.allButtons.forEach {
-            it.resetRelativeValues()
-            it.config.enabled = true
+            it.resetConfig()
         }
         controls.globalScale = 1.15f
         controls.alpha = 155

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenControllerView.kt
@@ -271,8 +271,8 @@ class OnScreenControllerView @JvmOverloads constructor(context : Context, attrs 
         controls.allButtons.forEach {
             it.resetConfig()
         }
-        controls.globalScale = 1.15f
-        controls.alpha = 155
+        controls.globalScale = OnScreenConfiguration.DefaultGlobalScale
+        controls.alpha = OnScreenConfiguration.DefaultAlpha
         invalidate()
     }
 

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -58,6 +58,11 @@ class OnScreenEditActivity : AppCompatActivity() {
         toggleFabVisibility(false)
     }
 
+    private val resizeAction = {
+        binding.onScreenControllerView.setEditMode(EditMode.Resize)
+        toggleFabVisibility(false)
+    }
+
     private val toggleAction : () -> Unit = {
         val buttonProps = binding.onScreenControllerView.getButtonProps()
         val checkedButtonsArray = buttonProps.map { it.enabled }.toBooleanArray()
@@ -107,7 +112,8 @@ class OnScreenEditActivity : AppCompatActivity() {
         Pair(R.drawable.ic_palette, paletteAction),
         Pair(R.drawable.ic_restore) { binding.onScreenControllerView.resetControls() },
         Pair(R.drawable.ic_toggle, toggleAction),
-        Pair(R.drawable.ic_edit, moveAction),
+        Pair(R.drawable.ic_move, moveAction),
+        Pair(R.drawable.ic_resize, resizeAction),
         Pair(R.drawable.ic_zoom_out) { binding.onScreenControllerView.decreaseScale() },
         Pair(R.drawable.ic_zoom_in) { binding.onScreenControllerView.increaseScale() },
         Pair(R.drawable.ic_opacity_minus) { binding.onScreenControllerView.decreaseOpacity() },

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -12,6 +12,7 @@ import android.os.VibratorManager
 import android.view.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.isGone
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import dagger.hilt.android.AndroidEntryPoint
@@ -108,12 +109,26 @@ class OnScreenEditActivity : AppCompatActivity() {
         }
     }
 
+    private val enableGridAction = {
+        appSettings.onScreenControlSnapToGrid = true
+        binding.onScreenControllerView.setSnapToGrid(true)
+        binding.alignmentGrid.isGone = false
+    }
+
+    private val disableGridAction = {
+        appSettings.onScreenControlSnapToGrid = false
+        binding.onScreenControllerView.setSnapToGrid(false)
+        binding.alignmentGrid.isGone = true
+    }
+
     private val actions : List<Pair<Int, () -> Unit>> = listOf(
         Pair(R.drawable.ic_palette, paletteAction),
         Pair(R.drawable.ic_restore) { binding.onScreenControllerView.resetControls() },
         Pair(R.drawable.ic_toggle, toggleAction),
         Pair(R.drawable.ic_move, moveAction),
         Pair(R.drawable.ic_resize, resizeAction),
+        Pair(R.drawable.ic_grid_on, enableGridAction),
+        Pair(R.drawable.ic_grid_off, disableGridAction),
         Pair(R.drawable.ic_zoom_out) { binding.onScreenControllerView.decreaseScale() },
         Pair(R.drawable.ic_zoom_in) { binding.onScreenControllerView.increaseScale() },
         Pair(R.drawable.ic_opacity_minus) { binding.onScreenControllerView.decreaseOpacity() },
@@ -146,6 +161,12 @@ class OnScreenEditActivity : AppCompatActivity() {
             getSystemService(VIBRATOR_SERVICE) as Vibrator
 
         binding.onScreenControllerView.recenterSticks = appSettings.onScreenControlRecenterSticks
+
+        val snapToGrid = appSettings.onScreenControlSnapToGrid
+        binding.onScreenControllerView.setSnapToGrid(snapToGrid)
+
+        binding.alignmentGrid.isGone = !snapToGrid
+        binding.alignmentGrid.gridSize = OnScreenEditInfo.GridSize
 
         actions.forEach { pair ->
             binding.fabParent.addView(LayoutInflater.from(this).inflate(R.layout.on_screen_edit_mini_fab, binding.fabParent, false).apply {

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -29,16 +29,14 @@ class OnScreenEditActivity : AppCompatActivity() {
     private val binding by lazy { OnScreenEditActivityBinding.inflate(layoutInflater) }
 
     private var fullEditVisible = true
-    private var editMode = false
 
     @Inject
     lateinit var appSettings : AppSettings
 
     private val closeAction : () -> Unit = {
-        if (editMode) {
+        if (binding.onScreenControllerView.isEditing) {
             toggleFabVisibility(true)
-            binding.onScreenControllerView.setEditMode(false)
-            editMode = false
+            binding.onScreenControllerView.setEditMode(EditMode.None)
         } else {
             fullEditVisible = !fullEditVisible
             toggleFabVisibility(fullEditVisible)
@@ -55,28 +53,32 @@ class OnScreenEditActivity : AppCompatActivity() {
         }
     }
 
-    private val editAction = {
-        editMode = true
-        binding.onScreenControllerView.setEditMode(true)
+    private val moveAction = {
+        binding.onScreenControllerView.setEditMode(EditMode.Move)
         toggleFabVisibility(false)
     }
 
     private val toggleAction : () -> Unit = {
         val buttonProps = binding.onScreenControllerView.getButtonProps()
-        val checkArray = buttonProps.map { it.second }.toBooleanArray()
+        val checkedButtonsArray = buttonProps.map { it.enabled }.toBooleanArray()
 
         MaterialAlertDialogBuilder(this)
-            .setMultiChoiceItems(buttonProps.map {
-                val longText = getString(it.first.long!!)
-                if (it.first.short == longText) longText else "$longText: ${it.first.short}"
-            }.toTypedArray(), checkArray) { _, which, isChecked ->
-                checkArray[which] = isChecked
-            }.setPositiveButton(R.string.confirm) { _, _ ->
-                buttonProps.forEachIndexed { index, pair ->
-                    if (checkArray[index] != pair.second)
-                        binding.onScreenControllerView.setButtonEnabled(pair.first, checkArray[index])
+            .setMultiChoiceItems(
+                buttonProps.map { button ->
+                    val longText = getString(button.buttonId.long!!)
+                    if (button.buttonId.short == longText) longText else "$longText: ${button.buttonId.short}"
+                }.toTypedArray(),
+                checkedButtonsArray
+            ) { _, which, isChecked ->
+                checkedButtonsArray[which] = isChecked
+            }
+            .setPositiveButton(R.string.confirm) { _, _ ->
+                buttonProps.forEachIndexed { index, button ->
+                    if (checkedButtonsArray[index] != button.enabled)
+                        binding.onScreenControllerView.setButtonEnabled(button.buttonId, checkedButtonsArray[index])
                 }
-            }.setNegativeButton(R.string.cancel, null)
+            }
+            .setNegativeButton(R.string.cancel, null)
             .setOnDismissListener { fullScreen() }
             .show()
     }
@@ -105,7 +107,7 @@ class OnScreenEditActivity : AppCompatActivity() {
         Pair(R.drawable.ic_palette, paletteAction),
         Pair(R.drawable.ic_restore) { binding.onScreenControllerView.resetControls() },
         Pair(R.drawable.ic_toggle, toggleAction),
-        Pair(R.drawable.ic_edit, editAction),
+        Pair(R.drawable.ic_edit, moveAction),
         Pair(R.drawable.ic_zoom_out) { binding.onScreenControllerView.decreaseScale() },
         Pair(R.drawable.ic_zoom_in) { binding.onScreenControllerView.increaseScale() },
         Pair(R.drawable.ic_opacity_minus) { binding.onScreenControllerView.decreaseOpacity() },

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditActivity.kt
@@ -7,6 +7,8 @@ package emu.skyline.input.onscreen
 
 import android.os.Build
 import android.os.Bundle
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.view.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -97,8 +99,6 @@ class OnScreenEditActivity : AppCompatActivity() {
             })
             show()
         }
-
-
     }
 
     private val actions : List<Pair<Int, () -> Unit>> = listOf(
@@ -130,6 +130,12 @@ class OnScreenEditActivity : AppCompatActivity() {
                 it.hide(WindowInsets.Type.systemBars())
             }
         }
+
+        binding.onScreenControllerView.vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            (getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+        else
+            @Suppress("DEPRECATION")
+            getSystemService(VIBRATOR_SERVICE) as Vibrator
 
         binding.onScreenControllerView.recenterSticks = appSettings.onScreenControlRecenterSticks
 

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ */
+
+package emu.skyline.input.onscreen
+
+enum class EditMode {
+    None,
+    Move,
+}
+
+/**
+ * A small class that holds information about the current edit session
+ * This is used to share information between the [OnScreenControllerView] and the individual [OnScreenButton]s
+ */
+class OnScreenEditInfo {
+    /**
+     * The current edit mode
+     */
+    var editMode : EditMode = EditMode.None
+
+    /**
+     * The button that is currently being edited
+     */
+    var editButton : OnScreenButton? = null
+
+    val isEditing get() = editMode != EditMode.None
+}

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
@@ -5,8 +5,8 @@
 
 package emu.skyline.input.onscreen
 
+import android.content.res.Resources
 import android.util.TypedValue
-import emu.skyline.SkylineApplication
 
 enum class EditMode {
     None,
@@ -39,10 +39,9 @@ class OnScreenEditInfo {
     val isEditing get() = editMode != EditMode.None
 
     companion object {
-
         /**
          * The size of the grid, calculated from the value of 8dp
          */
-        val GridSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, SkylineApplication.context.resources.displayMetrics).toInt()
+        var GridSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, Resources.getSystem().displayMetrics).toInt()
     }
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
@@ -8,6 +8,7 @@ package emu.skyline.input.onscreen
 enum class EditMode {
     None,
     Move,
+    Resize
 }
 
 /**

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenEditInfo.kt
@@ -5,6 +5,9 @@
 
 package emu.skyline.input.onscreen
 
+import android.util.TypedValue
+import emu.skyline.SkylineApplication
+
 enum class EditMode {
     None,
     Move,
@@ -26,5 +29,20 @@ class OnScreenEditInfo {
      */
     var editButton : OnScreenButton? = null
 
+    /**
+     * Whether the buttons should snap to a grid when in edit mode
+     */
+    var snapToGrid : Boolean = false
+
+    var gridSize : Int = GridSize
+
     val isEditing get() = editMode != EditMode.None
+
+    companion object {
+
+        /**
+         * The size of the grid, calculated from the value of 8dp
+         */
+        val GridSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, SkylineApplication.context.resources.displayMetrics).toInt()
+    }
 }

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
@@ -197,24 +197,24 @@ class TriggerButton(
 )
 
 class Controls(onScreenControllerView : OnScreenControllerView) {
-    private val buttonA = CircularButton(onScreenControllerView, A, 0.95f, 0.65f, 0.025f)
-    private val buttonB = CircularButton(onScreenControllerView, B, 0.9f, 0.765f, 0.025f)
-    private val buttonX = CircularButton(onScreenControllerView, X, 0.9f, 0.535f, 0.025f)
-    private val buttonY = CircularButton(onScreenControllerView, Y, 0.85f, 0.65f, 0.025f)
+    private val buttonA = CircularButton(onScreenControllerView, A, 0.81f, 0.73f, 0.025f)
+    private val buttonB = CircularButton(onScreenControllerView, B, 0.76f, 0.85f, 0.025f)
+    private val buttonX = CircularButton(onScreenControllerView, X, 0.76f, 0.61f, 0.025f)
+    private val buttonY = CircularButton(onScreenControllerView, Y, 0.71f, 0.73f, 0.025f)
 
-    private val buttonDpadLeft = CircularButton(onScreenControllerView, DpadLeft, 0.2f, 0.65f, 0.025f)
-    private val buttonDpadUp = CircularButton(onScreenControllerView, DpadUp, 0.25f, 0.535f, 0.025f)
-    private val buttonDpadRight = CircularButton(onScreenControllerView, DpadRight, 0.3f, 0.65f, 0.025f)
-    private val buttonDpadDown = CircularButton(onScreenControllerView, DpadDown, 0.25f, 0.765f, 0.025f)
+    private val buttonDpadLeft = CircularButton(onScreenControllerView, DpadLeft, 0.06f, 0.53f, 0.025f)
+    private val buttonDpadUp = CircularButton(onScreenControllerView, DpadUp, 0.11f, 0.41f, 0.025f)
+    private val buttonDpadRight = CircularButton(onScreenControllerView, DpadRight, 0.16f, 0.53f, 0.025f)
+    private val buttonDpadDown = CircularButton(onScreenControllerView, DpadDown, 0.11f, 0.65f, 0.025f)
 
-    private val buttonL = RectangularButton(onScreenControllerView, L, 0.1f, 0.25f, 0.09f, 0.1f)
-    private val buttonR = RectangularButton(onScreenControllerView, R, 0.9f, 0.25f, 0.09f, 0.1f)
+    private val buttonL = RectangularButton(onScreenControllerView, L, 0.1f, 0.22f, 0.09f, 0.1f)
+    private val buttonR = RectangularButton(onScreenControllerView, R, 0.9f, 0.22f, 0.09f, 0.1f)
 
-    private val buttonZL = TriggerButton(onScreenControllerView, ZL, 0.1f, 0.1f, 0.09f, 0.1f)
-    private val buttonZR = TriggerButton(onScreenControllerView, ZR, 0.9f, 0.1f, 0.09f, 0.1f)
+    private val buttonZL = TriggerButton(onScreenControllerView, ZL, 0.1f, 0.08f, 0.09f, 0.1f)
+    private val buttonZR = TriggerButton(onScreenControllerView, ZR, 0.9f, 0.08f, 0.09f, 0.1f)
 
-    private val buttonL3 = CircularButton(onScreenControllerView, L3, 0.35f, 0.87f, 0.025f, defaultEnabled = false)
-    private val buttonR3 = CircularButton(onScreenControllerView, R3, 0.65f, 0.87f, 0.025f, defaultEnabled = false)
+    private val buttonL3 = CircularButton(onScreenControllerView, L3, 0.12f, 0.87f, 0.025f, defaultEnabled = false)
+    private val buttonR3 = CircularButton(onScreenControllerView, R3, 0.88f, 0.87f, 0.025f, defaultEnabled = false)
 
     private val circularButtonPairs = listOf(setOf(buttonA, buttonB, buttonX, buttonY), setOf(buttonDpadLeft, buttonDpadUp, buttonDpadRight, buttonDpadDown))
 
@@ -225,14 +225,14 @@ class Controls(onScreenControllerView : OnScreenControllerView) {
     val buttonPairs = circularButtonPairs + triggerButtonPairs
 
     val circularButtons = circularButtonPairs.flatten() + stickButtons + listOf(
-        CircularButton(onScreenControllerView, Plus, 0.57f, 0.75f, 0.025f),
-        CircularButton(onScreenControllerView, Minus, 0.43f, 0.75f, 0.025f),
-        CircularButton(onScreenControllerView, Menu, 0.5f, 0.75f, 0.025f)
+        CircularButton(onScreenControllerView, Plus, 0.57f, 0.85f, 0.025f),
+        CircularButton(onScreenControllerView, Minus, 0.43f, 0.85f, 0.025f),
+        CircularButton(onScreenControllerView, Menu, 0.5f, 0.85f, 0.025f)
     )
 
     val joysticks = listOf(
-        JoystickButton(onScreenControllerView, Left, 0.1f, 0.8f, 0.05f),
-        JoystickButton(onScreenControllerView, Right, 0.75f, 0.6f, 0.05f)
+        JoystickButton(onScreenControllerView, Left, 0.24f, 0.75f, 0.053f),
+        JoystickButton(onScreenControllerView, Right, 0.9f, 0.53f, 0.053f)
     )
 
     val rectangularButtons = listOf(buttonL, buttonR)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
@@ -25,7 +25,8 @@ open class CircularButton(
     defaultRelativeX : Float,
     defaultRelativeY : Float,
     defaultRelativeRadiusToX : Float,
-    drawableId : Int = R.drawable.ic_button
+    drawableId : Int = R.drawable.ic_button,
+    defaultEnabled : Boolean = true
 ) : OnScreenButton(
     onScreenControllerView,
     buttonId,
@@ -33,7 +34,8 @@ open class CircularButton(
     defaultRelativeY,
     defaultRelativeRadiusToX * 2f,
     defaultRelativeRadiusToX * CONFIGURED_ASPECT_RATIO * 2f,
-    drawableId
+    drawableId,
+    defaultEnabled
 ) {
     val radius get() = itemWidth / 2f
 
@@ -60,7 +62,7 @@ class JoystickButton(
     private val innerButton = CircularButton(onScreenControllerView, buttonId, config.relativeX, config.relativeY, defaultRelativeRadiusToX * 0.75f, R.drawable.ic_stick)
 
     var recenterSticks = false
-    private lateinit var initialTapPosition : PointF
+    private var initialTapPosition = PointF()
     private var fingerDownTime = 0L
     private var fingerUpTime = 0L
     var shortDoubleTapped = false
@@ -156,7 +158,8 @@ open class RectangularButton(
     defaultRelativeY : Float,
     defaultRelativeWidth : Float,
     defaultRelativeHeight : Float,
-    drawableId : Int = R.drawable.ic_rectangular_button
+    drawableId : Int = R.drawable.ic_rectangular_button,
+    defaultEnabled : Boolean = true
 ) : OnScreenButton(
     onScreenControllerView,
     buttonId,
@@ -164,7 +167,8 @@ open class RectangularButton(
     defaultRelativeY,
     defaultRelativeWidth,
     defaultRelativeHeight,
-    drawableId
+    drawableId,
+    defaultEnabled
 ) {
     override fun isTouched(x : Float, y : Float) = currentBounds.contains(x.roundToInt(), y.roundToInt())
 }
@@ -209,13 +213,18 @@ class Controls(onScreenControllerView : OnScreenControllerView) {
     private val buttonZL = TriggerButton(onScreenControllerView, ZL, 0.1f, 0.1f, 0.09f, 0.1f)
     private val buttonZR = TriggerButton(onScreenControllerView, ZR, 0.9f, 0.1f, 0.09f, 0.1f)
 
+    private val buttonL3 = CircularButton(onScreenControllerView, L3, 0.35f, 0.87f, 0.025f, defaultEnabled = false)
+    private val buttonR3 = CircularButton(onScreenControllerView, R3, 0.65f, 0.87f, 0.025f, defaultEnabled = false)
+
     private val circularButtonPairs = listOf(setOf(buttonA, buttonB, buttonX, buttonY), setOf(buttonDpadLeft, buttonDpadUp, buttonDpadRight, buttonDpadDown))
 
     private val triggerButtonPairs = listOf(setOf(buttonL, buttonZL), setOf(buttonR, buttonZR))
 
+    private val stickButtons = setOf(buttonL3, buttonR3)
+
     val buttonPairs = circularButtonPairs + triggerButtonPairs
 
-    val circularButtons = circularButtonPairs.flatten() + listOf(
+    val circularButtons = circularButtonPairs.flatten() + stickButtons + listOf(
         CircularButton(onScreenControllerView, Plus, 0.57f, 0.75f, 0.025f),
         CircularButton(onScreenControllerView, Minus, 0.43f, 0.75f, 0.025f),
         CircularButton(onScreenControllerView, Menu, 0.5f, 0.75f, 0.025f)

--- a/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
+++ b/app/src/main/java/emu/skyline/input/onscreen/OnScreenItemDefinitions.kt
@@ -7,7 +7,6 @@ package emu.skyline.input.onscreen
 
 import android.graphics.Canvas
 import android.graphics.PointF
-import android.graphics.Typeface
 import android.os.SystemClock
 import androidx.core.graphics.minus
 import emu.skyline.R

--- a/app/src/main/java/emu/skyline/settings/AppSettings.kt
+++ b/app/src/main/java/emu/skyline/settings/AppSettings.kt
@@ -31,6 +31,7 @@ class AppSettings @Inject constructor(@ApplicationContext private val context : 
     var onScreenControl by sharedPreferences(context, true)
     var onScreenControlFeedback by sharedPreferences(context, true)
     var onScreenControlRecenterSticks by sharedPreferences(context, true)
+    var onScreenControlSnapToGrid by sharedPreferences(context, false)
 
     // Other
     var romFormatFilter by sharedPreferences(context, 0)

--- a/app/src/main/java/emu/skyline/views/AlignmentGridView.kt
+++ b/app/src/main/java/emu/skyline/views/AlignmentGridView.kt
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ */
+
+package emu.skyline.views
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+
+/**
+ * A view that draws a grid, used for aligning on-screen controller buttons
+ */
+class AlignmentGridView @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = 0) : View(context, attrs, defStyleAttr) {
+    var gridSize = 0
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    private val gridPaint = Paint().apply {
+        color = Color.WHITE
+        alpha = 135
+    }
+    private val gridCenterPaint = Paint().apply {
+        color = Color.WHITE
+        alpha = 55
+        strokeWidth = 10f
+    }
+
+    override fun onDraw(canvas : Canvas) {
+        super.onDraw(canvas)
+        drawGrid(canvas)
+    }
+
+    /**
+     * Draws a centered grid on the given canvas
+     */
+    private fun drawGrid(canvas : Canvas) {
+        val centerX = width / 2f
+        val centerY = height / 2f
+        val gridSize = gridSize
+        // Compute the coordinates of the first grid line for each axis, because we want a centered grid, which might not start at [0,0]
+        val startX = centerX % gridSize
+        val startY = centerY % gridSize
+
+        // Draw the center lines with a thicker stroke
+        canvas.drawLine(centerX, 0f, centerX, height.toFloat(), gridCenterPaint)
+        canvas.drawLine(0f, centerY, width.toFloat(), centerY, gridCenterPaint)
+
+        // Draw the rest of the grid starting from the start coordinates
+        // Draw vertical lines
+        for (i in 0..width step gridSize) {
+            canvas.drawLine(startX + i, 0f, startX + i, height.toFloat(), gridPaint)
+        }
+        // Draw horizontal lines
+        for (i in 0..height step gridSize) {
+            canvas.drawLine(0f, startY + i, width.toFloat(), startY + i, gridPaint)
+        }
+    }
+}

--- a/app/src/main/java/emu/skyline/views/AlignmentGridView.kt
+++ b/app/src/main/java/emu/skyline/views/AlignmentGridView.kt
@@ -16,7 +16,7 @@ import android.view.View
  * A view that draws a grid, used for aligning on-screen controller buttons
  */
 class AlignmentGridView @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = 0) : View(context, attrs, defStyleAttr) {
-    var gridSize = 0
+    var gridSize = 16
         set(value) {
             field = value
             invalidate()

--- a/app/src/main/res/drawable/ic_grid_off.xml
+++ b/app/src/main/res/drawable/ic_grid_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8,4v1.45l2,2L10,4h4v4h-3.45l2,2L14,10v1.45l2,2L16,10h4v4h-3.45l2,2L20,16v1.45l2,2L22,4c0,-1.1 -0.9,-2 -2,-2L4.55,2l2,2L8,4zM16,4h4v4h-4L16,4zM1.27,1.27L0,2.55l2,2L2,20c0,1.1 0.9,2 2,2h15.46l2,2 1.27,-1.27L1.27,1.27zM10,12.55L11.45,14L10,14v-1.45zM4,6.55L5.45,8L4,8L4,6.55zM8,20L4,20v-4h4v4zM8,14L4,14v-4h3.45l0.55,0.55L8,14zM14,20h-4v-4h3.45l0.55,0.54L14,20zM16,20v-1.46L17.46,20L16,20z" />
+</vector>

--- a/app/src/main/res/drawable/ic_grid_on.xml
+++ b/app/src/main/res/drawable/ic_grid_on.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,2L4,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM8,20L4,20v-4h4v4zM8,14L4,14v-4h4v4zM8,8L4,8L4,4h4v4zM14,20h-4v-4h4v4zM14,14h-4v-4h4v4zM14,8h-4L10,4h4v4zM20,20h-4v-4h4v4zM20,14h-4v-4h4v4zM20,8h-4L16,4h4v4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_move.xml
+++ b/app/src/main/res/drawable/ic_move.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,9h4L14,6h3l-5,-5 -5,5h3v3zM9,10L6,10L6,7l-5,5 5,5v-3h3v-4zM23,12l-5,-5v3h-3v4h3v3l5,-5zM14,15h-4v3L7,18l5,5 5,-5h-3v-3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_resize.xml
+++ b/app/src/main/res/drawable/ic_resize.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,11l0,-8l-8,0l3.29,3.29l-10,10l-3.29,-3.29l0,8l8,0l-3.29,-3.29l10,-10z" />
+</vector>

--- a/app/src/main/res/layout/on_screen_edit_activity.xml
+++ b/app/src/main/res/layout/on_screen_edit_activity.xml
@@ -4,6 +4,11 @@
     android:layout_height="match_parent"
     android:background="@android:color/black">
 
+    <emu.skyline.views.AlignmentGridView
+        android:id="@+id/alignment_grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
     <emu.skyline.input.onscreen.OnScreenControllerView
         android:id="@+id/on_screen_controller_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,8 @@
     <string name="dpad">D-pad</string>
     <string name="left_stick">Left Stick</string>
     <string name="right_stick">Right Stick</string>
+    <string name="left_stick_button">Left Stick Button</string>
+    <string name="right_stick_button">Right Stick Button</string>
     <string name="face_buttons">Face Buttons</string>
     <string name="shoulder_trigger">Shoulder &amp; Trigger Buttons</string>
     <string name="shoulder_rail">Shoulder Buttons on Joy-Con Rail</string>


### PR DESCRIPTION
Some long standing issues in on-screen controls have been fixed in this first wave of improvements, with more to come in following PRs.

- Buttons can be aligned to grid
- Button size can be adjusted invididually
- Better default position (you might need to reset buttons to default to see it)
- Separate L3/R3 buttons, disabled by default
- Toned down haptic feedback (vibration) a bit

See individual commits for details.