### PR TITLE
Crash fixes for uncommon occurences 

### DIFF
--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -78,7 +78,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     /**
      * The built-in [Vibrator] of the device
      */
-    lateinit var builtinVibrator : Vibrator
+    private lateinit var builtinVibrator : Vibrator
 
     /**
      * A map of [Vibrator]s that correspond to [InputManager.controllers]
@@ -108,7 +108,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     @Inject
     lateinit var appSettings : AppSettings
 
-    lateinit var emulationSettings : EmulationSettings
+    private lateinit var emulationSettings : EmulationSettings
 
     @Inject
     lateinit var inputManager : InputManager

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -370,10 +370,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
     @SuppressWarnings("WeakerAccess")
     fun resumeEmulator() {
-        if (!isEmulatorPaused) return
         gameSurface?.let { setSurface(it) }
-        if (!emulationSettings.isAudioOutputDisabled)
-            changeAudioStatus(true)
+        changeAudioStatus(!emulationSettings.isAudioOutputDisabled)
         isEmulatorPaused = false
     }
 
@@ -400,6 +398,8 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         super.onResume()
 
         resumeEmulator()
+
+        GpuDriverHelper.forceMaxGpuClocks(emulationSettings.forceMaxGpuClocks)
 
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
             @Suppress("DEPRECATION")

--- a/app/src/main/java/emu/skyline/adapter/AppViewItem.kt
+++ b/app/src/main/java/emu/skyline/adapter/AppViewItem.kt
@@ -7,7 +7,6 @@ package emu.skyline.adapter
 
 import android.app.Dialog
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.View

--- a/app/src/main/java/emu/skyline/adapter/GpuDriverViewItem.kt
+++ b/app/src/main/java/emu/skyline/adapter/GpuDriverViewItem.kt
@@ -5,6 +5,7 @@
 
 package emu.skyline.adapter
 
+import android.annotation.SuppressLint
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import emu.skyline.data.GpuDriverMetadata
@@ -24,6 +25,7 @@ open class GpuDriverViewItem(
 
     override fun getViewBindingFactory() = GpuDriverBindingFactory
 
+    @SuppressLint("SetTextI18n")
     override fun bind(holder : GenericViewHolder<GpuDriverItemBinding>, position : Int) {
         this.holder = holder
         val binding = holder.binding

--- a/app/src/main/java/emu/skyline/applet/swkbd/SoftwareKeyboardConfig.kt
+++ b/app/src/main/java/emu/skyline/applet/swkbd/SoftwareKeyboardConfig.kt
@@ -25,6 +25,7 @@ val OutsideOfMiiNicknameCodepoints = getCodepointArray('@', '%', '\\', 'ō', 'Ō
 data class KeyboardMode(
     var mode : u32 = 0u
 ) : ByteBufferSerializable {
+    @Suppress("unused")
     companion object {
         val Full = KeyboardMode(0u)
         val Numeric = KeyboardMode(1u)
@@ -118,6 +119,7 @@ data class PasswordMode(
 data class InputFormMode(
     var mode : u32 = 0u
 ) : ByteBufferSerializable {
+    @Suppress("unused")
     companion object {
         val OneLine = InputFormMode(0u)
         val MultiLine = InputFormMode(1u)
@@ -144,6 +146,7 @@ data class DictionaryInfo(
 /**
  * This data class matches KeyboardConfigVB in skyline/applet/swkbd/software_keyboard_config.h
  */
+@Suppress("ArrayInDataClass")
 data class SoftwareKeyboardConfig(
     var keyboardMode : KeyboardMode = KeyboardMode(),
     @param:ByteBufferSerializable.ByteBufferSerializableArray(0x9) val okText : CharArray = CharArray(0x9),

--- a/app/src/main/java/emu/skyline/applet/swkbd/SoftwareKeyboardDialog.kt
+++ b/app/src/main/java/emu/skyline/applet/swkbd/SoftwareKeyboardDialog.kt
@@ -14,13 +14,14 @@ import android.view.ViewGroup
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import emu.skyline.databinding.KeyboardDialogBinding
+import emu.skyline.utils.parcelable
 import emu.skyline.utils.stringFromChars
 import java.util.concurrent.FutureTask
 
 data class SoftwareKeyboardResult(val cancelled : Boolean, val text : String)
 
 class SoftwareKeyboardDialog : DialogFragment() {
-    private val config by lazy { requireArguments().getParcelable<SoftwareKeyboardConfig>("config")!! }
+    private val config by lazy { requireArguments().parcelable<SoftwareKeyboardConfig>("config")!! }
     private val initialText by lazy { requireArguments().getString("initialText")!! }
     private var stopped = false
 

--- a/app/src/main/java/emu/skyline/preference/DocumentsProviderPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/DocumentsProviderPreference.kt
@@ -18,7 +18,7 @@ import emu.skyline.settings.SettingsActivity
 import emu.skyline.provider.DocumentsProvider
 
 class DocumentsProviderPreference @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = R.attr.preferenceStyle) : Preference(context, attrs, defStyleAttr) {
-    fun launchOpenIntent(action : String) : Boolean {
+    private fun launchOpenIntent(action : String) : Boolean {
         return try {
             val intent = Intent(action)
             intent.addCategory(Intent.CATEGORY_DEFAULT)

--- a/app/src/main/java/emu/skyline/utils/ByteBufferSerializable.kt
+++ b/app/src/main/java/emu/skyline/utils/ByteBufferSerializable.kt
@@ -4,6 +4,7 @@
  */
 
 @file:OptIn(ExperimentalUnsignedTypes::class)
+@file:Suppress("SERIAL")
 
 package emu.skyline.utils
 
@@ -111,6 +112,7 @@ interface ByteBufferSerializable : Parcelable {
     /**
      * Holds information about the constructor of the classes and the properties for serialization
      */
+    @Suppress("ArrayInDataClass")
     private data class ByteBufferSerializationData(val bytes : Int, val classesAndSizes : Array<ClassAndSize>, val properties : Array<KProperty1<*, *>>) {
         companion object {
             fun getSerializationData(kClass : KClass<*>) : ByteBufferSerializationData {
@@ -233,7 +235,7 @@ interface ByteBufferSerializable : Parcelable {
     }
 
     companion object {
-        @JvmField
+        @JvmField @Suppress("unused")
         val CREATOR : ParcelableCreator = ParcelableCreator()
 
         /**

--- a/app/src/main/java/emu/skyline/utils/ParcelableHelper.kt
+++ b/app/src/main/java/emu/skyline/utils/ParcelableHelper.kt
@@ -15,13 +15,11 @@ inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
     else -> @Suppress("DEPRECATION") getParcelable(key) as? T
 }
 
-@Suppress("unused")
 inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableExtra(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
 }
 
-@Suppress("unused")
 inline fun <reified T : Parcelable> Intent.parcelableArrayList(key: String): ArrayList<T>? = when {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableArrayListExtra(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelableArrayListExtra(key)

--- a/app/src/main/java/emu/skyline/utils/ParcelableHelper.kt
+++ b/app/src/main/java/emu/skyline/utils/ParcelableHelper.kt
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2023 Skyline Team and Contributors (https://github.com/skyline-emu/)
+ */
+
+package emu.skyline.utils
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+
+inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
+}
+
+@Suppress("unused")
+inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
+}
+
+@Suppress("unused")
+inline fun <reified T : Parcelable> Intent.parcelableArrayList(key: String): ArrayList<T>? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableArrayListExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableArrayListExtra(key)
+}

--- a/app/src/main/java/emu/skyline/utils/WindowInsetsHelper.kt
+++ b/app/src/main/java/emu/skyline/utils/WindowInsetsHelper.kt
@@ -75,7 +75,7 @@ interface WindowInsetsHelper {
             }
         }
 
-        fun addPadding(view : View, consume : Boolean = true, left : Boolean = false, top : Boolean = false, right : Boolean = false, bottom : Boolean = false) {
+        private fun addPadding(view : View, consume : Boolean = true, left : Boolean = false, top : Boolean = false, right : Boolean = false, bottom : Boolean = false) {
             // Save initial padding values to avoid adding to the initial padding multiple times
             val basePadding = object {
                 val left = view.paddingLeft


### PR DESCRIPTION
Pause can happen in a few ways and some may not retain a flag that the emulator was paused, which can result in resume not being fired. What little is saved by not changing settings that are already set would be lost trying to effectively track the specific method the emulator was paused.