### PR TITLE
Fix GetSharedFontInOrderOfPriority

### DIFF
--- a/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
+++ b/app/src/main/cpp/skyline/services/pl/IPlatformServiceManager.cpp
@@ -59,7 +59,7 @@ namespace skyline::service::pl {
         request.outputBuf.at(1).copy_from(fontOffsets);
         request.outputBuf.at(2).copy_from(fontSizes);
 
-        response.Push<u8>(1); // Fonts are loaded
+        response.Push(static_cast<u32>(core.fonts.size()));
         response.Push(static_cast<u32>(fontCodes.size()));
 
         return {};


### PR DESCRIPTION
Not sure why, but Ryujinx returns size of loaded fonts and size of all fonts (https://github.com/Ryujinx/Ryujinx/blob/08831eecf77cedd3c4192ebab5a9c485fb15d51e/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs#L100). While Yuzu and Skyline returns loaded state and size of loaded fonts (https://github.com/yuzu-emu/yuzu/blob/54c359d1e3915653ce07a26e0e574aca5a331cb1/src/core/hle/service/ns/iplatform_service_manager.cpp#L292).
Changing to what returns Ryujinx fixes Kirby games, Tsukihime (maybe some others)