### PR TITLE
Add an option to filter files parsed as invalid

### DIFF
--- a/app/src/main/java/emu/skyline/MainActivity.kt
+++ b/app/src/main/java/emu/skyline/MainActivity.kt
@@ -215,7 +215,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun sortGameList(gameList : List<AppEntry>) : List<AppEntry> {
         val sortedApps : MutableList<AppEntry> = mutableListOf()
-        gameList.forEach { entry -> sortedApps.add(entry) }
+        gameList.forEach { entry ->
+            if (!appSettings.filterInvalidFiles || entry.loaderResult != LoaderResult.ParsingError)
+                sortedApps.add(entry)
+        }
         when (appSettings.sortAppsBy) {
             SortingOrder.AlphabeticalAsc.ordinal -> sortedApps.sortBy { it.name }
             SortingOrder.AlphabeticalDesc.ordinal -> sortedApps.sortByDescending { it.name }

--- a/app/src/main/java/emu/skyline/settings/AppSettings.kt
+++ b/app/src/main/java/emu/skyline/settings/AppSettings.kt
@@ -25,6 +25,7 @@ class AppSettings @Inject constructor(@ApplicationContext private val context : 
     var layoutType by sharedPreferences(context, 1)
     var sortAppsBy by sharedPreferences(context, 0)
     var selectAction by sharedPreferences(context, false)
+    var filterInvalidFiles by sharedPreferences(context, false)
 
     // Input
     var onScreenControl by sharedPreferences(context, true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
     <string name="select_action">Always Show Game Information</string>
     <string name="select_action_desc_on">Game information will be shown on clicking a game</string>
     <string name="select_action_desc_off">Game information will only be shown on long-clicking a game</string>
+    <string name="filter_invalid_files_desc_off">Show files that have been parsed as invalid</string>
+    <string name="filter_invalid_files_desc_on">Hide files that have been parsed as invalid</string>
     <!-- Settings - Game -->
     <string name="game">Game</string>
     <string name="use_custom_settings">Enable Custom Settings</string>

--- a/app/src/main/res/xml/app_preferences.xml
+++ b/app/src/main/res/xml/app_preferences.xml
@@ -57,5 +57,10 @@
             android:summaryOn="@string/select_action_desc_on"
             app:key="select_action"
             app:title="@string/select_action" />
+        <emu.skyline.preference.RefreshSwitchPreferenceCompat
+            android:defaultValue="false"
+            android:summaryOff="@string/filter_invalid_files_desc_off"
+            android:summaryOn="@string/filter_invalid_files_desc_on"
+            app:key="filter_invalid_files" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This allows the game list to (optionally) skip displaying files that were parsed as invalid. It can filter out junk files kept in the game folder and DLC, which also parse as invalid. Again, it is optional. At such time as DLC are no longer parsed as invalid, this would automatically stop applying to them and it will be up to the emulator to determine how to handle that.

This is the third and final attempt to balance the convenience of storing all files together without a negative impact on navigating the emulator efficiently. This is a compromise between not making any assumptions about the file that the emulator hasn't already made and not setting any expectations on how DLC will be supported.

<details>
  <summary>Before / Disabled</summary>

![signal-2023-05-06-072601_002](https://user-images.githubusercontent.com/1173913/236621315-ce034ae4-2a66-4c3f-a8c8-b1aa33b9e36a.png)
</details>

<details>
  <summary>After / Enabled</summary>

![signal-2023-05-06-072604_002](https://user-images.githubusercontent.com/1173913/236621320-452ec925-fabf-4124-9741-4f0176c0c47e.png)
</details>